### PR TITLE
Changed gitignore to ignore all __pycache__ folders anywhere they occur.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@
 odm360.log
 
 #cache
-odm360/__pycache__/
+__pycache__/
 
 test_data


### PR DESCRIPTION
The .gitignore file was specifically pointing to only the ```__pycache__``` directory within ```odm360/```. This meant every time I run Flask on my computer, I have to delete a __pycache__ directory. Changed it to ignore all pycache directories anywhere. 

This should be absolutely trivial, I'm only doing a pull request in the name of good behavior. Please merge into webapp; it'll then cascade into master when we merge webapp (which I think we should do soon). 