### PR TITLE
Working provisioning script for base pi including postgresql, and a quickstart in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See also: https://www.opendronemap.org/2020/05/360-cameras/
 This project is built around raspbian, but can likely be deployed on almost any linux flavor.
 
 If you wish to test and develop code, we recommend establishing a Miniconda environment.
-When deploying on a raspberry pi, you can skip this part.
+When deploying on a raspberry pi, you can skip this part. To deploy on a pi, [here is a set of instructions](provisioning/setup_pi.md)
 ```
 conda env create -f environment.yml
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From the 360 data, we can get detailed 3D reconstructions in OpenDroneMap:
 See also: https://www.opendronemap.org/2020/05/360-cameras/
 
 ## Quickstart on Raspberry Pi
-This is a quick listing of install steps, intended for someone who already knows most of the what's needed and just needs a checklist/reminder. [Full instructions here].(provisioning/setup_pi.md)
+This is a quick listing of install steps, intended for someone who already knows most of the what's needed and just needs a checklist/reminder. [Full instructions here](provisioning/setup_pi.md).
 
 - Buy Pis, SD cards, cameras, wires, GNSS receivers, etc. [Parts list here](provisioning/setup_pi.md).
 - Solder, jumper, assemble, etc. [Instructions here](provisioning/setup_pi.md).

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This is a quick listing of install steps, intended for someone who already knows
 - Change the default password ```passwd```, update, upgrade ```sudo apt update && sudo apt upgrade -y``` and install Git ```sudo apt install git -y```.
 - Clone odm360 repo ```git clone https://github.com/OpenDroneMap/odm360.git```, cd into the folder ```cd odm360```
 - Run provisioning/base_pi_setup.sh ```provisioning/base_pi_setup.sh```
