### PR TITLE
Provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From the 360 data, we can get detailed 3D reconstructions in OpenDroneMap:
 See also: https://www.opendronemap.org/2020/05/360-cameras/
 
 ## Quickstart on Raspberry Pi
-This is a quick listing of install steps, intended for someone who already knows most of the what's needed and just needs a checklist/reminder. [Full instructions here](provisioning/setup_pi.md).
+This is a quick listing of install steps, intended for someone who already knows most of what's needed and just needs a checklist/reminder. [Full instructions here](provisioning/setup_pi.md).
 
 - Buy Pis, SD cards, cameras, wires, GNSS receivers, etc. [Parts list here](provisioning/setup_pi.md).
 - Solder, jumper, assemble, etc. [Instructions here](provisioning/setup_pi.md).

--- a/provisioning/database_setup.sh
+++ b/provisioning/database_setup.sh
@@ -8,7 +8,13 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev
 # echo Installing requirements from setup.py using pip
 # pip3 install -e .
 
-sudo -u postgres createuser -d odm360
+echo Creating postgres user odm360
+sudo -u postgres psql -c "CREATE USER odm360 WITH PASSWORD 'md51bb536130df443a4bb77eaf446bca7ca';"
+
+echo Creating database odm360
+sudo -u postgres psql -c "CREATE DATABASE odm360 WITH OWNER odm360;"
+
+
 
 
 echo ##########################################################

--- a/provisioning/database_setup.sh
+++ b/provisioning/database_setup.sh
@@ -9,7 +9,12 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev
 # pip3 install -e .
 
 echo Creating postgres user odm360
-sudo -u postgres psql -c "CREATE USER odm360 WITH PASSWORD 'md51bb536130df443a4bb77eaf446bca7ca';"
+# TODO This is a pretty obvious password (it's md5 hashed).
+# Generate another one using bash:
+# echo -n passwordusername | md5sum
+# and paste the result into the following command
+# with the prefix 'md5' (the hash below begins with 44ec)
+sudo -u postgres psql -c "CREATE ROLE odm360 WITH PASSWORD 'md544ec1a1a609f26f78f20decd3a34bd2d';"
 
 echo Creating database odm360
 sudo -u postgres psql -c "CREATE DATABASE odm360 WITH OWNER odm360;"

--- a/provisioning/database_setup.sh
+++ b/provisioning/database_setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Set up a Postgresql database ready for use with odm360
+
+echo Installing posgresql
+sudo apt install -y postgresql postgresql-contrib libpq-dev
+
+# echo Installing requirements from setup.py using pip
+# pip3 install -e .
+
+sudo -u postgres createuser -d odm360
+
+
+echo ##########################################################
+echo Now you should have a Postgresql database with a user and password properly configured to connect to using psycopg2 from Python.
+echo ##########################################################
+echo


### PR DESCRIPTION
There is now a script, ```provisioning/database_setup.sh``` that sets up a postgresql user called odm360 and an empty database called odm360.

The user is already configured with a password, which is md5 hashed (not super secure, but way better than dumping a raw password into the repo). 

After running that script (and knowing the password), you can access the database from psycopg. 

Next I'll create some utility functions in Python to create the appropriate tables and interact with them (pretty much like in the instructions in ```provisioning/setup_pi.md```)