### PR TITLE
Fix error in database setup (add login and createdb)

### DIFF
--- a/provisioning/database_setup.sh
+++ b/provisioning/database_setup.sh
@@ -15,6 +15,8 @@ echo Creating postgres user odm360
 # and paste the result into the following command
 # with the prefix 'md5' (the hash below begins with 44ec)
 sudo -u postgres psql -c "CREATE ROLE odm360 WITH PASSWORD 'md544ec1a1a609f26f78f20decd3a34bd2d';"
+sudo -u postgres psql -c "ALTER ROLE odm360 WITH LOGIN"
+sudo -u postgres psql -c "ALTER ROLE odm360 WITH CREATEDB"
 
 echo Creating database odm360
 sudo -u postgres psql -c "CREATE DATABASE odm360 WITH OWNER odm360;"


### PR DESCRIPTION
Sorry folks, I forgot to include two necessary lines in the database_setup.py script. Without them the database is created and can be poked from psql, but not from psycopg2. 

It's a tiny change, absolutely necessary, and doesn't affect anything else. Please merge!