+- Run the web app with ```python3 -m flask run --host=0.0.0.0```
+- See the dashboard by going to [http://raspberrypi.local:5000/](http://raspberrypi.local:5000/) in your browser
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,24 @@ From the 360 data, we can get detailed 3D reconstructions in OpenDroneMap:
 
 See also: https://www.opendronemap.org/2020/05/360-cameras/
 
+## Quickstart on Raspberry Pi
+This is a quick listing of install steps, intended for someone who already knows most of the what's needed and just needs a checklist/reminder. [Full instructions here].(provisioning/setup_pi.md)
+
+- Buy Pis, SD cards, cameras, wires, GNSS receivers, etc. [Parts list here](provisioning/setup_pi.md).
+- Solder, jumper, assemble, etc. [Instructions here](provisioning/setup_pi.md).
+- Flash parent SD card with [Raspberry Pi OS](https://www.raspberrypi.org/downloads/raspberry-pi-os/)
+- Add empty ```ssh``` file and appropriate ```wpa_supplicant.conf``` [like this]((https://www.raspberrypi.org/documentation/configuration/wireless/headless.md) with wifi info to boot partition on that SD card. Put it in the parent Pi and start it up.
+- SSH into the pi ```ssh pi@raspberrypi.local``` with password ```raspberry```.
+- Change the default password ```passwd```, update, upgrade ```sudo apt update && sudo apt upgrade -y``` and install Git ```sudo apt install git -y```.
+- Clone odm360 repo ```git clone https://github.com/OpenDroneMap/odm360.git```, cd into the folder ```cd odm360```
+- Run provisioning/base_pi_setup.sh ```provisioning/base_pi_setup.sh```
+
 ## Requirements
 
 This project is built around raspbian, but can likely be deployed on almost any linux flavor.
 
 If you wish to test and develop code, we recommend establishing a Miniconda environment.
-When deploying on a raspberry pi, you can skip this part. To deploy on a pi, [here is a set of instructions](provisioning/setup_pi.md)
+When deploying on a raspberry pi, you can skip this part. 
 ```
 conda env create -f environment.yml
 ```

--- a/provisioning/base_pi_setup.sh
+++ b/provisioning/base_pi_setup.sh
@@ -24,10 +24,7 @@ sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
 echo enabling UART
 echo $'\n# Enable UART\nenable_uart=1' | sudo tee -a /boot/config.txt
 
-echo fetching the ODM360 code and installing the requirements
-git clone https://github.com/OpenDroneMap/odm360
-cd odm360
+echo Installing requirements from setup.py using pip
 pip3 install -e .
-cd ../
 
 echo Now you should have a Raspberry Pi set up with the basic infrastructure common to all devices in the kit. The next steps depend whether this device is intended to be a Parent or Child.

--- a/provisioning/base_pi_setup.sh
+++ b/provisioning/base_pi_setup.sh
@@ -13,7 +13,7 @@ echo Installing emacs because it is the best editor and IDE. You are welcome.
 sudo apt install -y emacs-nox
 
 echo Installing posgresql
-sudo apt install -y postgresql postgresql-contrib
+sudo apt install -y postgresql postgresql-contrib libpq-dev
 
 # TODO check if already done before sedding in the disable flag
 echo Disabling IPv6

--- a/provisioning/base_pi_setup.sh
+++ b/provisioning/base_pi_setup.sh
@@ -12,6 +12,9 @@ sudo apt install -y git python3-pip libgphoto2-dev libatlas-base-dev gfortran
 echo Installing emacs because it is the best editor and IDE. You are welcome.
 sudo apt install -y emacs-nox
 
+echo Installing posgresql
+sudo apt install -y postgresql postgresql-contrib
+
 echo Disabling IPv6
 sudo sed -i '$s/$/ ipv6.disable=1/' /boot/cmdline.txt
 

--- a/provisioning/base_pi_setup.sh
+++ b/provisioning/base_pi_setup.sh
@@ -15,16 +15,21 @@ sudo apt install -y emacs-nox
 echo Installing posgresql
 sudo apt install -y postgresql postgresql-contrib
 
+# TODO check if already done before sedding in the disable flag
 echo Disabling IPv6
 sudo sed -i '$s/$/ ipv6.disable=1/' /boot/cmdline.txt
 
 echo Disabling serial console to free up UART serial line
 sudo sed -i 's/console=serial0,115200 //g' /boot/cmdline.txt
 
+# TODO check if already done before pushing this line into the file
 echo enabling UART
 echo $'\n# Enable UART\nenable_uart=1' | sudo tee -a /boot/config.txt
 
 echo Installing requirements from setup.py using pip
 pip3 install -e .
 
+echo ##########################################################
 echo Now you should have a Raspberry Pi set up with the basic infrastructure common to all devices in the kit. The next steps depend whether this device is intended to be a Parent or Child.
+echo ##########################################################
+echo

--- a/provisioning/setup_pi.md
+++ b/provisioning/setup_pi.md
@@ -2,17 +2,6 @@
 
 We provide pre-configured images for the various components (Parent, Child, and Timeserver) of the ODM360 kit __(TODO: THAT)__, but for developers or people wishing to customize their setup, this is the full install procedure.
 
-## Quickstart
-- Buy Pis, SD cards, cameras, wires, GNSS receivers, etc
-- Solder, jumper, assemble, etc
-- Flash parent SD card with [Raspberry Pi OS](https://www.raspberrypi.org/downloads/raspberry-pi-os/)
-- Add empty ```ssh``` file and appropriate ```wpa_supplicant.conf``` [like this]((https://www.raspberrypi.org/documentation/configuration/wireless/headless.md) with wifi info to boot partition on that SD card. Put it in the parent Pi and start it up.
-- SSH into the pi ```ssh pi@raspberrypi.local``` with password ```raspberry```.
-- Change the default password ```passwd```, update, upgrade ```sudo apt update && sudo apt upgrade -y``` and install Git ```sudo apt install git -y```.
-- Clone odm360 repo ```git clone https://github.com/OpenDroneMap/odm360.git```, cd into the folder ```cd odm360```
-- Run provisioning/base_pi_setup.sh ```provisioning/base_pi_setup.sh```
-
-
 ## Buy stuff and get ready
 - Get a the appropriate Raspberry Pi for the component you are making.
   - For a TimeServer or a Child, this is a Raspberry Pi Zero W (or the WH, which is the same device but has pre-soldered headers, which will save you some work).

--- a/provisioning/setup_pi.md
+++ b/provisioning/setup_pi.md
@@ -7,9 +7,10 @@ We provide pre-configured images for the various components (Parent, Child, and 
 - Solder, jumper, assemble, etc
 - Flash parent SD card with Raspberry Pi OS
 - Add empty ```ssh``` file and appropriate ```wpa_supplicant.conf``` with wifi info to boot partition on that SD card. Put it in the parent Pi and start it up.
-- SSH into the pi. Update, upgrade, and install Git.
-- Clone odm360 repo, cd into the folder
-- Run provisioning/base_pi_setup.sh
+- SSH into the pi ```ssh pi@raspberrypi.local``` with password ```raspberry```.
+- Change the default password ```passwd```, update, upgrade ```sudo apt update && sudo apt upgrade -y``` and install Git ```sudo apt install git```.
+- Clone odm360 repo ```git clone https://github.com/OpenDroneMap/odm360```, cd into the folder ```cd odm360```
+- Run provisioning/base_pi_setup.sh ```provisioning/base_pi_setup.sh```
 
 
 ## Buy stuff and get ready
@@ -46,7 +47,7 @@ I copy the contents of that example, navigate to the root of the ```boot``` part
   - Also in the ```boot``` partition, you need to place a file called ```ssh```. It doesn't matter what's in it (an empty file is fine) and there's no extension on the filename. This enables [SSH](https://en.wikipedia.org/wiki/Secure_Shell) on the Pi (disabled by default). You can do this on Linux or Mac by navigating to the root of the ```boot``` partition and typing ```touch ssh```.
 - Eject the SD card and remove it from your computer, put it in the Pi, and power it up. Wait about 90 seconds to make sure it has time to boot up before you try to connect to it.
 - Make sure your computer is connected to the same WiFi network as the Pi, open a terminal, and type ```ssh pi@raspberrypi.local```.
-  - Didn't work? ```Could not resolve hostname...``` or something like it? Sigh. Ok, try to figure out if the Pi is on the WiFi. You can try [nmap](https://nmap.org/) to attempt to identify every device on your local subnet, but I recently found a lovely FOSS application called [Angry IP Scanner](https://angryip.org/); it's great. Try it. If you're lucky, you'll see the Pi on the network along with its IP address, and maybe you can ssh into it using the IP address instead of the ```raspberrypi.local``` alias. If not, you'll have to dive into the world of Google, StackExchange, and the Raspberry Pi forums until you get it sorted.
+  - Didn't work? ```Could not resolve hostname...``` or something like it? Sigh. Ok, try to figure out if the Pi is on the WiFi. You can try [nmap](https://nmap.org/) to attempt to identify every device on your local subnet with ```nmap -sP 192.168.X.0/24```, but I recently found a lovely FOSS application called [Angry IP Scanner](https://angryip.org/); it's great. Try it. If you're lucky, you'll see the Pi on the network along with its IP address, and maybe you can ssh into it using the IP address instead of the ```raspberrypi.local``` alias. If not, you'll have to dive into the world of Google, StackExchange, and the Raspberry Pi forums until you get it sorted.
 - Log into the Pi using the default password, which is ```raspberry```. Once you're in, immediately type ```passwd``` (_without_ ```sudo```) and—at the prompts—enter first the old and then the new password (twice). Try not to forget the new password.
 - Get everything up to date with ```sudo apt update && sudo apt upgrade -y```. This will take a few minutes, more if your Internet connection is slow.
 - You might as well install a few more basic infrastructure bits while you're at it:

--- a/provisioning/setup_pi.md
+++ b/provisioning/setup_pi.md
@@ -5,11 +5,11 @@ We provide pre-configured images for the various components (Parent, Child, and 
 ## Quick overview
 - Buy Pis, SD cards, cameras, wires, GNSS receivers, etc
 - Solder, jumper, assemble, etc
-- Flash parent SD card with Raspberry Pi OS
-- Add empty ```ssh``` file and appropriate ```wpa_supplicant.conf``` with wifi info to boot partition on that SD card. Put it in the parent Pi and start it up.
+- Flash parent SD card with [Raspberry Pi OS](https://www.raspberrypi.org/downloads/raspberry-pi-os/)
+- Add empty ```ssh``` file and appropriate ```wpa_supplicant.conf``` [like this]((https://www.raspberrypi.org/documentation/configuration/wireless/headless.md) with wifi info to boot partition on that SD card. Put it in the parent Pi and start it up.
 - SSH into the pi ```ssh pi@raspberrypi.local``` with password ```raspberry```.
-- Change the default password ```passwd```, update, upgrade ```sudo apt update && sudo apt upgrade -y``` and install Git ```sudo apt install git```.
-- Clone odm360 repo ```git clone https://github.com/OpenDroneMap/odm360```, cd into the folder ```cd odm360```
+- Change the default password ```passwd```, update, upgrade ```sudo apt update && sudo apt upgrade -y``` and install Git ```sudo apt install git -y```.
+- Clone odm360 repo ```git clone https://github.com/OpenDroneMap/odm360.git```, cd into the folder ```cd odm360```
 - Run provisioning/base_pi_setup.sh ```provisioning/base_pi_setup.sh```
 
 

--- a/provisioning/setup_pi.md
+++ b/provisioning/setup_pi.md
@@ -2,6 +2,16 @@
 
 We provide pre-configured images for the various components (Parent, Child, and Timeserver) of the ODM360 kit __(TODO: THAT)__, but for developers or people wishing to customize their setup, this is the full install procedure.
 
+## Quick overview
+- Buy Pis, SD cards, cameras, wires, GNSS receivers, etc
+- Solder, jumper, assemble, etc
+- Flash parent SD card with Raspberry Pi OS
+- Add empty ```ssh``` file and appropriate ```wpa_supplicant.conf``` with wifi info to boot partition on that SD card. Put it in the parent Pi and start it up.
+- SSH into the pi. Update, upgrade, and install Git.
+- Clone odm360 repo, cd into the folder
+- Run provisioning/base_pi_setup.sh
+
+
 ## Buy stuff and get ready
 - Get a the appropriate Raspberry Pi for the component you are making.
   - For a TimeServer or a Child, this is a Raspberry Pi Zero W (or the WH, which is the same device but has pre-soldered headers, which will save you some work).

--- a/provisioning/setup_pi.md
+++ b/provisioning/setup_pi.md
@@ -2,7 +2,7 @@
 
 We provide pre-configured images for the various components (Parent, Child, and Timeserver) of the ODM360 kit __(TODO: THAT)__, but for developers or people wishing to customize their setup, this is the full install procedure.
 
-## Quick overview
+## Quickstart
 - Buy Pis, SD cards, cameras, wires, GNSS receivers, etc
 - Solder, jumper, assemble, etc
 - Flash parent SD card with [Raspberry Pi OS](https://www.raspberrypi.org/downloads/raspberry-pi-os/)

--- a/provisioning/systemd_services/odm360_dashboard.service
+++ b/provisioning/systemd_services/odm360_dashboard.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=uWSGI instance to serve ODM360 dashboard
+After=network.target
+
+[Service]
+ExecStart=/home/pi/odm360/uwsgi --ini odm360.ini
+WorkingDirectory=/home/pi/odm360/
+User=www-data
+Group=www-data
+StandardOutput=file:/home/pi/log.txt
+StandardError=file:/home/pi/error.log
+
+[Install]
+WantedBy=multi-user.target

--- a/provisioning/webapp_certbot.sh
+++ b/provisioning/webapp_certbot.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# Grabs a letsencrypt cert if for some reason you need one
+
+echo Unless you need this (i.e. you are on a cloud dev instance), do not.
+echo please enter the domain name of your server
+read domain_name
+echo
+echo Please enter an email address for certificate renewal information
+read email
+echo
+
+echo installing Certbot
+if ! type "certbot"; then
+    sudo add-apt-repository -y ppa:certbot/certbot
+    sudo apt install -y python-certbot-nginx
+else echo Certbot seems to be already installed
+fi
+
+echo Procuring a certificate for the site from LetsEncrypt using Certbot
+sudo certbot --nginx -n --agree-tos --redirect -m $email -d $domain_name -d www.$domain_name

--- a/provisioning/webapp_dashboard_setup.sh
+++ b/provisioning/webapp_dashboard_setup.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -eu
+
+# Sets up an ODM360 web app with wsgi and nginx
+# Assumes a non-root sudo user.
+
+echo Updating and upgrading the OS
+sudo apt -y update
+sudo apt -y upgrade
+
+echo installing nginx
+if ! type "nginx"; then
+    sudo apt install -y nginx
+else echo Nginx seems to be already installed
+fi
+
+
+echo adding the odm360 site to nginx
+cat > odm360 <<EOF
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:/home/pi/odm360/odm360.sock;
+    }
+}
+EOF
+
+sudo mv odm360 /etc/nginx/sites-available/
+
+echo creating symlink to odm360 site in nginx sites-enabled
+if [ ! -f /etc/nginx/sites-enabled/odm360 ]; then
+    sudo ln -s /etc/nginx/sites-available/odm360 /etc/nginx/sites-enabled
+else echo Looks like the symlink has already been created
+fi
+
+echo setting up uwsgi and flask
+pip install wheel
+pip install uwsgi flask
+
+echo adding the odm360 service to Systemd
+sudo cp provisioning/odm360_dashboard.service /etc/systemd/system/
+
+echo starting and enabling the odm360_dashboard service with Systemd
+sudo systemctl start odm360_dashboard.service
+sudo systemctl enable odm360_dashboard.service

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
         "python-nmap",
         "Flask",
         "Flask-Login",
-        "Bootstrap-Flask"
-        "uwsgi"
-        "libpq-dev"
-        "psycopg2"
+        "Bootstrap-Flask",
+        "uwsgi",
+        "libpq-dev",
+        "psycopg2",
     ],
     extras_require={
         "dev": ["pytest", "pytest-cov", "black"],

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "Flask-Login",
         "Bootstrap-Flask",
         "uwsgi",
-        "libpq-dev",
         "psycopg2",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
         "Flask",
         "Flask-Login",
         "Bootstrap-Flask"
+        "uwsgi"
+        "libpq-dev"
+        "psycopg2"
     ],
     extras_require={
         "dev": ["pytest", "pytest-cov", "black"],


### PR DESCRIPTION
This is a pretty focused changeset. It's intended to make it way easier and faster to get to a basic configured Pi. 

I've tested it on a Raspberry Pi 4 B. It works well.

None of it touches anyone else's actual code.

The main functional change is the ```provisioning/base_pi_setup.sh``` script that now runs quite smoothly. Install a new RPi OS, clone ODM, and run the script and it takes care of everything else up to the database install.

The other main change is I've dropped a Quickstart section in to the main Readme. So I'm venturing outside of my sandbox provisioning directory. Nevertheless, it seems like the main Readme is a good place to have a set of instructions to get going fast. If others agree, please merge.

