### PR TITLE
Added a parameterized openscad version of the base

### DIFF
--- a/hardware/scad/base.scad
+++ b/hardware/scad/base.scad
@@ -1,0 +1,38 @@
+//define dimensions. All in mm
+num_cams = 7;
+plate_thickness = 3.25; // thickness of base plate
+mid_thickness = 6; // Thickness of inner raised area (first "step")
+edge_thickness = 10.5; // Thickness of the raised edge where the holes are
+edge_width_from_hole = 4; // Width of the edge, material on each side of the hole
+hole_diameter = 8; 
+radius_to_hole = 100; // Distance from center to the center of the mounting holes
+mid_area_width = 10; // Width of the inner raised area
+radius_central_gap = 40; // Radius of the empty central area
+
+// Don't touch
+rotate_angle = 360/num_cams;
+overhang = edge_width_from_hole + hole_diameter/2;
+plate_length = radius_to_hole + overhang;
+poly_side = tan(360/(num_cams * 2)) * 2 *
+            (plate_length);
+
+for (cam = [1 : num_cams]){
+    rotate([0, 0, cam * rotate_angle]){
+        difference(){
+            union(){
+                translate([radius_central_gap, -poly_side / 2, 0]){
+                    cube([plate_length - radius_central_gap, poly_side, plate_thickness]);
+                }
+                translate([radius_to_hole - overhang,-poly_side / 2,0]){
+                    cube([overhang * 2, poly_side, edge_thickness]);
+                }
+                translate([radius_to_hole - overhang - mid_area_width, -poly_side / 2, 0]){
+                    cube([mid_area_width, poly_side, mid_thickness]);
+                }
+            }
+            translate([radius_to_hole, 0, -1]){
+                cylinder(r = hole_diameter / 2, h = edge_thickness + 2, $fn = 64);
+            }
+        }
+    }
+}

--- a/hardware/scad/base.stl
+++ b/hardware/scad/base.stl
@@ -1,0 +1,13582 @@
+solid OpenSCAD_Model
+  facet normal 0.623492 0.78183 -0
+    outer loop
+      vertex 108 52.0101 0
+      vertex 26.6738 116.866 10.5
+      vertex 108 52.0101 10.5
+    endloop
+  endfacet
+  facet normal 0.623492 0.78183 0
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex 108 52.0101 0
+      vertex 26.6738 116.866 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 82 39.4891 3.25
+      vertex 40 19.263 3.25
+      vertex 82 -39.4891 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.2523 88.7312 3.25
+      vertex 40 19.263 3.25
+      vertex 82 39.4891 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.2523 88.7312 3.25
+      vertex 9.87918 43.2835 3.25
+      vertex 40 19.263 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 20.2523 88.7312 3.25
+      vertex -27.6809 34.7107 3.25
+      vertex 9.87918 43.2835 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6809 34.7107 3.25
+      vertex -56.7458 71.1569 3.25
+      vertex -44.3967 0 3.25
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.7458 71.1569 3.25
+      vertex -27.6809 34.7107 3.25
+      vertex 20.2523 88.7312 3.25
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40 -19.263 3.25
+      vertex 82 -39.4891 3.25
+      vertex 40 19.263 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40 -19.263 3.25
+      vertex 20.2523 -88.7312 3.25
+      vertex 82 -39.4891 3.25
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.87918 -43.2835 3.25
+      vertex 20.2523 -88.7312 3.25
+      vertex 40 -19.263 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6809 -34.7107 3.25
+      vertex 20.2523 -88.7312 3.25
+      vertex 9.87918 -43.2835 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -27.6809 -34.7107 3.25
+      vertex -56.7458 -71.1569 3.25
+      vertex 20.2523 -88.7312 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.3967 0 3.25
+      vertex -56.7458 -71.1569 3.25
+      vertex -27.6809 -34.7107 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.0131 0 3.25
+      vertex -44.3967 0 3.25
+      vertex -56.7458 71.1569 3.25
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -44.3967 0 3.25
+      vertex -91.0131 0 3.25
+      vertex -56.7458 -71.1569 3.25
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.2237 -42.3893 0
+      vertex -27.6809 -34.7107 0
+      vertex -86.1444 -42.7737 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.1032 43.1641 0
+      vertex -86.1004 43.5566 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.3403 -42.0144 0
+      vertex -27.6809 -34.7107 0
+      vertex -86.2237 -42.3893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.1444 42.7737 0
+      vertex -86.1032 43.1641 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.493 -41.6528 0
+      vertex -27.6809 -34.7107 0
+      vertex -86.3403 -42.0144 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.2237 42.3893 0
+      vertex -86.1444 42.7737 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -86.493 -41.6528 0
+      vertex -44.3967 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.3403 42.0144 0
+      vertex -86.2237 42.3893 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.6805 -41.308 0
+      vertex -44.3967 0 0
+      vertex -86.493 -41.6528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.493 41.6528 0
+      vertex -86.3403 42.0144 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.9008 -40.9831 0
+      vertex -44.3967 0 0
+      vertex -86.6805 -41.308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.6805 41.308 0
+      vertex -86.493 41.6528 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.152 -40.6814 0
+      vertex -44.3967 0 0
+      vertex -86.9008 -40.9831 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -86.9008 40.9831 0
+      vertex -86.6805 41.308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.4315 -40.4058 0
+      vertex -44.3967 0 0
+      vertex -87.152 -40.6814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -87.152 40.6814 0
+      vertex -86.9008 40.9831 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.7367 -40.1589 0
+      vertex -44.3967 0 0
+      vertex -87.4315 -40.4058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -87.4315 40.4058 0
+      vertex -87.152 40.6814 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -88.0646 -39.9431 0
+      vertex -44.3967 0 0
+      vertex -87.7367 -40.1589 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -87.7367 40.1589 0
+      vertex -87.4315 40.4058 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -88.4121 -39.7605 0
+      vertex -44.3967 0 0
+      vertex -88.0646 -39.9431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -88.0646 39.9431 0
+      vertex -87.7367 40.1589 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -88.7758 -39.6128 0
+      vertex -44.3967 0 0
+      vertex -88.4121 -39.7605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -88.4121 39.7605 0
+      vertex -88.0646 39.9431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -89.1522 -39.5015 0
+      vertex -44.3967 0 0
+      vertex -88.7758 -39.6128 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -88.7758 39.6128 0
+      vertex -88.4121 39.7605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -44.3967 0 0
+      vertex -89.1522 -39.5015 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -89.1522 39.5015 0
+      vertex -88.7758 39.6128 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -89.1522 -39.5015 0
+      vertex -89.5377 -39.4277 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 0 0
+      vertex -44.3967 0 0
+      vertex -119.871 -3.85793e-07 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -89.5377 -39.4277 0
+      vertex -89.9286 -39.3919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 3.85793e-07 0
+      vertex -44.3967 0 0
+      vertex -119.871 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -89.9286 -39.3919 0
+      vertex -90.3212 -39.3947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -44.3967 0 0
+      vertex -119.871 3.85793e-07 0
+      vertex -89.1522 39.5015 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -90.3212 -39.3947 0
+      vertex -90.7115 -39.4359 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -89.1522 39.5015 0
+      vertex -119.871 3.85793e-07 0
+      vertex -89.5377 39.4277 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -90.7115 -39.4359 0
+      vertex -91.096 -39.5152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -89.5377 39.4277 0
+      vertex -119.871 3.85793e-07 0
+      vertex -89.9286 39.3919 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -91.096 -39.5152 0
+      vertex -91.4708 -39.6317 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -89.9286 39.3919 0
+      vertex -119.871 3.85793e-07 0
+      vertex -90.3212 39.3947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -91.4708 -39.6317 0
+      vertex -91.8324 -39.7845 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -90.3212 39.3947 0
+      vertex -119.871 3.85793e-07 0
+      vertex -90.7115 39.4359 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -91.8324 -39.7845 0
+      vertex -92.1773 -39.972 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -90.7115 39.4359 0
+      vertex -119.871 3.85793e-07 0
+      vertex -91.096 39.5152 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -92.1773 -39.972 0
+      vertex -92.5022 -40.1923 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -91.096 39.5152 0
+      vertex -119.871 3.85793e-07 0
+      vertex -91.4708 39.6317 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -92.5022 -40.1923 0
+      vertex -92.8038 -40.4435 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -91.4708 39.6317 0
+      vertex -119.871 3.85793e-07 0
+      vertex -91.8324 39.7845 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -92.8038 -40.4435 0
+      vertex -93.0795 -40.723 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -91.8324 39.7845 0
+      vertex -119.871 3.85793e-07 0
+      vertex -92.1773 39.972 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.0795 -40.723 0
+      vertex -93.3263 -41.0282 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -92.1773 39.972 0
+      vertex -119.871 3.85793e-07 0
+      vertex -92.5022 40.1923 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.3263 -41.0282 0
+      vertex -93.5421 -41.3561 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -92.5022 40.1923 0
+      vertex -119.871 3.85793e-07 0
+      vertex -92.8038 40.4435 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.5421 -41.3561 0
+      vertex -93.7247 -41.7036 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -92.8038 40.4435 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.0795 40.723 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.7247 -41.7036 0
+      vertex -93.8724 -42.0673 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.0795 40.723 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.3263 41.0282 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.8724 -42.0673 0
+      vertex -93.9837 -42.4437 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.3263 41.0282 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.5421 41.3561 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.9837 -42.4437 0
+      vertex -94.0576 -42.8292 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.5421 41.3561 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.7247 41.7036 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -94.0576 -42.8292 0
+      vertex -94.0933 -43.2201 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.7247 41.7036 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.8724 42.0673 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.1362 43.9475 0
+      vertex -27.6809 34.7107 0
+      vertex -86.1004 43.5566 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.21 44.3331 0
+      vertex -27.6809 34.7107 0
+      vertex -86.1362 43.9475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.3214 44.7095 0
+      vertex -27.6809 34.7107 0
+      vertex -86.21 44.3331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.469 45.0732 0
+      vertex -27.6809 34.7107 0
+      vertex -86.3214 44.7095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 34.7107 0
+      vertex -86.469 45.0732 0
+      vertex -74.7383 93.7189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.6516 45.4207 0
+      vertex -74.7383 93.7189 0
+      vertex -86.469 45.0732 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.8674 45.7486 0
+      vertex -74.7383 93.7189 0
+      vertex -86.6516 45.4207 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.1143 46.0538 0
+      vertex -74.7383 93.7189 0
+      vertex -86.8674 45.7486 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.3899 46.3333 0
+      vertex -74.7383 93.7189 0
+      vertex -87.1143 46.0538 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -87.6916 46.5844 0
+      vertex -74.7383 93.7189 0
+      vertex -87.3899 46.3333 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -88.0165 46.8048 0
+      vertex -74.7383 93.7189 0
+      vertex -87.6916 46.5844 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -88.3614 46.9922 0
+      vertex -74.7383 93.7189 0
+      vertex -88.0165 46.8048 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -88.723 47.145 0
+      vertex -74.7383 93.7189 0
+      vertex -88.3614 46.9922 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -89.0978 47.2616 0
+      vertex -74.7383 93.7189 0
+      vertex -88.723 47.145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -89.4822 47.3409 0
+      vertex -74.7383 93.7189 0
+      vertex -89.0978 47.2616 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -89.8726 47.3821 0
+      vertex -74.7383 93.7189 0
+      vertex -89.4822 47.3409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -90.2651 47.3848 0
+      vertex -74.7383 93.7189 0
+      vertex -89.8726 47.3821 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -90.6561 47.3491 0
+      vertex -74.7383 93.7189 0
+      vertex -90.2651 47.3848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -91.0416 47.2752 0
+      vertex -74.7383 93.7189 0
+      vertex -90.6561 47.3491 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -91.418 47.1639 0
+      vertex -74.7383 93.7189 0
+      vertex -91.0416 47.2752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -91.7817 47.0162 0
+      vertex -74.7383 93.7189 0
+      vertex -91.418 47.1639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -92.1292 46.8336 0
+      vertex -74.7383 93.7189 0
+      vertex -91.7817 47.0162 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -92.4571 46.6178 0
+      vertex -74.7383 93.7189 0
+      vertex -92.1292 46.8336 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -92.7623 46.3709 0
+      vertex -74.7383 93.7189 0
+      vertex -92.4571 46.6178 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.0418 46.0953 0
+      vertex -74.7383 93.7189 0
+      vertex -92.7623 46.3709 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.2929 45.7936 0
+      vertex -74.7383 93.7189 0
+      vertex -93.0418 46.0953 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.5133 45.4688 0
+      vertex -74.7383 93.7189 0
+      vertex -93.2929 45.7936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.7008 45.1239 0
+      vertex -74.7383 93.7189 0
+      vertex -93.5133 45.4688 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 3.85793e-07 0
+      vertex -93.7008 45.1239 0
+      vertex -93.8535 44.7623 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.9837 42.4437 0
+      vertex -119.871 3.85793e-07 0
+      vertex -94.0576 42.8292 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -94.0576 42.8292 0
+      vertex -119.871 3.85793e-07 0
+      vertex -94.0933 43.2201 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -94.0933 43.2201 0
+      vertex -119.871 3.85793e-07 0
+      vertex -94.0906 43.6127 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -94.0906 43.6127 0
+      vertex -119.871 3.85793e-07 0
+      vertex -94.0494 44.003 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -94.0494 44.003 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.9701 44.3875 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.9701 44.3875 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.8535 44.7623 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.7008 45.1239 0
+      vertex -119.871 3.85793e-07 0
+      vertex -74.7383 93.7189 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex -18.2619 97.2125 0
+      vertex -18.2537 97.605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex -18.3086 96.8228 0
+      vertex -18.2619 97.2125 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex -18.3933 96.4395 0
+      vertex -18.3086 96.8228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex -18.5151 96.0663 0
+      vertex -18.3933 96.4395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -18.6729 95.7069 0
+      vertex -18.5151 96.0663 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -18.8652 95.3647 0
+      vertex -18.6729 95.7069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -19.0901 95.0429 0
+      vertex -18.8652 95.3647 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -19.3455 94.7448 0
+      vertex -19.0901 95.0429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -19.6288 94.4731 0
+      vertex -19.3455 94.7448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -19.9374 94.2305 0
+      vertex -19.6288 94.4731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -20.2683 94.0194 0
+      vertex -19.9374 94.2305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -20.6183 93.8417 0
+      vertex -20.2683 94.0194 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -20.9841 93.6991 0
+      vertex -20.6183 93.8417 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex -21.362 93.5931 0
+      vertex -20.9841 93.6991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 34.7107 0
+      vertex -21.362 93.5931 0
+      vertex 9.87918 43.2835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.362 93.5931 0
+      vertex -27.6809 34.7107 0
+      vertex -21.7485 93.5246 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.7485 93.5246 0
+      vertex -27.6809 34.7107 0
+      vertex -22.1399 93.4944 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.1399 93.4944 0
+      vertex -27.6809 34.7107 0
+      vertex -22.5324 93.5026 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.5324 93.5026 0
+      vertex -27.6809 34.7107 0
+      vertex -22.9221 93.5493 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.9221 93.5493 0
+      vertex -27.6809 34.7107 0
+      vertex -23.3054 93.634 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.3054 93.634 0
+      vertex -27.6809 34.7107 0
+      vertex -23.6786 93.7558 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.6786 93.7558 0
+      vertex -27.6809 34.7107 0
+      vertex -24.038 93.9136 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.038 93.9136 0
+      vertex -27.6809 34.7107 0
+      vertex -24.3802 94.1059 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.3802 94.1059 0
+      vertex -27.6809 34.7107 0
+      vertex -24.7019 94.3308 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.7019 94.3308 0
+      vertex -27.6809 34.7107 0
+      vertex -25.0001 94.5862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 93.7189 0
+      vertex -25.0001 94.5862 0
+      vertex -27.6809 34.7107 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1518 96.6027 0
+      vertex -74.7383 93.7189 0
+      vertex -26.2203 96.9892 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.0458 96.2248 0
+      vertex -74.7383 93.7189 0
+      vertex -26.1518 96.6027 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.9032 95.859 0
+      vertex -74.7383 93.7189 0
+      vertex -26.0458 96.2248 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.7255 95.509 0
+      vertex -74.7383 93.7189 0
+      vertex -25.9032 95.859 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.5143 95.1781 0
+      vertex -74.7383 93.7189 0
+      vertex -25.7255 95.509 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.2717 94.8695 0
+      vertex -74.7383 93.7189 0
+      vertex -25.5143 95.1781 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.0001 94.5862 0
+      vertex -74.7383 93.7189 0
+      vertex -25.2717 94.8695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9314 -74.5095 0
+      vertex 108 -52.0101 0
+      vertex 64.2839 -74.6823 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 66.3348 77.8469 0
+      vertex 66.3486 78.2393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.5637 -74.372 0
+      vertex 108 -52.0101 0
+      vertex 63.9314 -74.5095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 66.2827 77.4579 0
+      vertex 66.3348 77.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 108 -52.0101 0
+      vertex 63.5637 -74.372 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 66.1926 77.0758 0
+      vertex 66.2827 77.4579 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 40 -19.263 0
+      vertex 97.4624 -3.09204 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 66.0656 76.7044 0
+      vertex 66.1926 77.0758 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 97.4624 -3.09204 0
+      vertex 40 -19.263 0
+      vertex 97.1716 -2.82843 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 65.9028 76.3472 0
+      vertex 66.0656 76.7044 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 97.1716 -2.82843 0
+      vertex 40 -19.263 0
+      vertex 96.908 -2.53757 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 65.7057 76.0077 0
+      vertex 65.9028 76.3472 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.908 -2.53757 0
+      vertex 40 -19.263 0
+      vertex 96.6741 -2.22228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 65.4763 75.6892 0
+      vertex 65.7057 76.0077 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.6741 -2.22228 0
+      vertex 40 -19.263 0
+      vertex 96.4723 -1.88559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 19.263 0
+      vertex 96 0 0
+      vertex 40 -19.263 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.4723 -1.88559 0
+      vertex 40 -19.263 0
+      vertex 96.3045 -1.53073 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 63.5637 74.372 0
+      vertex 96 0 0
+      vertex 40 19.263 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.3045 -1.53073 0
+      vertex 40 -19.263 0
+      vertex 96.1722 -1.16114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 65.2168 75.3947 0
+      vertex 65.4763 75.6892 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.1722 -1.16114 0
+      vertex 40 -19.263 0
+      vertex 96.0769 -0.780361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 64.9297 75.127 0
+      vertex 65.2168 75.3947 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.0769 -0.780361 0
+      vertex 40 -19.263 0
+      vertex 96.0193 -0.392068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 64.6177 74.8888 0
+      vertex 64.9297 75.127 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 96.0193 -0.392068 0
+      vertex 40 -19.263 0
+      vertex 96 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 64.2839 74.6823 0
+      vertex 64.6177 74.8888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 63.5637 -74.372 0
+      vertex 63.1843 -74.2713 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 63.9314 74.5095 0
+      vertex 64.2839 74.6823 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 63.1843 -74.2713 0
+      vertex 62.7968 -74.2083 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 63.5637 74.372 0
+      vertex 63.9314 74.5095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 62.7968 -74.2083 0
+      vertex 62.4051 -74.1835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.5637 74.372 0
+      vertex 40 19.263 0
+      vertex 63.1843 74.2713 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 62.4051 -74.1835 0
+      vertex 62.0128 -74.1973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.1843 74.2713 0
+      vertex 40 19.263 0
+      vertex 62.7968 74.2083 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 62.0128 -74.1973 0
+      vertex 61.6237 -74.2495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.7968 74.2083 0
+      vertex 40 19.263 0
+      vertex 62.4051 74.1835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 61.6237 -74.2495 0
+      vertex 61.2416 -74.3395 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.4051 74.1835 0
+      vertex 40 19.263 0
+      vertex 62.0128 74.1973 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 61.2416 -74.3395 0
+      vertex 60.8702 -74.4665 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 62.0128 74.1973 0
+      vertex 40 19.263 0
+      vertex 61.6237 74.2495 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 60.8702 -74.4665 0
+      vertex 60.5131 -74.6294 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.6237 74.2495 0
+      vertex 40 19.263 0
+      vertex 61.2416 74.3395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 60.5131 -74.6294 0
+      vertex 60.1736 -74.8264 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 61.2416 74.3395 0
+      vertex 40 19.263 0
+      vertex 60.8702 74.4665 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 40 -19.263 0
+      vertex 60.1736 -74.8264 0
+      vertex 59.855 -75.0558 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.8702 74.4665 0
+      vertex 40 19.263 0
+      vertex 60.5131 74.6294 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 59.855 -75.0558 0
+      vertex 59.5605 -75.3153 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.5131 74.6294 0
+      vertex 40 19.263 0
+      vertex 60.1736 74.8264 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 59.5605 -75.3153 0
+      vertex 59.2928 -75.6025 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 60.1736 74.8264 0
+      vertex 40 19.263 0
+      vertex 59.855 75.0558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 59.2928 -75.6025 0
+      vertex 59.0546 -75.9144 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex 59.855 75.0558 0
+      vertex 40 19.263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 59.0546 -75.9144 0
+      vertex 58.8481 -76.2483 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.855 75.0558 0
+      vertex 9.87918 43.2835 0
+      vertex 59.5605 75.3153 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 58.8481 -76.2483 0
+      vertex 58.6753 -76.6007 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.5605 75.3153 0
+      vertex 9.87918 43.2835 0
+      vertex 59.2928 75.6025 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 58.6753 -76.6007 0
+      vertex 58.5379 -76.9684 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.2928 75.6025 0
+      vertex 9.87918 43.2835 0
+      vertex 59.0546 75.9144 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 58.5379 -76.9684 0
+      vertex 58.4372 -77.3478 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 59.0546 75.9144 0
+      vertex 9.87918 43.2835 0
+      vertex 58.8481 76.2483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 58.4372 -77.3478 0
+      vertex 58.3741 -77.7353 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.8481 76.2483 0
+      vertex 9.87918 43.2835 0
+      vertex 58.6753 76.6007 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 58.3741 -77.7353 0
+      vertex 58.3494 -78.1271 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.6753 76.6007 0
+      vertex 9.87918 43.2835 0
+      vertex 58.5379 76.9684 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 104 0 0
+      vertex 108 52.0101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.981 -0.392068 0
+      vertex 104 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.923 -0.780361 0
+      vertex 103.981 -0.392068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.828 -1.16114 0
+      vertex 103.923 -0.780361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.696 -1.53073 0
+      vertex 103.828 -1.16114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.528 -1.88559 0
+      vertex 103.696 -1.53073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.326 -2.22228 0
+      vertex 103.528 -1.88559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 103.092 -2.53757 0
+      vertex 103.326 -2.22228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 102.828 -2.82843 0
+      vertex 103.092 -2.53757 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 102.538 -3.09204 0
+      vertex 102.828 -2.82843 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 102.222 -3.32588 0
+      vertex 102.538 -3.09204 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 101.886 -3.52768 0
+      vertex 102.222 -3.32588 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 101.531 -3.69552 0
+      vertex 101.886 -3.52768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 101.161 -3.82776 0
+      vertex 101.531 -3.69552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 100.78 -3.92314 0
+      vertex 101.161 -3.82776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 100.392 -3.98074 0
+      vertex 100.78 -3.92314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 100 -4 0
+      vertex 100.392 -3.98074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 99.6079 -3.98074 0
+      vertex 100 -4 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 99.2196 -3.92314 0
+      vertex 99.6079 -3.98074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 98.8389 -3.82776 0
+      vertex 99.2196 -3.92314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 98.4693 -3.69552 0
+      vertex 98.8389 -3.82776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 98.1144 -3.52768 0
+      vertex 98.4693 -3.69552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 97.7777 -3.32588 0
+      vertex 98.1144 -3.52768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 97.4624 -3.09204 0
+      vertex 97.7777 -3.32588 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.0656 -76.7044 0
+      vertex 108 -52.0101 0
+      vertex 66.1926 -77.0758 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3348 -77.8469 0
+      vertex 108 -52.0101 0
+      vertex 66.3486 -78.2393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.2827 -77.4579 0
+      vertex 108 -52.0101 0
+      vertex 66.3348 -77.8469 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.1926 -77.0758 0
+      vertex 108 -52.0101 0
+      vertex 66.2827 -77.4579 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.9028 -76.3472 0
+      vertex 108 -52.0101 0
+      vertex 66.0656 -76.7044 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.7057 -76.0077 0
+      vertex 108 -52.0101 0
+      vertex 65.9028 -76.3472 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.4763 -75.6892 0
+      vertex 108 -52.0101 0
+      vertex 65.7057 -76.0077 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.6177 -74.8888 0
+      vertex 108 -52.0101 0
+      vertex 64.9297 -75.127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.9297 -75.127 0
+      vertex 108 -52.0101 0
+      vertex 65.2168 -75.3947 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.2168 -75.3947 0
+      vertex 108 -52.0101 0
+      vertex 65.4763 -75.6892 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 66.3238 -78.631 0
+      vertex 66.3486 -78.2393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 66.2608 -79.0185 0
+      vertex 66.3238 -78.631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 66.1601 -79.3979 0
+      vertex 66.2608 -79.0185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 66.0227 -79.7656 0
+      vertex 66.1601 -79.3979 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 65.8499 -80.118 0
+      vertex 66.0227 -79.7656 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 65.6434 -80.4519 0
+      vertex 65.8499 -80.118 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 65.4051 -80.7638 0
+      vertex 65.6434 -80.4519 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 65.1375 -81.051 0
+      vertex 65.4051 -80.7638 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 108 -52.0101 0
+      vertex 64.8429 -81.3105 0
+      vertex 65.1375 -81.051 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 64.8429 -81.3105 0
+      vertex 108 -52.0101 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.5379 76.9684 0
+      vertex 9.87918 43.2835 0
+      vertex 58.4372 77.3478 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex 58.3494 -78.1271 0
+      vertex 58.3631 -78.5193 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 58.3631 -78.5193 0
+      vertex 58.4153 -78.9084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 58.4153 -78.9084 0
+      vertex 58.5053 -79.2905 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.8429 -81.3105 0
+      vertex 26.6738 -116.866 0
+      vertex 64.5244 -81.5399 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 64.1849 -81.7369 0
+      vertex 64.5244 -81.5399 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 63.8277 -81.8998 0
+      vertex 64.1849 -81.7369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 63.4563 -82.0268 0
+      vertex 63.8277 -81.8998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 63.0742 -82.1168 0
+      vertex 63.4563 -82.0268 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 62.6852 -82.169 0
+      vertex 63.0742 -82.1168 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 62.2929 -82.1828 0
+      vertex 62.6852 -82.169 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 61.9011 -82.158 0
+      vertex 62.2929 -82.1828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 61.5137 -82.095 0
+      vertex 61.9011 -82.158 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 61.1343 -81.9942 0
+      vertex 61.5137 -82.095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 60.7666 -81.8568 0
+      vertex 61.1343 -81.9942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 60.4141 -81.684 0
+      vertex 60.7666 -81.8568 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 60.0803 -81.4775 0
+      vertex 60.4141 -81.684 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 59.7683 -81.2393 0
+      vertex 60.0803 -81.4775 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 59.4812 -80.9716 0
+      vertex 59.7683 -81.2393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 59.2217 -80.6771 0
+      vertex 59.4812 -80.9716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 58.9923 -80.3586 0
+      vertex 59.2217 -80.6771 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 58.7952 -80.0191 0
+      vertex 58.9923 -80.3586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 58.6324 -79.6619 0
+      vertex 58.7952 -80.0191 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 58.5053 -79.2905 0
+      vertex 58.6324 -79.6619 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.3631 -78.5193 0
+      vertex 26.6738 -116.866 0
+      vertex 9.87918 -43.2835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.855 -75.0558 0
+      vertex 9.87918 -43.2835 0
+      vertex 40 -19.263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.2619 -97.2125 0
+      vertex 26.6738 -116.866 0
+      vertex -18.2537 -97.605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.2839 -97.9964 0
+      vertex -18.2537 -97.605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.3524 -98.3829 0
+      vertex -18.2839 -97.9964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.4584 -98.7608 0
+      vertex -18.3524 -98.3829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.601 -99.1266 0
+      vertex -18.4584 -98.7608 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.7787 -99.4766 0
+      vertex -18.601 -99.1266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.9899 -99.8075 0
+      vertex -18.7787 -99.4766 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -19.2324 -100.116 0
+      vertex -18.9899 -99.8075 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -19.5041 -100.399 0
+      vertex -19.2324 -100.116 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -19.8022 -100.655 0
+      vertex -19.5041 -100.399 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -20.124 -100.88 0
+      vertex -19.8022 -100.655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -20.4662 -101.072 0
+      vertex -20.124 -100.88 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -20.8256 -101.23 0
+      vertex -20.4662 -101.072 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -21.1988 -101.352 0
+      vertex -20.8256 -101.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -21.5821 -101.436 0
+      vertex -21.1988 -101.352 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -21.9718 -101.483 0
+      vertex -21.5821 -101.436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -22.3643 -101.491 0
+      vertex -21.9718 -101.483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -22.7557 -101.461 0
+      vertex -22.3643 -101.491 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -23.1422 -101.393 0
+      vertex -22.7557 -101.461 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -23.1422 -101.393 0
+      vertex 26.6738 -116.866 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -26.2505 -97.3806 0
+      vertex -26.2423 -97.7731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.2505 -97.3806 0
+      vertex -74.7383 -93.7189 0
+      vertex -27.6809 -34.7107 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -26.2423 -97.7731 0
+      vertex -26.1956 -98.1628 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -74.7383 -93.7189 0
+      vertex -86.469 -45.0732 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1109 -98.5461 0
+      vertex -74.7383 -93.7189 0
+      vertex -26.1956 -98.1628 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.9891 -98.9193 0
+      vertex -74.7383 -93.7189 0
+      vertex -26.1109 -98.5461 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.8313 -99.2787 0
+      vertex -74.7383 -93.7189 0
+      vertex -25.9891 -98.9193 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.639 -99.6209 0
+      vertex -74.7383 -93.7189 0
+      vertex -25.8313 -99.2787 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4141 -99.9426 0
+      vertex -74.7383 -93.7189 0
+      vertex -25.639 -99.6209 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.1587 -100.241 0
+      vertex -74.7383 -93.7189 0
+      vertex -25.4141 -99.9426 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.8754 -100.512 0
+      vertex -74.7383 -93.7189 0
+      vertex -25.1587 -100.241 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5668 -100.755 0
+      vertex -74.7383 -93.7189 0
+      vertex -24.8754 -100.512 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.2359 -100.966 0
+      vertex -74.7383 -93.7189 0
+      vertex -24.5668 -100.755 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.8859 -101.144 0
+      vertex -74.7383 -93.7189 0
+      vertex -24.2359 -100.966 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.5201 -101.286 0
+      vertex -74.7383 -93.7189 0
+      vertex -23.8859 -101.144 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1422 -101.393 0
+      vertex -74.7383 -93.7189 0
+      vertex -23.5201 -101.286 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.981 0.392068 0
+      vertex 108 52.0101 0
+      vertex 104 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.923 0.780361 0
+      vertex 108 52.0101 0
+      vertex 103.981 0.392068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.828 1.16114 0
+      vertex 108 52.0101 0
+      vertex 103.923 0.780361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.696 1.53073 0
+      vertex 108 52.0101 0
+      vertex 103.828 1.16114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.528 1.88559 0
+      vertex 108 52.0101 0
+      vertex 103.696 1.53073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.326 2.22228 0
+      vertex 108 52.0101 0
+      vertex 103.528 1.88559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 103.092 2.53757 0
+      vertex 108 52.0101 0
+      vertex 103.326 2.22228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 102.828 2.82843 0
+      vertex 108 52.0101 0
+      vertex 103.092 2.53757 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 102.538 3.09204 0
+      vertex 108 52.0101 0
+      vertex 102.828 2.82843 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 102.222 3.32588 0
+      vertex 108 52.0101 0
+      vertex 102.538 3.09204 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 101.886 3.52768 0
+      vertex 108 52.0101 0
+      vertex 102.222 3.32588 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 101.531 3.69552 0
+      vertex 108 52.0101 0
+      vertex 101.886 3.52768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 101.161 3.82776 0
+      vertex 108 52.0101 0
+      vertex 101.531 3.69552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 100.78 3.92314 0
+      vertex 108 52.0101 0
+      vertex 101.161 3.82776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 100.392 3.98074 0
+      vertex 108 52.0101 0
+      vertex 100.78 3.92314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 100 4 0
+      vertex 108 52.0101 0
+      vertex 100.392 3.98074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 99.6079 3.98074 0
+      vertex 108 52.0101 0
+      vertex 100 4 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 99.2196 3.92314 0
+      vertex 108 52.0101 0
+      vertex 99.6079 3.98074 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 98.8389 3.82776 0
+      vertex 108 52.0101 0
+      vertex 99.2196 3.92314 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 98.4693 3.69552 0
+      vertex 108 52.0101 0
+      vertex 98.8389 3.82776 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 98.1144 3.52768 0
+      vertex 108 52.0101 0
+      vertex 98.4693 3.69552 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 97.7777 3.32588 0
+      vertex 108 52.0101 0
+      vertex 98.1144 3.52768 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 97.4624 3.09204 0
+      vertex 108 52.0101 0
+      vertex 97.7777 3.32588 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 97.1716 2.82843 0
+      vertex 108 52.0101 0
+      vertex 97.4624 3.09204 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 97.1716 2.82843 0
+      vertex 96.908 2.53757 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 96.908 2.53757 0
+      vertex 96.6741 2.22228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 96.6741 2.22228 0
+      vertex 96.4723 1.88559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 96.4723 1.88559 0
+      vertex 96.3045 1.53073 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 96.3045 1.53073 0
+      vertex 96.1722 1.16114 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 96.1722 1.16114 0
+      vertex 96.0769 0.780361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.2839 -74.6823 0
+      vertex 108 -52.0101 0
+      vertex 64.6177 -74.8888 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96 0 0
+      vertex 66.3486 78.2393 0
+      vertex 96.0193 0.392068 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 96.0193 0.392068 0
+      vertex 66.3486 78.2393 0
+      vertex 96.0769 0.780361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 97.1716 2.82843 0
+      vertex 66.3486 78.2393 0
+      vertex 108 52.0101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.3238 78.631 0
+      vertex 108 52.0101 0
+      vertex 66.3486 78.2393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.2608 79.0185 0
+      vertex 108 52.0101 0
+      vertex 66.3238 78.631 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.1601 79.3979 0
+      vertex 108 52.0101 0
+      vertex 66.2608 79.0185 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 66.0227 79.7656 0
+      vertex 108 52.0101 0
+      vertex 66.1601 79.3979 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.8499 80.118 0
+      vertex 108 52.0101 0
+      vertex 66.0227 79.7656 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.6434 80.4519 0
+      vertex 108 52.0101 0
+      vertex 65.8499 80.118 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.4051 80.7638 0
+      vertex 108 52.0101 0
+      vertex 65.6434 80.4519 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 65.1375 81.051 0
+      vertex 108 52.0101 0
+      vertex 65.4051 80.7638 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.8429 81.3105 0
+      vertex 108 52.0101 0
+      vertex 65.1375 81.051 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex 64.8429 81.3105 0
+      vertex 64.5244 81.5399 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.4372 77.3478 0
+      vertex 9.87918 43.2835 0
+      vertex 58.3741 77.7353 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.3741 77.7353 0
+      vertex 9.87918 43.2835 0
+      vertex 58.3494 78.1271 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 58.3494 78.1271 0
+      vertex 9.87918 43.2835 0
+      vertex 58.3631 78.5193 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex 58.3631 78.5193 0
+      vertex 9.87918 43.2835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.8429 81.3105 0
+      vertex 26.6738 116.866 0
+      vertex 108 52.0101 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.1849 81.7369 0
+      vertex 26.6738 116.866 0
+      vertex 64.5244 81.5399 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.8277 81.8998 0
+      vertex 26.6738 116.866 0
+      vertex 64.1849 81.7369 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.4563 82.0268 0
+      vertex 26.6738 116.866 0
+      vertex 63.8277 81.8998 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.0742 82.1168 0
+      vertex 26.6738 116.866 0
+      vertex 63.4563 82.0268 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.6852 82.169 0
+      vertex 26.6738 116.866 0
+      vertex 63.0742 82.1168 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.2929 82.1828 0
+      vertex 26.6738 116.866 0
+      vertex 62.6852 82.169 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.9011 82.158 0
+      vertex 26.6738 116.866 0
+      vertex 62.2929 82.1828 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.5137 82.095 0
+      vertex 26.6738 116.866 0
+      vertex 61.9011 82.158 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.1343 81.9942 0
+      vertex 26.6738 116.866 0
+      vertex 61.5137 82.095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.7666 81.8568 0
+      vertex 26.6738 116.866 0
+      vertex 61.1343 81.9942 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.4141 81.684 0
+      vertex 26.6738 116.866 0
+      vertex 60.7666 81.8568 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 60.0803 81.4775 0
+      vertex 26.6738 116.866 0
+      vertex 60.4141 81.684 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.7683 81.2393 0
+      vertex 26.6738 116.866 0
+      vertex 60.0803 81.4775 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.4812 80.9716 0
+      vertex 26.6738 116.866 0
+      vertex 59.7683 81.2393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 59.2217 80.6771 0
+      vertex 26.6738 116.866 0
+      vertex 59.4812 80.9716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.9923 80.3586 0
+      vertex 26.6738 116.866 0
+      vertex 59.2217 80.6771 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.7952 80.0191 0
+      vertex 26.6738 116.866 0
+      vertex 58.9923 80.3586 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.6324 79.6619 0
+      vertex 26.6738 116.866 0
+      vertex 58.7952 80.0191 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5053 79.2905 0
+      vertex 26.6738 116.866 0
+      vertex 58.6324 79.6619 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.3631 78.5193 0
+      vertex 26.6738 116.866 0
+      vertex 58.4153 78.9084 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.4153 78.9084 0
+      vertex 26.6738 116.866 0
+      vertex 58.5053 79.2905 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5151 96.0663 0
+      vertex 26.6738 116.866 0
+      vertex 9.87918 43.2835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.2839 97.9964 0
+      vertex 26.6738 116.866 0
+      vertex -18.2537 97.605 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3524 98.3829 0
+      vertex 26.6738 116.866 0
+      vertex -18.2839 97.9964 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4584 98.7608 0
+      vertex 26.6738 116.866 0
+      vertex -18.3524 98.3829 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.601 99.1266 0
+      vertex 26.6738 116.866 0
+      vertex -18.4584 98.7608 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.7787 99.4766 0
+      vertex 26.6738 116.866 0
+      vertex -18.601 99.1266 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9899 99.8075 0
+      vertex 26.6738 116.866 0
+      vertex -18.7787 99.4766 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.2324 100.116 0
+      vertex 26.6738 116.866 0
+      vertex -18.9899 99.8075 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5041 100.399 0
+      vertex 26.6738 116.866 0
+      vertex -19.2324 100.116 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8022 100.655 0
+      vertex 26.6738 116.866 0
+      vertex -19.5041 100.399 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.124 100.88 0
+      vertex 26.6738 116.866 0
+      vertex -19.8022 100.655 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.4662 101.072 0
+      vertex 26.6738 116.866 0
+      vertex -20.124 100.88 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8256 101.23 0
+      vertex 26.6738 116.866 0
+      vertex -20.4662 101.072 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1988 101.352 0
+      vertex 26.6738 116.866 0
+      vertex -20.8256 101.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5821 101.436 0
+      vertex 26.6738 116.866 0
+      vertex -21.1988 101.352 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9718 101.483 0
+      vertex 26.6738 116.866 0
+      vertex -21.5821 101.436 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.3643 101.491 0
+      vertex 26.6738 116.866 0
+      vertex -21.9718 101.483 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.7557 101.461 0
+      vertex 26.6738 116.866 0
+      vertex -22.3643 101.491 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.1422 101.393 0
+      vertex 26.6738 116.866 0
+      vertex -22.7557 101.461 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 93.7189 0
+      vertex -23.1422 101.393 0
+      vertex -23.5201 101.286 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.2203 96.9892 0
+      vertex -74.7383 93.7189 0
+      vertex -26.2505 97.3806 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.1004 43.5566 0
+      vertex -27.6809 34.7107 0
+      vertex -44.3967 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.2505 97.3806 0
+      vertex -74.7383 93.7189 0
+      vertex -26.2423 97.7731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -86.21 -44.3331 0
+      vertex -86.1362 -43.9475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.1444 -42.7737 0
+      vertex -27.6809 -34.7107 0
+      vertex -86.1032 -43.1641 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.1422 101.393 0
+      vertex -74.7383 93.7189 0
+      vertex 26.6738 116.866 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.8859 101.144 0
+      vertex -74.7383 93.7189 0
+      vertex -23.5201 101.286 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.2359 100.966 0
+      vertex -74.7383 93.7189 0
+      vertex -23.8859 101.144 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.5668 100.755 0
+      vertex -74.7383 93.7189 0
+      vertex -24.2359 100.966 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.8754 100.512 0
+      vertex -74.7383 93.7189 0
+      vertex -24.5668 100.755 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.1587 100.241 0
+      vertex -74.7383 93.7189 0
+      vertex -24.8754 100.512 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.4141 99.9426 0
+      vertex -74.7383 93.7189 0
+      vertex -25.1587 100.241 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.639 99.6209 0
+      vertex -74.7383 93.7189 0
+      vertex -25.4141 99.9426 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.8313 99.2787 0
+      vertex -74.7383 93.7189 0
+      vertex -25.639 99.6209 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.9891 98.9193 0
+      vertex -74.7383 93.7189 0
+      vertex -25.8313 99.2787 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1109 98.5461 0
+      vertex -74.7383 93.7189 0
+      vertex -25.9891 98.9193 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.2423 97.7731 0
+      vertex -74.7383 93.7189 0
+      vertex -26.1956 98.1628 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.1956 98.1628 0
+      vertex -74.7383 93.7189 0
+      vertex -26.1109 98.5461 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -86.1032 -43.1641 0
+      vertex -27.6809 -34.7107 0
+      vertex -86.1004 -43.5566 0
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -86.1004 -43.5566 0
+      vertex -27.6809 -34.7107 0
+      vertex -86.1362 -43.9475 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -86.3214 -44.7095 0
+      vertex -86.21 -44.3331 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -86.469 -45.0732 0
+      vertex -86.3214 -44.7095 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -86.6516 -45.4207 0
+      vertex -86.469 -45.0732 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -86.8674 -45.7486 0
+      vertex -86.6516 -45.4207 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -87.1143 -46.0538 0
+      vertex -86.8674 -45.7486 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -87.3899 -46.3333 0
+      vertex -87.1143 -46.0538 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -87.6916 -46.5844 0
+      vertex -87.3899 -46.3333 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -88.0165 -46.8048 0
+      vertex -87.6916 -46.5844 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -88.3614 -46.9922 0
+      vertex -88.0165 -46.8048 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -88.723 -47.145 0
+      vertex -88.3614 -46.9922 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -89.0978 -47.2616 0
+      vertex -88.723 -47.145 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -89.4822 -47.3409 0
+      vertex -89.0978 -47.2616 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -89.8726 -47.3821 0
+      vertex -89.4822 -47.3409 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -90.2651 -47.3848 0
+      vertex -89.8726 -47.3821 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -90.6561 -47.3491 0
+      vertex -90.2651 -47.3848 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -91.0416 -47.2752 0
+      vertex -90.6561 -47.3491 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -91.418 -47.1639 0
+      vertex -91.0416 -47.2752 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -91.7817 -47.0162 0
+      vertex -91.418 -47.1639 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -92.1292 -46.8336 0
+      vertex -91.7817 -47.0162 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -92.4571 -46.6178 0
+      vertex -92.1292 -46.8336 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -92.7623 -46.3709 0
+      vertex -92.4571 -46.6178 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -93.0418 -46.0953 0
+      vertex -92.7623 -46.3709 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -93.2929 -45.7936 0
+      vertex -93.0418 -46.0953 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -93.5133 -45.4688 0
+      vertex -93.2929 -45.7936 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -93.7008 -45.1239 0
+      vertex -93.5133 -45.4688 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.7008 -45.1239 0
+      vertex -74.7383 -93.7189 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -93.8724 42.0673 0
+      vertex -119.871 3.85793e-07 0
+      vertex -93.9837 42.4437 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -94.0906 -43.6127 0
+      vertex -119.871 -3.85793e-07 0
+      vertex -94.0933 -43.2201 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -94.0494 -44.003 0
+      vertex -119.871 -3.85793e-07 0
+      vertex -94.0906 -43.6127 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.9701 -44.3875 0
+      vertex -119.871 -3.85793e-07 0
+      vertex -94.0494 -44.003 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.8535 -44.7623 0
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.9701 -44.3875 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -93.7008 -45.1239 0
+      vertex -119.871 -3.85793e-07 0
+      vertex -93.8535 -44.7623 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3086 -96.8228 0
+      vertex 26.6738 -116.866 0
+      vertex -18.2619 -97.2125 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.3933 -96.4395 0
+      vertex 26.6738 -116.866 0
+      vertex -18.3086 -96.8228 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5151 -96.0663 0
+      vertex 26.6738 -116.866 0
+      vertex -18.3933 -96.4395 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex -18.5151 -96.0663 0
+      vertex 9.87918 -43.2835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.6729 -95.7069 0
+      vertex 9.87918 -43.2835 0
+      vertex -18.5151 -96.0663 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.8652 -95.3647 0
+      vertex 9.87918 -43.2835 0
+      vertex -18.6729 -95.7069 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.0901 -95.0429 0
+      vertex 9.87918 -43.2835 0
+      vertex -18.8652 -95.3647 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3455 -94.7448 0
+      vertex 9.87918 -43.2835 0
+      vertex -19.0901 -95.0429 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6288 -94.4731 0
+      vertex 9.87918 -43.2835 0
+      vertex -19.3455 -94.7448 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.9374 -94.2305 0
+      vertex 9.87918 -43.2835 0
+      vertex -19.6288 -94.4731 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.2683 -94.0194 0
+      vertex 9.87918 -43.2835 0
+      vertex -19.9374 -94.2305 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.6183 -93.8417 0
+      vertex 9.87918 -43.2835 0
+      vertex -20.2683 -94.0194 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9841 -93.6991 0
+      vertex 9.87918 -43.2835 0
+      vertex -20.6183 -93.8417 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.362 -93.5931 0
+      vertex 9.87918 -43.2835 0
+      vertex -20.9841 -93.6991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -21.362 -93.5931 0
+      vertex -21.7485 -93.5246 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -21.7485 -93.5246 0
+      vertex -22.1399 -93.4944 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -22.1399 -93.4944 0
+      vertex -22.5324 -93.5026 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -22.5324 -93.5026 0
+      vertex -22.9221 -93.5493 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -22.9221 -93.5493 0
+      vertex -23.3054 -93.634 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -23.3054 -93.634 0
+      vertex -23.6786 -93.7558 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -23.6786 -93.7558 0
+      vertex -24.038 -93.9136 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -24.038 -93.9136 0
+      vertex -24.3802 -94.1059 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -24.3802 -94.1059 0
+      vertex -24.7019 -94.3308 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -24.7019 -94.3308 0
+      vertex -25.0001 -94.5862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -25.0001 -94.5862 0
+      vertex -25.2717 -94.8695 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -25.2717 -94.8695 0
+      vertex -25.5143 -95.1781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.362 -93.5931 0
+      vertex -27.6809 -34.7107 0
+      vertex 9.87918 -43.2835 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7255 -95.509 0
+      vertex -27.6809 -34.7107 0
+      vertex -25.5143 -95.1781 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.9032 -95.859 0
+      vertex -27.6809 -34.7107 0
+      vertex -25.7255 -95.509 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.0458 -96.2248 0
+      vertex -27.6809 -34.7107 0
+      vertex -25.9032 -95.859 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.1518 -96.6027 0
+      vertex -27.6809 -34.7107 0
+      vertex -26.0458 -96.2248 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.2203 -96.9892 0
+      vertex -27.6809 -34.7107 0
+      vertex -26.1518 -96.6027 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.6809 -34.7107 0
+      vertex -26.2203 -96.9892 0
+      vertex -26.2505 -97.3806 0
+    endloop
+  endfacet
+  facet normal -0.623489 -0.781832 0
+    outer loop
+      vertex 9.87918 43.2835 0
+      vertex 40 19.263 3.25
+      vertex 9.87918 43.2835 3.25
+    endloop
+  endfacet
+  facet normal -0.623489 -0.781832 -0
+    outer loop
+      vertex 40 19.263 3.25
+      vertex 9.87918 43.2835 0
+      vertex 40 19.263 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -86.1362 43.9475 10.5
+      vertex -86.1004 43.5566 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -86.21 44.3331 10.5
+      vertex -86.1362 43.9475 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -86.3214 44.7095 10.5
+      vertex -86.21 44.3331 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -86.469 45.0732 10.5
+      vertex -86.3214 44.7095 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -86.6516 45.4207 10.5
+      vertex -86.469 45.0732 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -86.8674 45.7486 10.5
+      vertex -86.6516 45.4207 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -87.1143 46.0538 10.5
+      vertex -86.8674 45.7486 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -87.3899 46.3333 10.5
+      vertex -87.1143 46.0538 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -87.6916 46.5844 10.5
+      vertex -87.3899 46.3333 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -88.0165 46.8048 10.5
+      vertex -87.6916 46.5844 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -88.3614 46.9922 10.5
+      vertex -88.0165 46.8048 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -88.723 47.145 10.5
+      vertex -88.3614 46.9922 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -89.0978 47.2616 10.5
+      vertex -88.723 47.145 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -89.4822 47.3409 10.5
+      vertex -89.0978 47.2616 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -89.8726 47.3821 10.5
+      vertex -89.4822 47.3409 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -90.2651 47.3848 10.5
+      vertex -89.8726 47.3821 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -90.6561 47.3491 10.5
+      vertex -90.2651 47.3848 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -91.0416 47.2752 10.5
+      vertex -90.6561 47.3491 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -91.418 47.1639 10.5
+      vertex -91.0416 47.2752 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -91.7817 47.0162 10.5
+      vertex -91.418 47.1639 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -92.1292 46.8336 10.5
+      vertex -91.7817 47.0162 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -92.4571 46.6178 10.5
+      vertex -92.1292 46.8336 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -92.7623 46.3709 10.5
+      vertex -92.4571 46.6178 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -93.0418 46.0953 10.5
+      vertex -92.7623 46.3709 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -93.2929 45.7936 10.5
+      vertex -93.0418 46.0953 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -93.5133 45.4688 10.5
+      vertex -93.2929 45.7936 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -93.7008 45.1239 10.5
+      vertex -93.5133 45.4688 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.871 3.85793e-07 10.5
+      vertex -93.7008 45.1239 10.5
+      vertex -74.7383 93.7189 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.871 3.85793e-07 10.5
+      vertex -94.0933 43.2201 10.5
+      vertex -94.0906 43.6127 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.871 3.85793e-07 10.5
+      vertex -94.0906 43.6127 10.5
+      vertex -94.0494 44.003 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.0933 43.2201 10.5
+      vertex -119.871 3.85793e-07 10.5
+      vertex -102.112 0 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.9701 44.3875 10.5
+      vertex -119.871 3.85793e-07 10.5
+      vertex -94.0494 44.003 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.8535 44.7623 10.5
+      vertex -119.871 3.85793e-07 10.5
+      vertex -93.9701 44.3875 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.7008 45.1239 10.5
+      vertex -119.871 3.85793e-07 10.5
+      vertex -93.8535 44.7623 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.21 -44.3331 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.1362 -43.9475 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.3214 -44.7095 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.21 -44.3331 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.469 -45.0732 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.3214 -44.7095 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.6516 -45.4207 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.469 -45.0732 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.8674 -45.7486 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.6516 -45.4207 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.1143 -46.0538 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.8674 -45.7486 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.3899 -46.3333 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -87.1143 -46.0538 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.6916 -46.5844 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -87.3899 -46.3333 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -88.0165 -46.8048 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -87.6916 -46.5844 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -88.3614 -46.9922 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -88.0165 -46.8048 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -88.723 -47.145 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -88.3614 -46.9922 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.0978 -47.2616 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -88.723 -47.145 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.4822 -47.3409 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -89.0978 -47.2616 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.8726 -47.3821 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -89.4822 -47.3409 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -89.8726 -47.3821 10.5
+      vertex -74.7383 -93.7189 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -90.2651 -47.3848 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -89.8726 -47.3821 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -90.6561 -47.3491 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -90.2651 -47.3848 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.0416 -47.2752 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -90.6561 -47.3491 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.418 -47.1639 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -91.0416 -47.2752 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.7817 -47.0162 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -91.418 -47.1639 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.1292 -46.8336 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -91.7817 -47.0162 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.4571 -46.6178 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -92.1292 -46.8336 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.7623 -46.3709 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -92.4571 -46.6178 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.0418 -46.0953 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -92.7623 -46.3709 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.2929 -45.7936 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -93.0418 -46.0953 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.5133 -45.4688 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -93.2929 -45.7936 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.7008 -45.1239 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -93.5133 -45.4688 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.7008 -45.1239 10.5
+      vertex -93.8535 -44.7623 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.0576 -42.8292 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -94.0933 -43.2201 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.0933 -43.2201 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -94.0906 -43.6127 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.871 0 10.5
+      vertex -102.112 0 10.5
+      vertex -119.871 3.85793e-07 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -102.112 0 10.5
+      vertex -119.871 0 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.0906 -43.6127 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -94.0494 -44.003 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.0494 -44.003 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.9701 -44.3875 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.9701 -44.3875 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.8535 -44.7623 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.7008 -45.1239 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -74.7383 -93.7189 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.2619 -97.2125 10.5
+      vertex -18.2537 -97.605 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.3086 -96.8228 10.5
+      vertex -18.2619 -97.2125 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.3933 -96.4395 10.5
+      vertex -18.3086 -96.8228 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.5151 -96.0663 10.5
+      vertex -18.3933 -96.4395 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.6729 -95.7069 10.5
+      vertex -18.5151 -96.0663 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.8652 -95.3647 10.5
+      vertex -18.6729 -95.7069 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -19.0901 -95.0429 10.5
+      vertex -18.8652 -95.3647 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -19.3455 -94.7448 10.5
+      vertex -19.0901 -95.0429 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -19.6288 -94.4731 10.5
+      vertex -19.3455 -94.7448 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -19.9374 -94.2305 10.5
+      vertex -19.6288 -94.4731 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -20.2683 -94.0194 10.5
+      vertex -19.9374 -94.2305 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -20.6183 -93.8417 10.5
+      vertex -20.2683 -94.0194 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -20.9841 -93.6991 10.5
+      vertex -20.6183 -93.8417 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -21.362 -93.5931 10.5
+      vertex -20.9841 -93.6991 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -21.362 -93.5931 10.5
+      vertex 22.7221 -99.5521 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.2203 -96.9892 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -26.2505 -97.3806 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1518 -96.6027 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -26.2203 -96.9892 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.0458 -96.2248 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -26.1518 -96.6027 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.9032 -95.859 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -26.0458 -96.2248 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7255 -95.509 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -25.9032 -95.859 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.5143 -95.1781 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -25.7255 -95.509 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2717 -94.8695 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -25.5143 -95.1781 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0001 -94.5862 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -25.2717 -94.8695 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.7019 -94.3308 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -25.0001 -94.5862 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.3802 -94.1059 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -24.7019 -94.3308 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.038 -93.9136 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -24.3802 -94.1059 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6786 -93.7558 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -24.038 -93.9136 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3054 -93.634 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -23.6786 -93.7558 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9221 -93.5493 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -23.3054 -93.634 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5324 -93.5026 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -22.9221 -93.5493 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.1399 -93.4944 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -22.5324 -93.5026 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.7485 -93.5246 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -22.1399 -93.4944 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.362 -93.5931 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -21.7485 -93.5246 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2619 97.2125 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.2537 97.605 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3086 96.8228 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.2619 97.2125 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3933 96.4395 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.3086 96.8228 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5151 96.0663 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.3933 96.4395 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.6729 95.7069 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.5151 96.0663 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.8652 95.3647 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.6729 95.7069 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.0901 95.0429 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -18.8652 95.3647 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.3455 94.7448 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -19.0901 95.0429 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.6288 94.4731 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -19.3455 94.7448 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -19.9374 94.2305 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -19.6288 94.4731 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.2683 94.0194 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -19.9374 94.2305 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.6183 93.8417 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -20.2683 94.0194 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -20.9841 93.6991 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -20.6183 93.8417 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.362 93.5931 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex -20.9841 93.6991 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -21.362 93.5931 10.5
+      vertex -21.7485 93.5246 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.362 93.5931 10.5
+      vertex -63.666 79.8346 10.5
+      vertex 22.7221 99.5521 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.1399 93.4944 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -21.7485 93.5246 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5324 93.5026 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -22.1399 93.4944 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.9221 93.5493 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -22.5324 93.5026 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.3054 93.634 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -22.9221 93.5493 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.6786 93.7558 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -23.3054 93.634 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.038 93.9136 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -23.6786 93.7558 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.3802 94.1059 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -24.038 93.9136 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.7019 94.3308 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -24.3802 94.1059 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.0001 94.5862 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -24.7019 94.3308 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.2717 94.8695 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -25.0001 94.5862 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.5143 95.1781 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -25.2717 94.8695 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.7255 95.509 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -25.5143 95.1781 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.9032 95.859 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -25.7255 95.509 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.0458 96.2248 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -25.9032 95.859 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1518 96.6027 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -26.0458 96.2248 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.2203 96.9892 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -26.1518 96.6027 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 10.5
+      vertex -26.2203 96.9892 10.5
+      vertex -26.2505 97.3806 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 -52.0101 10.5
+      vertex 66.3348 -77.8469 10.5
+      vertex 66.3486 -78.2393 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 -52.0101 10.5
+      vertex 66.2827 -77.4579 10.5
+      vertex 66.3348 -77.8469 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 -52.0101 10.5
+      vertex 66.1926 -77.0758 10.5
+      vertex 66.2827 -77.4579 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 66.0656 -76.7044 10.5
+      vertex 66.1926 -77.0758 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 65.9028 -76.3472 10.5
+      vertex 66.0656 -76.7044 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 65.7057 -76.0077 10.5
+      vertex 65.9028 -76.3472 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 65.4763 -75.6892 10.5
+      vertex 65.7057 -76.0077 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 65.2168 -75.3947 10.5
+      vertex 65.4763 -75.6892 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 64.9297 -75.127 10.5
+      vertex 65.2168 -75.3947 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 64.6177 -74.8888 10.5
+      vertex 64.9297 -75.127 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 64.2839 -74.6823 10.5
+      vertex 64.6177 -74.8888 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 63.9314 -74.5095 10.5
+      vertex 64.2839 -74.6823 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 63.5637 -74.372 10.5
+      vertex 63.9314 -74.5095 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 63.1843 -74.2713 10.5
+      vertex 63.5637 -74.372 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 62.7968 -74.2083 10.5
+      vertex 63.1843 -74.2713 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 62.4051 -74.1835 10.5
+      vertex 62.7968 -74.2083 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 62.0128 -74.1973 10.5
+      vertex 62.4051 -74.1835 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 61.6237 -74.2495 10.5
+      vertex 62.0128 -74.1973 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 61.2416 -74.3395 10.5
+      vertex 61.6237 -74.2495 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 60.8702 -74.4665 10.5
+      vertex 61.2416 -74.3395 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 60.5131 -74.6294 10.5
+      vertex 60.8702 -74.4665 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 60.1736 -74.8264 10.5
+      vertex 60.5131 -74.6294 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 59.855 -75.0558 10.5
+      vertex 60.1736 -74.8264 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 59.855 -75.0558 10.5
+      vertex 92 -44.3049 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 58.3494 -78.1271 10.5
+      vertex 58.3741 -77.7353 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 58.3741 -77.7353 10.5
+      vertex 58.4372 -77.3478 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 58.4372 -77.3478 10.5
+      vertex 58.5379 -76.9684 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 58.5379 -76.9684 10.5
+      vertex 58.6753 -76.6007 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 58.6753 -76.6007 10.5
+      vertex 58.8481 -76.2483 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 58.8481 -76.2483 10.5
+      vertex 59.0546 -75.9144 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 59.0546 -75.9144 10.5
+      vertex 59.2928 -75.6025 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.855 -75.0558 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex 59.5605 -75.3153 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 59.2928 -75.6025 10.5
+      vertex 59.5605 -75.3153 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.3494 -78.1271 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex 26.6738 -116.866 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.2839 -97.9964 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.2537 -97.605 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.3524 -98.3829 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.2839 -97.9964 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4584 -98.7608 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.3524 -98.3829 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.601 -99.1266 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.4584 -98.7608 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.7787 -99.4766 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.601 -99.1266 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.9899 -99.8075 10.5
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.7787 -99.4766 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex -18.9899 -99.8075 10.5
+      vertex 26.6738 -116.866 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.2324 -100.116 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -18.9899 -99.8075 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.5041 -100.399 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -19.2324 -100.116 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -19.8022 -100.655 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -19.5041 -100.399 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.124 -100.88 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -19.8022 -100.655 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.4662 -101.072 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -20.124 -100.88 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -20.8256 -101.23 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -20.4662 -101.072 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.1988 -101.352 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -20.8256 -101.23 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.5821 -101.436 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -21.1988 -101.352 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21.9718 -101.483 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -21.5821 -101.436 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.3643 -101.491 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -21.9718 -101.483 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.7557 -101.461 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -22.3643 -101.491 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1422 -101.393 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex -22.7557 -101.461 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 -93.7189 10.5
+      vertex -23.1422 -101.393 10.5
+      vertex -23.5201 -101.286 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -26.2423 -97.7731 10.5
+      vertex -26.2505 -97.3806 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -26.1956 -98.1628 10.5
+      vertex -26.2423 -97.7731 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -74.7383 -93.7189 10.5
+      vertex -26.1956 -98.1628 10.5
+      vertex -63.666 -79.8346 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1956 -98.1628 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -26.1109 -98.5461 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1109 -98.5461 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -25.9891 -98.9193 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.9891 -98.9193 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -25.8313 -99.2787 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.8313 -99.2787 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -25.639 -99.6209 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.639 -99.6209 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -25.4141 -99.9426 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.4141 -99.9426 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -25.1587 -100.241 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.1587 -100.241 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -24.8754 -100.512 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.8754 -100.512 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -24.5668 -100.755 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1422 -101.393 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex 26.6738 -116.866 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.8859 -101.144 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -23.5201 -101.286 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.2359 -100.966 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -23.8859 -101.144 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.5668 -100.755 10.5
+      vertex -74.7383 -93.7189 10.5
+      vertex -24.2359 -100.966 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.1362 -43.9475 10.5
+      vertex -63.666 -79.8346 10.5
+      vertex -86.1004 -43.5566 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -86.1032 -43.1641 10.5
+      vertex -86.1004 -43.5566 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -86.1444 -42.7737 10.5
+      vertex -86.1032 -43.1641 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -86.2237 -42.3893 10.5
+      vertex -86.1444 -42.7737 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -86.3403 -42.0144 10.5
+      vertex -86.2237 -42.3893 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -86.493 -41.6528 10.5
+      vertex -86.3403 -42.0144 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -102.112 0 10.5
+      vertex -86.493 -41.6528 10.5
+      vertex -63.666 -79.8346 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.9837 -42.4437 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -94.0576 -42.8292 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.8724 -42.0673 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.9837 -42.4437 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.7247 -41.7036 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.8724 -42.0673 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.5421 -41.3561 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.7247 -41.7036 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.3263 -41.0282 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.5421 -41.3561 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.0795 -40.723 10.5
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.3263 -41.0282 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -93.0795 -40.723 10.5
+      vertex -102.112 0 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.8038 -40.4435 10.5
+      vertex -102.112 0 10.5
+      vertex -93.0795 -40.723 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.5022 -40.1923 10.5
+      vertex -102.112 0 10.5
+      vertex -92.8038 -40.4435 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.1773 -39.972 10.5
+      vertex -102.112 0 10.5
+      vertex -92.5022 -40.1923 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.8324 -39.7845 10.5
+      vertex -102.112 0 10.5
+      vertex -92.1773 -39.972 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.4708 -39.6317 10.5
+      vertex -102.112 0 10.5
+      vertex -91.8324 -39.7845 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.096 -39.5152 10.5
+      vertex -102.112 0 10.5
+      vertex -91.4708 -39.6317 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -90.7115 -39.4359 10.5
+      vertex -102.112 0 10.5
+      vertex -91.096 -39.5152 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -90.3212 -39.3947 10.5
+      vertex -102.112 0 10.5
+      vertex -90.7115 -39.4359 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -89.9286 -39.3919 10.5
+      vertex -102.112 0 10.5
+      vertex -90.3212 -39.3947 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -89.5377 -39.4277 10.5
+      vertex -102.112 0 10.5
+      vertex -89.9286 -39.3919 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -89.1522 -39.5015 10.5
+      vertex -102.112 0 10.5
+      vertex -89.5377 -39.4277 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -88.7758 -39.6128 10.5
+      vertex -102.112 0 10.5
+      vertex -89.1522 -39.5015 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -88.4121 -39.7605 10.5
+      vertex -102.112 0 10.5
+      vertex -88.7758 -39.6128 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -88.0646 -39.9431 10.5
+      vertex -102.112 0 10.5
+      vertex -88.4121 -39.7605 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.7367 -40.1589 10.5
+      vertex -102.112 0 10.5
+      vertex -88.0646 -39.9431 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.4315 -40.4058 10.5
+      vertex -102.112 0 10.5
+      vertex -87.7367 -40.1589 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -87.152 -40.6814 10.5
+      vertex -102.112 0 10.5
+      vertex -87.4315 -40.4058 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.9008 -40.9831 10.5
+      vertex -102.112 0 10.5
+      vertex -87.152 -40.6814 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.6805 -41.308 10.5
+      vertex -102.112 0 10.5
+      vertex -86.9008 -40.9831 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.493 -41.6528 10.5
+      vertex -102.112 0 10.5
+      vertex -86.6805 -41.308 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 104 0 10.5
+      vertex 108 -52.0101 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.981 0.392068 10.5
+      vertex 104 0 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.923 0.780361 10.5
+      vertex 103.981 0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.828 1.16114 10.5
+      vertex 103.923 0.780361 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.696 1.53073 10.5
+      vertex 103.828 1.16114 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.528 1.88559 10.5
+      vertex 103.696 1.53073 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.326 2.22228 10.5
+      vertex 103.528 1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 103.092 2.53757 10.5
+      vertex 103.326 2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 102.828 2.82843 10.5
+      vertex 103.092 2.53757 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 102.538 3.09204 10.5
+      vertex 102.828 2.82843 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 102.222 3.32588 10.5
+      vertex 102.538 3.09204 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 101.886 3.52768 10.5
+      vertex 102.222 3.32588 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 101.531 3.69552 10.5
+      vertex 101.886 3.52768 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 92 44.3049 10.5
+      vertex 101.531 3.69552 10.5
+      vertex 108 52.0101 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 101.531 3.69552 10.5
+      vertex 92 44.3049 10.5
+      vertex 101.161 3.82776 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 101.161 3.82776 10.5
+      vertex 92 44.3049 10.5
+      vertex 100.78 3.92314 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 100.78 3.92314 10.5
+      vertex 92 44.3049 10.5
+      vertex 100.392 3.98074 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 100.392 3.98074 10.5
+      vertex 92 44.3049 10.5
+      vertex 100 4 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 100 4 10.5
+      vertex 92 44.3049 10.5
+      vertex 99.6079 3.98074 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.6079 3.98074 10.5
+      vertex 92 44.3049 10.5
+      vertex 99.2196 3.92314 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 99.2196 3.92314 10.5
+      vertex 92 44.3049 10.5
+      vertex 98.8389 3.82776 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.8389 3.82776 10.5
+      vertex 92 44.3049 10.5
+      vertex 98.4693 3.69552 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.4693 3.69552 10.5
+      vertex 92 44.3049 10.5
+      vertex 98.1144 3.52768 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 98.1144 3.52768 10.5
+      vertex 92 44.3049 10.5
+      vertex 97.7777 3.32588 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.7777 3.32588 10.5
+      vertex 92 44.3049 10.5
+      vertex 97.4624 3.09204 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.4624 3.09204 10.5
+      vertex 92 44.3049 10.5
+      vertex 97.1716 2.82843 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 97.1716 2.82843 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.908 2.53757 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.908 2.53757 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.6741 2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.6741 2.22228 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.4723 1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.4723 1.88559 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.3045 1.53073 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.3045 1.53073 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.1722 1.16114 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.0193 0.392068 10.5
+      vertex 92 44.3049 10.5
+      vertex 96 0 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.0769 0.780361 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.0193 0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96.1722 1.16114 10.5
+      vertex 92 44.3049 10.5
+      vertex 96.0769 0.780361 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.3348 77.8469 10.5
+      vertex 108 52.0101 10.5
+      vertex 66.3486 78.2393 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 66.3238 78.631 10.5
+      vertex 66.3486 78.2393 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 66.2608 79.0185 10.5
+      vertex 66.3238 78.631 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 66.1601 79.3979 10.5
+      vertex 66.2608 79.0185 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 66.0227 79.7656 10.5
+      vertex 66.1601 79.3979 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 65.8499 80.118 10.5
+      vertex 66.0227 79.7656 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 65.6434 80.4519 10.5
+      vertex 65.8499 80.118 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 65.4051 80.7638 10.5
+      vertex 65.6434 80.4519 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 65.1375 81.051 10.5
+      vertex 65.4051 80.7638 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 64.8429 81.3105 10.5
+      vertex 65.1375 81.051 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex 64.8429 81.3105 10.5
+      vertex 108 52.0101 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.4153 78.9084 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.3631 78.5193 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5053 79.2905 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.4153 78.9084 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.6324 79.6619 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.5053 79.2905 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.7952 80.0191 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.6324 79.6619 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.9923 80.3586 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.7952 80.0191 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.2217 80.6771 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.9923 80.3586 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.4812 80.9716 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 59.2217 80.6771 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.7683 81.2393 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 59.4812 80.9716 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.0803 81.4775 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 59.7683 81.2393 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4141 81.684 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 60.0803 81.4775 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex 60.4141 81.684 10.5
+      vertex 26.6738 116.866 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7666 81.8568 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 60.4141 81.684 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1343 81.9942 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 60.7666 81.8568 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5137 82.095 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 61.1343 81.9942 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9011 82.158 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 61.5137 82.095 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.2929 82.1828 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 61.9011 82.158 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6852 82.169 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 62.2929 82.1828 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0742 82.1168 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 62.6852 82.169 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4563 82.0268 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 63.0742 82.1168 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.8277 81.8998 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 63.4563 82.0268 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.1849 81.7369 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 63.8277 81.8998 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5244 81.5399 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 64.1849 81.7369 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.8429 81.3105 10.5
+      vertex 26.6738 116.866 10.5
+      vertex 64.5244 81.5399 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.981 -0.392068 10.5
+      vertex 108 -52.0101 10.5
+      vertex 104 0 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.923 -0.780361 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.981 -0.392068 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.828 -1.16114 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.923 -0.780361 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.696 -1.53073 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.828 -1.16114 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.528 -1.88559 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.696 -1.53073 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.326 -2.22228 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.528 -1.88559 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 103.092 -2.53757 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.326 -2.22228 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 102.828 -2.82843 10.5
+      vertex 108 -52.0101 10.5
+      vertex 103.092 -2.53757 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 102.538 -3.09204 10.5
+      vertex 108 -52.0101 10.5
+      vertex 102.828 -2.82843 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 102.222 -3.32588 10.5
+      vertex 108 -52.0101 10.5
+      vertex 102.538 -3.09204 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 101.886 -3.52768 10.5
+      vertex 108 -52.0101 10.5
+      vertex 102.222 -3.32588 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 101.531 -3.69552 10.5
+      vertex 108 -52.0101 10.5
+      vertex 101.886 -3.52768 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 101.531 -3.69552 10.5
+      vertex 101.161 -3.82776 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 101.161 -3.82776 10.5
+      vertex 100.78 -3.92314 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 100.78 -3.92314 10.5
+      vertex 100.392 -3.98074 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 100.392 -3.98074 10.5
+      vertex 100 -4 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 100 -4 10.5
+      vertex 99.6079 -3.98074 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 99.6079 -3.98074 10.5
+      vertex 99.2196 -3.92314 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 99.2196 -3.92314 10.5
+      vertex 98.8389 -3.82776 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 98.8389 -3.82776 10.5
+      vertex 98.4693 -3.69552 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 98.4693 -3.69552 10.5
+      vertex 98.1144 -3.52768 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 98.1144 -3.52768 10.5
+      vertex 97.7777 -3.32588 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 97.7777 -3.32588 10.5
+      vertex 97.4624 -3.09204 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 97.4624 -3.09204 10.5
+      vertex 97.1716 -2.82843 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 97.1716 -2.82843 10.5
+      vertex 96.908 -2.53757 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96.908 -2.53757 10.5
+      vertex 96.6741 -2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96.6741 -2.22228 10.5
+      vertex 96.4723 -1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96.4723 -1.88559 10.5
+      vertex 96.3045 -1.53073 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96.3045 -1.53073 10.5
+      vertex 96.1722 -1.16114 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96.1722 -1.16114 10.5
+      vertex 96.0769 -0.780361 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96 0 10.5
+      vertex 92 44.3049 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 96 0 10.5
+      vertex 92 -44.3049 10.5
+      vertex 96.0193 -0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 -44.3049 10.5
+      vertex 96.0769 -0.780361 10.5
+      vertex 96.0193 -0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 101.531 -3.69552 10.5
+      vertex 92 -44.3049 10.5
+      vertex 108 -52.0101 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.1926 -77.0758 10.5
+      vertex 108 -52.0101 10.5
+      vertex 92 -44.3049 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.3238 -78.631 10.5
+      vertex 108 -52.0101 10.5
+      vertex 66.3486 -78.2393 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.2608 -79.0185 10.5
+      vertex 108 -52.0101 10.5
+      vertex 66.3238 -78.631 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.1601 -79.3979 10.5
+      vertex 108 -52.0101 10.5
+      vertex 66.2608 -79.0185 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 66.0227 -79.7656 10.5
+      vertex 108 -52.0101 10.5
+      vertex 66.1601 -79.3979 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.8499 -80.118 10.5
+      vertex 108 -52.0101 10.5
+      vertex 66.0227 -79.7656 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.6434 -80.4519 10.5
+      vertex 108 -52.0101 10.5
+      vertex 65.8499 -80.118 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.4051 -80.7638 10.5
+      vertex 108 -52.0101 10.5
+      vertex 65.6434 -80.4519 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65.1375 -81.051 10.5
+      vertex 108 -52.0101 10.5
+      vertex 65.4051 -80.7638 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.8429 -81.3105 10.5
+      vertex 108 -52.0101 10.5
+      vertex 65.1375 -81.051 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 -116.866 10.5
+      vertex 64.8429 -81.3105 10.5
+      vertex 64.5244 -81.5399 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.8429 -81.3105 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 108 -52.0101 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.1849 -81.7369 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 64.5244 -81.5399 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.8277 -81.8998 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 64.1849 -81.7369 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.4563 -82.0268 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 63.8277 -81.8998 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.0742 -82.1168 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 63.4563 -82.0268 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.6852 -82.169 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 63.0742 -82.1168 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.2929 -82.1828 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 62.6852 -82.169 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.9011 -82.158 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 62.2929 -82.1828 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5137 -82.095 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 61.9011 -82.158 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.1343 -81.9942 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 61.5137 -82.095 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.7666 -81.8568 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 61.1343 -81.9942 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4141 -81.684 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 60.7666 -81.8568 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.0803 -81.4775 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 60.4141 -81.684 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.7683 -81.2393 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 60.0803 -81.4775 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.4812 -80.9716 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 59.7683 -81.2393 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.2217 -80.6771 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 59.4812 -80.9716 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.9923 -80.3586 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 59.2217 -80.6771 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.7952 -80.0191 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 58.9923 -80.3586 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.6324 -79.6619 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 58.7952 -80.0191 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5053 -79.2905 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 58.6324 -79.6619 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.4153 -78.9084 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 58.5053 -79.2905 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.3631 -78.5193 10.5
+      vertex 26.6738 -116.866 10.5
+      vertex 58.4153 -78.9084 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 -116.866 10.5
+      vertex 58.3631 -78.5193 10.5
+      vertex 58.3494 -78.1271 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.2827 77.4579 10.5
+      vertex 108 52.0101 10.5
+      vertex 66.3348 77.8469 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.1926 77.0758 10.5
+      vertex 108 52.0101 10.5
+      vertex 66.2827 77.4579 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 108 52.0101 10.5
+      vertex 66.1926 77.0758 10.5
+      vertex 92 44.3049 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.0656 76.7044 10.5
+      vertex 92 44.3049 10.5
+      vertex 66.1926 77.0758 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.9028 76.3472 10.5
+      vertex 92 44.3049 10.5
+      vertex 66.0656 76.7044 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.7057 76.0077 10.5
+      vertex 92 44.3049 10.5
+      vertex 65.9028 76.3472 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.4763 75.6892 10.5
+      vertex 92 44.3049 10.5
+      vertex 65.7057 76.0077 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.2168 75.3947 10.5
+      vertex 92 44.3049 10.5
+      vertex 65.4763 75.6892 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.9297 75.127 10.5
+      vertex 92 44.3049 10.5
+      vertex 65.2168 75.3947 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.6177 74.8888 10.5
+      vertex 92 44.3049 10.5
+      vertex 64.9297 75.127 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.2839 74.6823 10.5
+      vertex 92 44.3049 10.5
+      vertex 64.6177 74.8888 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.9314 74.5095 10.5
+      vertex 92 44.3049 10.5
+      vertex 64.2839 74.6823 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.5637 74.372 10.5
+      vertex 92 44.3049 10.5
+      vertex 63.9314 74.5095 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.1843 74.2713 10.5
+      vertex 92 44.3049 10.5
+      vertex 63.5637 74.372 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.7968 74.2083 10.5
+      vertex 92 44.3049 10.5
+      vertex 63.1843 74.2713 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.4051 74.1835 10.5
+      vertex 92 44.3049 10.5
+      vertex 62.7968 74.2083 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0128 74.1973 10.5
+      vertex 92 44.3049 10.5
+      vertex 62.4051 74.1835 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.6237 74.2495 10.5
+      vertex 92 44.3049 10.5
+      vertex 62.0128 74.1973 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2416 74.3395 10.5
+      vertex 92 44.3049 10.5
+      vertex 61.6237 74.2495 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.8702 74.4665 10.5
+      vertex 92 44.3049 10.5
+      vertex 61.2416 74.3395 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5131 74.6294 10.5
+      vertex 92 44.3049 10.5
+      vertex 60.8702 74.4665 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.1736 74.8264 10.5
+      vertex 92 44.3049 10.5
+      vertex 60.5131 74.6294 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.855 75.0558 10.5
+      vertex 92 44.3049 10.5
+      vertex 60.1736 74.8264 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex 59.855 75.0558 10.5
+      vertex 59.5605 75.3153 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.3631 78.5193 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.3494 78.1271 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.3494 78.1271 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.3741 77.7353 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.3741 77.7353 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.4372 77.3478 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.4372 77.3478 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.5379 76.9684 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5379 76.9684 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.6753 76.6007 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.6753 76.6007 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 58.8481 76.2483 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.8481 76.2483 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 59.0546 75.9144 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.855 75.0558 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 92 44.3049 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.2928 75.6025 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 59.5605 75.3153 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.0546 75.9144 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 59.2928 75.6025 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.9899 99.8075 10.5
+      vertex 22.7221 99.5521 10.5
+      vertex 26.6738 116.866 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -18.2839 97.9964 10.5
+      vertex -18.2537 97.605 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -18.3524 98.3829 10.5
+      vertex -18.2839 97.9964 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -18.4584 98.7608 10.5
+      vertex -18.3524 98.3829 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -18.601 99.1266 10.5
+      vertex -18.4584 98.7608 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -18.7787 99.4766 10.5
+      vertex -18.601 99.1266 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -18.9899 99.8075 10.5
+      vertex -18.7787 99.4766 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -19.2324 100.116 10.5
+      vertex -18.9899 99.8075 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -19.5041 100.399 10.5
+      vertex -19.2324 100.116 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -19.8022 100.655 10.5
+      vertex -19.5041 100.399 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -20.124 100.88 10.5
+      vertex -19.8022 100.655 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -20.4662 101.072 10.5
+      vertex -20.124 100.88 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -20.8256 101.23 10.5
+      vertex -20.4662 101.072 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -21.1988 101.352 10.5
+      vertex -20.8256 101.23 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -21.5821 101.436 10.5
+      vertex -21.1988 101.352 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -21.9718 101.483 10.5
+      vertex -21.5821 101.436 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -22.3643 101.491 10.5
+      vertex -21.9718 101.483 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -22.7557 101.461 10.5
+      vertex -22.3643 101.491 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.6738 116.866 10.5
+      vertex -23.1422 101.393 10.5
+      vertex -22.7557 101.461 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -23.1422 101.393 10.5
+      vertex 26.6738 116.866 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.2423 97.7731 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -26.2505 97.3806 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1956 98.1628 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -26.2423 97.7731 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -26.1956 98.1628 10.5
+      vertex -26.1109 98.5461 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -26.1109 98.5461 10.5
+      vertex -25.9891 98.9193 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -25.9891 98.9193 10.5
+      vertex -25.8313 99.2787 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -25.8313 99.2787 10.5
+      vertex -25.639 99.6209 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -25.639 99.6209 10.5
+      vertex -25.4141 99.9426 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -25.4141 99.9426 10.5
+      vertex -25.1587 100.241 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -25.1587 100.241 10.5
+      vertex -24.8754 100.512 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -24.8754 100.512 10.5
+      vertex -24.5668 100.755 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -24.5668 100.755 10.5
+      vertex -24.2359 100.966 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1422 101.393 10.5
+      vertex -74.7383 93.7189 10.5
+      vertex -23.5201 101.286 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -23.8859 101.144 10.5
+      vertex -23.5201 101.286 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -24.2359 100.966 10.5
+      vertex -23.8859 101.144 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -26.1956 98.1628 10.5
+      vertex -74.7383 93.7189 10.5
+      vertex -63.666 79.8346 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -89.8726 47.3821 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -74.7383 93.7189 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.1032 43.1641 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -86.1004 43.5566 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.1444 42.7737 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -86.1032 43.1641 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.2237 42.3893 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -86.1444 42.7737 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.3403 42.0144 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -86.2237 42.3893 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -86.493 41.6528 10.5
+      vertex -63.666 79.8346 10.5
+      vertex -86.3403 42.0144 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -102.112 0 10.5
+      vertex -86.493 41.6528 10.5
+      vertex -86.6805 41.308 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.493 41.6528 10.5
+      vertex -102.112 0 10.5
+      vertex -63.666 79.8346 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -86.9008 40.9831 10.5
+      vertex -102.112 0 10.5
+      vertex -86.6805 41.308 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.152 40.6814 10.5
+      vertex -102.112 0 10.5
+      vertex -86.9008 40.9831 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.4315 40.4058 10.5
+      vertex -102.112 0 10.5
+      vertex -87.152 40.6814 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -87.7367 40.1589 10.5
+      vertex -102.112 0 10.5
+      vertex -87.4315 40.4058 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -88.0646 39.9431 10.5
+      vertex -102.112 0 10.5
+      vertex -87.7367 40.1589 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -88.4121 39.7605 10.5
+      vertex -102.112 0 10.5
+      vertex -88.0646 39.9431 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -88.7758 39.6128 10.5
+      vertex -102.112 0 10.5
+      vertex -88.4121 39.7605 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.1522 39.5015 10.5
+      vertex -102.112 0 10.5
+      vertex -88.7758 39.6128 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.5377 39.4277 10.5
+      vertex -102.112 0 10.5
+      vertex -89.1522 39.5015 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -89.9286 39.3919 10.5
+      vertex -102.112 0 10.5
+      vertex -89.5377 39.4277 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -90.3212 39.3947 10.5
+      vertex -102.112 0 10.5
+      vertex -89.9286 39.3919 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -90.7115 39.4359 10.5
+      vertex -102.112 0 10.5
+      vertex -90.3212 39.3947 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.096 39.5152 10.5
+      vertex -102.112 0 10.5
+      vertex -90.7115 39.4359 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.4708 39.6317 10.5
+      vertex -102.112 0 10.5
+      vertex -91.096 39.5152 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.8324 39.7845 10.5
+      vertex -102.112 0 10.5
+      vertex -91.4708 39.6317 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.1773 39.972 10.5
+      vertex -102.112 0 10.5
+      vertex -91.8324 39.7845 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.5022 40.1923 10.5
+      vertex -102.112 0 10.5
+      vertex -92.1773 39.972 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -92.8038 40.4435 10.5
+      vertex -102.112 0 10.5
+      vertex -92.5022 40.1923 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.0795 40.723 10.5
+      vertex -102.112 0 10.5
+      vertex -92.8038 40.4435 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.3263 41.0282 10.5
+      vertex -102.112 0 10.5
+      vertex -93.0795 40.723 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.5421 41.3561 10.5
+      vertex -102.112 0 10.5
+      vertex -93.3263 41.0282 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.7247 41.7036 10.5
+      vertex -102.112 0 10.5
+      vertex -93.5421 41.3561 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.8724 42.0673 10.5
+      vertex -102.112 0 10.5
+      vertex -93.7247 41.7036 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -93.9837 42.4437 10.5
+      vertex -102.112 0 10.5
+      vertex -93.8724 42.0673 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -94.0576 42.8292 10.5
+      vertex -102.112 0 10.5
+      vertex -93.9837 42.4437 10.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -102.112 0 10.5
+      vertex -94.0576 42.8292 10.5
+      vertex -94.0933 43.2201 10.5
+    endloop
+  endfacet
+  facet normal -0.623489 -0.781832 0
+    outer loop
+      vertex 22.7221 99.5521 6
+      vertex 92 44.3049 10.5
+      vertex 22.7221 99.5521 10.5
+    endloop
+  endfacet
+  facet normal -0.623489 -0.781832 -0
+    outer loop
+      vertex 92 44.3049 10.5
+      vertex 22.7221 99.5521 6
+      vertex 92 44.3049 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 92 44.3049 6
+      vertex 82 39.4891 6
+      vertex 92 -44.3049 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 6
+      vertex 82 39.4891 6
+      vertex 92 44.3049 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 6
+      vertex 20.2523 88.7312 6
+      vertex 82 39.4891 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 22.7221 99.5521 6
+      vertex -56.7458 71.1569 6
+      vertex 20.2523 88.7312 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -63.666 79.8346 6
+      vertex -56.7458 71.1569 6
+      vertex 22.7221 99.5521 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 79.8346 6
+      vertex -91.0131 0 6
+      vertex -56.7458 71.1569 6
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -91.0131 0 6
+      vertex -63.666 79.8346 6
+      vertex -102.112 0 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 82 -39.4891 6
+      vertex 92 -44.3049 6
+      vertex 82 39.4891 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 82 -39.4891 6
+      vertex 22.7221 -99.5521 6
+      vertex 92 -44.3049 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 20.2523 -88.7312 6
+      vertex 22.7221 -99.5521 6
+      vertex 82 -39.4891 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.7458 -71.1569 6
+      vertex 22.7221 -99.5521 6
+      vertex 20.2523 -88.7312 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.7458 -71.1569 6
+      vertex -63.666 -79.8346 6
+      vertex 22.7221 -99.5521 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -91.0131 0 6
+      vertex -63.666 -79.8346 6
+      vertex -56.7458 -71.1569 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -63.666 -79.8346 6
+      vertex -91.0131 0 6
+      vertex -102.112 0 6
+    endloop
+  endfacet
+  facet normal -0.623489 -0.781832 0
+    outer loop
+      vertex 20.2523 88.7312 3.25
+      vertex 82 39.4891 6
+      vertex 20.2523 88.7312 6
+    endloop
+  endfacet
+  facet normal -0.623489 -0.781832 -0
+    outer loop
+      vertex 82 39.4891 6
+      vertex 20.2523 88.7312 3.25
+      vertex 82 39.4891 3.25
+    endloop
+  endfacet
+  facet normal 0.811438 -0.584439 0
+    outer loop
+      vertex 58.9923 80.3586 10.5
+      vertex 59.2217 80.6771 0
+      vertex 59.2217 80.6771 10.5
+    endloop
+  endfacet
+  facet normal 0.811438 -0.584439 0
+    outer loop
+      vertex 59.2217 80.6771 0
+      vertex 58.9923 80.3586 10.5
+      vertex 58.9923 80.3586 0
+    endloop
+  endfacet
+  facet normal -0.584439 -0.811438 0
+    outer loop
+      vertex 64.5244 81.5399 0
+      vertex 64.8429 81.3105 10.5
+      vertex 64.5244 81.5399 10.5
+    endloop
+  endfacet
+  facet normal -0.584439 -0.811438 -0
+    outer loop
+      vertex 64.8429 81.3105 10.5
+      vertex 64.5244 81.5399 0
+      vertex 64.8429 81.3105 0
+    endloop
+  endfacet
+  facet normal 0.991121 -0.132965 0
+    outer loop
+      vertex 58.3631 78.5193 10.5
+      vertex 58.4153 78.9084 0
+      vertex 58.4153 78.9084 10.5
+    endloop
+  endfacet
+  facet normal 0.991121 -0.132965 0
+    outer loop
+      vertex 58.4153 78.9084 0
+      vertex 58.3631 78.5193 10.5
+      vertex 58.3631 78.5193 0
+    endloop
+  endfacet
+  facet normal -0.0351554 -0.999382 0
+    outer loop
+      vertex 62.2929 82.1828 0
+      vertex 62.6852 82.169 10.5
+      vertex 62.2929 82.1828 10.5
+    endloop
+  endfacet
+  facet normal -0.0351554 -0.999382 -0
+    outer loop
+      vertex 62.6852 82.169 10.5
+      vertex 62.2929 82.1828 0
+      vertex 62.6852 82.169 0
+    endloop
+  endfacet
+  facet normal 0.229267 0.973364 -0
+    outer loop
+      vertex 61.6237 74.2495 0
+      vertex 61.2416 74.3395 10.5
+      vertex 61.6237 74.2495 10.5
+    endloop
+  endfacet
+  facet normal 0.229267 0.973364 0
+    outer loop
+      vertex 61.2416 74.3395 10.5
+      vertex 61.6237 74.2495 0
+      vertex 61.2416 74.3395 0
+    endloop
+  endfacet
+  facet normal -0.414935 -0.909851 0
+    outer loop
+      vertex 63.8277 81.8998 0
+      vertex 64.1849 81.7369 10.5
+      vertex 63.8277 81.8998 10.5
+    endloop
+  endfacet
+  facet normal -0.414935 -0.909851 -0
+    outer loop
+      vertex 64.1849 81.7369 10.5
+      vertex 63.8277 81.8998 0
+      vertex 64.1849 81.7369 0
+    endloop
+  endfacet
+  facet normal -0.66099 -0.750395 0
+    outer loop
+      vertex 64.8429 81.3105 0
+      vertex 65.1375 81.051 10.5
+      vertex 64.8429 81.3105 10.5
+    endloop
+  endfacet
+  facet normal -0.66099 -0.750395 -0
+    outer loop
+      vertex 65.1375 81.051 10.5
+      vertex 64.8429 81.3105 0
+      vertex 65.1375 81.051 0
+    endloop
+  endfacet
+  facet normal -0.99115 0.132748 0
+    outer loop
+      vertex 66.2827 77.4579 0
+      vertex 66.3348 77.8469 10.5
+      vertex 66.3348 77.8469 0
+    endloop
+  endfacet
+  facet normal -0.99115 0.132748 0
+    outer loop
+      vertex 66.3348 77.8469 10.5
+      vertex 66.2827 77.4579 0
+      vertex 66.2827 77.4579 10.5
+    endloop
+  endfacet
+  facet normal -0.946209 0.323556 0
+    outer loop
+      vertex 66.0656 76.7044 0
+      vertex 66.1926 77.0758 10.5
+      vertex 66.1926 77.0758 0
+    endloop
+  endfacet
+  facet normal -0.946209 0.323556 0
+    outer loop
+      vertex 66.1926 77.0758 10.5
+      vertex 66.0656 76.7044 0
+      vertex 66.0656 76.7044 10.5
+    endloop
+  endfacet
+  facet normal -0.966534 -0.256537 0
+    outer loop
+      vertex 66.2608 79.0185 0
+      vertex 66.1601 79.3979 10.5
+      vertex 66.1601 79.3979 0
+    endloop
+  endfacet
+  facet normal -0.966534 -0.256537 0
+    outer loop
+      vertex 66.1601 79.3979 10.5
+      vertex 66.2608 79.0185 0
+      vertex 66.2608 79.0185 10.5
+    endloop
+  endfacet
+  facet normal -0.98704 -0.160474 0
+    outer loop
+      vertex 66.3238 78.631 0
+      vertex 66.2608 79.0185 10.5
+      vertex 66.2608 79.0185 0
+    endloop
+  endfacet
+  facet normal -0.98704 -0.160474 0
+    outer loop
+      vertex 66.2608 79.0185 10.5
+      vertex 66.3238 78.631 0
+      vertex 66.3238 78.631 10.5
+    endloop
+  endfacet
+  facet normal 0.973364 -0.229267 0
+    outer loop
+      vertex 58.4153 78.9084 10.5
+      vertex 58.5053 79.2905 0
+      vertex 58.5053 79.2905 10.5
+    endloop
+  endfacet
+  facet normal 0.973364 -0.229267 0
+    outer loop
+      vertex 58.5053 79.2905 0
+      vertex 58.4153 78.9084 10.5
+      vertex 58.4153 78.9084 0
+    endloop
+  endfacet
+  facet normal 0.750284 -0.661116 0
+    outer loop
+      vertex 59.2217 80.6771 10.5
+      vertex 59.4812 80.9716 0
+      vertex 59.4812 80.9716 10.5
+    endloop
+  endfacet
+  facet normal 0.750284 -0.661116 0
+    outer loop
+      vertex 59.4812 80.9716 0
+      vertex 59.2217 80.6771 10.5
+      vertex 59.2217 80.6771 0
+    endloop
+  endfacet
+  facet normal -0.440169 0.897915 0
+    outer loop
+      vertex 64.2839 74.6823 0
+      vertex 63.9314 74.5095 10.5
+      vertex 64.2839 74.6823 10.5
+    endloop
+  endfacet
+  facet normal -0.440169 0.897915 0
+    outer loop
+      vertex 63.9314 74.5095 10.5
+      vertex 64.2839 74.6823 0
+      vertex 63.9314 74.5095 0
+    endloop
+  endfacet
+  facet normal 0.864821 -0.50208 0
+    outer loop
+      vertex 58.7952 80.0191 10.5
+      vertex 58.9923 80.3586 0
+      vertex 58.9923 80.3586 10.5
+    endloop
+  endfacet
+  facet normal 0.864821 -0.50208 0
+    outer loop
+      vertex 58.9923 80.3586 0
+      vertex 58.7952 80.0191 10.5
+      vertex 58.7952 80.0191 0
+    endloop
+  endfacet
+  facet normal 0.850493 0.525986 0
+    outer loop
+      vertex 59.0546 75.9144 10.5
+      vertex 58.8481 76.2483 0
+      vertex 58.8481 76.2483 10.5
+    endloop
+  endfacet
+  facet normal 0.850493 0.525986 0
+    outer loop
+      vertex 58.8481 76.2483 0
+      vertex 59.0546 75.9144 10.5
+      vertex 59.0546 75.9144 0
+    endloop
+  endfacet
+  facet normal -0.160474 0.98704 0
+    outer loop
+      vertex 63.1843 74.2713 0
+      vertex 62.7968 74.2083 10.5
+      vertex 63.1843 74.2713 10.5
+    endloop
+  endfacet
+  facet normal -0.160474 0.98704 0
+    outer loop
+      vertex 62.7968 74.2083 10.5
+      vertex 63.1843 74.2713 0
+      vertex 62.7968 74.2083 0
+    endloop
+  endfacet
+  facet normal -0.811438 0.584439 0
+    outer loop
+      vertex 65.4763 75.6892 0
+      vertex 65.7057 76.0077 10.5
+      vertex 65.7057 76.0077 0
+    endloop
+  endfacet
+  facet normal -0.811438 0.584439 0
+    outer loop
+      vertex 65.7057 76.0077 10.5
+      vertex 65.4763 75.6892 0
+      vertex 65.4763 75.6892 10.5
+    endloop
+  endfacet
+  facet normal -0.132998 -0.991116 0
+    outer loop
+      vertex 62.6852 82.169 0
+      vertex 63.0742 82.1168 10.5
+      vertex 62.6852 82.169 10.5
+    endloop
+  endfacet
+  facet normal -0.132998 -0.991116 -0
+    outer loop
+      vertex 63.0742 82.1168 10.5
+      vertex 62.6852 82.169 0
+      vertex 63.0742 82.1168 0
+    endloop
+  endfacet
+  facet normal 0.415031 0.909807 -0
+    outer loop
+      vertex 60.8702 74.4665 0
+      vertex 60.5131 74.6294 10.5
+      vertex 60.8702 74.4665 10.5
+    endloop
+  endfacet
+  facet normal 0.415031 0.909807 0
+    outer loop
+      vertex 60.5131 74.6294 10.5
+      vertex 60.8702 74.4665 0
+      vertex 60.5131 74.6294 0
+    endloop
+  endfacet
+  facet normal 0.584318 0.811525 -0
+    outer loop
+      vertex 60.1736 74.8264 0
+      vertex 59.855 75.0558 10.5
+      vertex 60.1736 74.8264 10.5
+    endloop
+  endfacet
+  facet normal 0.584318 0.811525 0
+    outer loop
+      vertex 59.855 75.0558 10.5
+      vertex 60.1736 74.8264 0
+      vertex 59.855 75.0558 0
+    endloop
+  endfacet
+  facet normal 0.323556 0.946209 -0
+    outer loop
+      vertex 61.2416 74.3395 0
+      vertex 60.8702 74.4665 10.5
+      vertex 61.2416 74.3395 10.5
+    endloop
+  endfacet
+  facet normal 0.323556 0.946209 0
+    outer loop
+      vertex 60.8702 74.4665 10.5
+      vertex 61.2416 74.3395 0
+      vertex 60.8702 74.4665 0
+    endloop
+  endfacet
+  facet normal -0.50189 -0.864932 0
+    outer loop
+      vertex 64.1849 81.7369 0
+      vertex 64.5244 81.5399 10.5
+      vertex 64.1849 81.7369 10.5
+    endloop
+  endfacet
+  facet normal -0.50189 -0.864932 -0
+    outer loop
+      vertex 64.5244 81.5399 10.5
+      vertex 64.1849 81.7369 0
+      vertex 64.5244 81.5399 0
+    endloop
+  endfacet
+  facet normal -0.5261 0.850423 0
+    outer loop
+      vertex 64.6177 74.8888 0
+      vertex 64.2839 74.6823 10.5
+      vertex 64.6177 74.8888 10.5
+    endloop
+  endfacet
+  facet normal -0.5261 0.850423 0
+    outer loop
+      vertex 64.2839 74.6823 10.5
+      vertex 64.6177 74.8888 0
+      vertex 64.2839 74.6823 0
+    endloop
+  endfacet
+  facet normal -0.909947 0.414724 0
+    outer loop
+      vertex 65.9028 76.3472 0
+      vertex 66.0656 76.7044 10.5
+      vertex 66.0656 76.7044 0
+    endloop
+  endfacet
+  facet normal -0.909947 0.414724 0
+    outer loop
+      vertex 66.0656 76.7044 10.5
+      vertex 65.9028 76.3472 0
+      vertex 65.9028 76.3472 10.5
+    endloop
+  endfacet
+  facet normal -0.229267 -0.973364 0
+    outer loop
+      vertex 63.0742 82.1168 0
+      vertex 63.4563 82.0268 10.5
+      vertex 63.0742 82.1168 10.5
+    endloop
+  endfacet
+  facet normal -0.229267 -0.973364 -0
+    outer loop
+      vertex 63.4563 82.0268 10.5
+      vertex 63.0742 82.1168 0
+      vertex 63.4563 82.0268 0
+    endloop
+  endfacet
+  facet normal 0.5261 -0.850423 0
+    outer loop
+      vertex 60.0803 81.4775 0
+      vertex 60.4141 81.684 10.5
+      vertex 60.0803 81.4775 10.5
+    endloop
+  endfacet
+  facet normal 0.5261 -0.850423 0
+    outer loop
+      vertex 60.4141 81.684 10.5
+      vertex 60.0803 81.4775 0
+      vertex 60.4141 81.684 0
+    endloop
+  endfacet
+  facet normal 0.50189 0.864932 -0
+    outer loop
+      vertex 60.5131 74.6294 0
+      vertex 60.1736 74.8264 10.5
+      vertex 60.5131 74.6294 10.5
+    endloop
+  endfacet
+  facet normal 0.50189 0.864932 0
+    outer loop
+      vertex 60.1736 74.8264 10.5
+      vertex 60.5131 74.6294 0
+      vertex 60.1736 74.8264 0
+    endloop
+  endfacet
+  facet normal -0.897865 -0.44027 0
+    outer loop
+      vertex 66.0227 79.7656 0
+      vertex 65.8499 80.118 10.5
+      vertex 65.8499 80.118 0
+    endloop
+  endfacet
+  facet normal -0.897865 -0.44027 0
+    outer loop
+      vertex 65.8499 80.118 10.5
+      vertex 66.0227 79.7656 0
+      vertex 66.0227 79.7656 10.5
+    endloop
+  endfacet
+  facet normal -0.750284 0.661116 0
+    outer loop
+      vertex 65.2168 75.3947 0
+      vertex 65.4763 75.6892 10.5
+      vertex 65.4763 75.6892 0
+    endloop
+  endfacet
+  facet normal -0.750284 0.661116 0
+    outer loop
+      vertex 65.4763 75.6892 10.5
+      vertex 65.2168 75.3947 0
+      vertex 65.2168 75.3947 10.5
+    endloop
+  endfacet
+  facet normal -0.936737 -0.350034 0
+    outer loop
+      vertex 66.1601 79.3979 0
+      vertex 66.0227 79.7656 10.5
+      vertex 66.0227 79.7656 0
+    endloop
+  endfacet
+  facet normal -0.936737 -0.350034 0
+    outer loop
+      vertex 66.0227 79.7656 10.5
+      vertex 66.1601 79.3979 0
+      vertex 66.1601 79.3979 10.5
+    endloop
+  endfacet
+  facet normal -0.606826 0.794835 0
+    outer loop
+      vertex 64.9297 75.127 0
+      vertex 64.6177 74.8888 10.5
+      vertex 64.9297 75.127 10.5
+    endloop
+  endfacet
+  facet normal -0.606826 0.794835 0
+    outer loop
+      vertex 64.6177 74.8888 10.5
+      vertex 64.9297 75.127 0
+      vertex 64.6177 74.8888 0
+    endloop
+  endfacet
+  facet normal 0.936737 0.350034 0
+    outer loop
+      vertex 58.6753 76.6007 10.5
+      vertex 58.5379 76.9684 0
+      vertex 58.5379 76.9684 10.5
+    endloop
+  endfacet
+  facet normal 0.936737 0.350034 0
+    outer loop
+      vertex 58.5379 76.9684 0
+      vertex 58.6753 76.6007 10.5
+      vertex 58.6753 76.6007 0
+    endloop
+  endfacet
+  facet normal 0.606826 -0.794835 0
+    outer loop
+      vertex 59.7683 81.2393 0
+      vertex 60.0803 81.4775 10.5
+      vertex 59.7683 81.2393 10.5
+    endloop
+  endfacet
+  facet normal 0.606826 -0.794835 0
+    outer loop
+      vertex 60.0803 81.4775 10.5
+      vertex 59.7683 81.2393 0
+      vertex 60.0803 81.4775 0
+    endloop
+  endfacet
+  facet normal 0.909947 -0.414724 0
+    outer loop
+      vertex 58.6324 79.6619 10.5
+      vertex 58.7952 80.0191 0
+      vertex 58.7952 80.0191 10.5
+    endloop
+  endfacet
+  facet normal 0.909947 -0.414724 0
+    outer loop
+      vertex 58.7952 80.0191 0
+      vertex 58.6324 79.6619 10.5
+      vertex 58.6324 79.6619 0
+    endloop
+  endfacet
+  facet normal 0.99939 -0.0349099 0
+    outer loop
+      vertex 58.3494 78.1271 10.5
+      vertex 58.3631 78.5193 0
+      vertex 58.3631 78.5193 10.5
+    endloop
+  endfacet
+  facet normal 0.99939 -0.0349099 0
+    outer loop
+      vertex 58.3631 78.5193 0
+      vertex 58.3494 78.1271 10.5
+      vertex 58.3494 78.1271 0
+    endloop
+  endfacet
+  facet normal -0.973307 0.229508 0
+    outer loop
+      vertex 66.1926 77.0758 0
+      vertex 66.2827 77.4579 10.5
+      vertex 66.2827 77.4579 0
+    endloop
+  endfacet
+  facet normal -0.973307 0.229508 0
+    outer loop
+      vertex 66.2827 77.4579 10.5
+      vertex 66.1926 77.0758 0
+      vertex 66.1926 77.0758 10.5
+    endloop
+  endfacet
+  facet normal 0.987 0.160722 0
+    outer loop
+      vertex 58.4372 77.3478 10.5
+      vertex 58.3741 77.7353 0
+      vertex 58.3741 77.7353 10.5
+    endloop
+  endfacet
+  facet normal 0.987 0.160722 0
+    outer loop
+      vertex 58.3741 77.7353 0
+      vertex 58.4372 77.3478 10.5
+      vertex 58.4372 77.3478 0
+    endloop
+  endfacet
+  facet normal -0.323556 -0.946209 0
+    outer loop
+      vertex 63.4563 82.0268 0
+      vertex 63.8277 81.8998 10.5
+      vertex 63.4563 82.0268 10.5
+    endloop
+  endfacet
+  facet normal -0.323556 -0.946209 -0
+    outer loop
+      vertex 63.8277 81.8998 10.5
+      vertex 63.4563 82.0268 0
+      vertex 63.8277 81.8998 0
+    endloop
+  endfacet
+  facet normal 0.160514 -0.987034 0
+    outer loop
+      vertex 61.5137 82.095 0
+      vertex 61.9011 82.158 10.5
+      vertex 61.5137 82.095 10.5
+    endloop
+  endfacet
+  facet normal 0.160514 -0.987034 0
+    outer loop
+      vertex 61.9011 82.158 10.5
+      vertex 61.5137 82.095 0
+      vertex 61.9011 82.158 0
+    endloop
+  endfacet
+  facet normal 0.897865 0.44027 0
+    outer loop
+      vertex 58.8481 76.2483 10.5
+      vertex 58.6753 76.6007 0
+      vertex 58.6753 76.6007 10.5
+    endloop
+  endfacet
+  facet normal 0.897865 0.44027 0
+    outer loop
+      vertex 58.6753 76.6007 0
+      vertex 58.8481 76.2483 10.5
+      vertex 58.8481 76.2483 0
+    endloop
+  endfacet
+  facet normal 0.794741 0.606949 0
+    outer loop
+      vertex 59.2928 75.6025 10.5
+      vertex 59.0546 75.9144 0
+      vertex 59.0546 75.9144 10.5
+    endloop
+  endfacet
+  facet normal 0.794741 0.606949 0
+    outer loop
+      vertex 59.0546 75.9144 0
+      vertex 59.2928 75.6025 10.5
+      vertex 59.2928 75.6025 0
+    endloop
+  endfacet
+  facet normal 0.440169 -0.897915 0
+    outer loop
+      vertex 60.4141 81.684 0
+      vertex 60.7666 81.8568 10.5
+      vertex 60.4141 81.684 10.5
+    endloop
+  endfacet
+  facet normal 0.440169 -0.897915 0
+    outer loop
+      vertex 60.7666 81.8568 10.5
+      vertex 60.4141 81.684 0
+      vertex 60.7666 81.8568 0
+    endloop
+  endfacet
+  facet normal 0.0631712 -0.998003 0
+    outer loop
+      vertex 61.9011 82.158 0
+      vertex 62.2929 82.1828 10.5
+      vertex 61.9011 82.158 10.5
+    endloop
+  endfacet
+  facet normal 0.0631712 -0.998003 0
+    outer loop
+      vertex 62.2929 82.1828 10.5
+      vertex 61.9011 82.158 0
+      vertex 62.2929 82.1828 0
+    endloop
+  endfacet
+  facet normal 0.256775 -0.966471 0
+    outer loop
+      vertex 61.1343 81.9942 0
+      vertex 61.5137 82.095 10.5
+      vertex 61.1343 81.9942 10.5
+    endloop
+  endfacet
+  facet normal 0.256775 -0.966471 0
+    outer loop
+      vertex 61.5137 82.095 10.5
+      vertex 61.1343 81.9942 0
+      vertex 61.5137 82.095 0
+    endloop
+  endfacet
+  facet normal 0.998019 0.0629175 0
+    outer loop
+      vertex 58.3741 77.7353 10.5
+      vertex 58.3494 78.1271 0
+      vertex 58.3494 78.1271 10.5
+    endloop
+  endfacet
+  facet normal 0.998019 0.0629175 0
+    outer loop
+      vertex 58.3494 78.1271 0
+      vertex 58.3741 77.7353 10.5
+      vertex 58.3741 77.7353 0
+    endloop
+  endfacet
+  facet normal 0.350034 -0.936737 0
+    outer loop
+      vertex 60.7666 81.8568 0
+      vertex 61.1343 81.9942 10.5
+      vertex 60.7666 81.8568 10.5
+    endloop
+  endfacet
+  facet normal 0.350034 -0.936737 0
+    outer loop
+      vertex 61.1343 81.9942 10.5
+      vertex 60.7666 81.8568 0
+      vertex 61.1343 81.9942 0
+    endloop
+  endfacet
+  facet normal -0.864821 0.50208 0
+    outer loop
+      vertex 65.7057 76.0077 0
+      vertex 65.9028 76.3472 10.5
+      vertex 65.9028 76.3472 0
+    endloop
+  endfacet
+  facet normal -0.864821 0.50208 0
+    outer loop
+      vertex 65.9028 76.3472 10.5
+      vertex 65.7057 76.0077 0
+      vertex 65.7057 76.0077 10.5
+    endloop
+  endfacet
+  facet normal 0.946131 -0.323784 0
+    outer loop
+      vertex 58.5053 79.2905 10.5
+      vertex 58.6324 79.6619 0
+      vertex 58.6324 79.6619 10.5
+    endloop
+  endfacet
+  facet normal 0.946131 -0.323784 0
+    outer loop
+      vertex 58.6324 79.6619 0
+      vertex 58.5053 79.2905 10.5
+      vertex 58.5053 79.2905 0
+    endloop
+  endfacet
+  facet normal -0.794618 -0.60711 0
+    outer loop
+      vertex 65.6434 80.4519 0
+      vertex 65.4051 80.7638 10.5
+      vertex 65.4051 80.7638 0
+    endloop
+  endfacet
+  facet normal -0.794618 -0.60711 0
+    outer loop
+      vertex 65.4051 80.7638 10.5
+      vertex 65.6434 80.4519 0
+      vertex 65.6434 80.4519 10.5
+    endloop
+  endfacet
+  facet normal 0.966534 0.256537 0
+    outer loop
+      vertex 58.5379 76.9684 10.5
+      vertex 58.4372 77.3478 0
+      vertex 58.4372 77.3478 10.5
+    endloop
+  endfacet
+  facet normal 0.966534 0.256537 0
+    outer loop
+      vertex 58.4372 77.3478 0
+      vertex 58.5379 76.9684 10.5
+      vertex 58.5379 76.9684 0
+    endloop
+  endfacet
+  facet normal -0.731631 -0.681701 0
+    outer loop
+      vertex 65.4051 80.7638 0
+      vertex 65.1375 81.051 10.5
+      vertex 65.1375 81.051 0
+    endloop
+  endfacet
+  facet normal -0.731631 -0.681701 0
+    outer loop
+      vertex 65.1375 81.051 10.5
+      vertex 65.4051 80.7638 0
+      vertex 65.4051 80.7638 10.5
+    endloop
+  endfacet
+  facet normal -0.999382 0.0351465 0
+    outer loop
+      vertex 66.3348 77.8469 0
+      vertex 66.3486 78.2393 10.5
+      vertex 66.3486 78.2393 0
+    endloop
+  endfacet
+  facet normal -0.999382 0.0351465 0
+    outer loop
+      vertex 66.3486 78.2393 10.5
+      vertex 66.3348 77.8469 0
+      vertex 66.3348 77.8469 10.5
+    endloop
+  endfacet
+  facet normal 0.681964 -0.731386 0
+    outer loop
+      vertex 59.4812 80.9716 0
+      vertex 59.7683 81.2393 10.5
+      vertex 59.4812 80.9716 10.5
+    endloop
+  endfacet
+  facet normal 0.681964 -0.731386 0
+    outer loop
+      vertex 59.7683 81.2393 10.5
+      vertex 59.4812 80.9716 0
+      vertex 59.7683 81.2393 0
+    endloop
+  endfacet
+  facet normal -0.998002 -0.0631872 0
+    outer loop
+      vertex 66.3486 78.2393 0
+      vertex 66.3238 78.631 10.5
+      vertex 66.3238 78.631 0
+    endloop
+  endfacet
+  facet normal -0.998002 -0.0631872 0
+    outer loop
+      vertex 66.3238 78.631 10.5
+      vertex 66.3486 78.2393 0
+      vertex 66.3486 78.2393 10.5
+    endloop
+  endfacet
+  facet normal 0.661116 0.750284 -0
+    outer loop
+      vertex 59.855 75.0558 0
+      vertex 59.5605 75.3153 10.5
+      vertex 59.855 75.0558 10.5
+    endloop
+  endfacet
+  facet normal 0.661116 0.750284 0
+    outer loop
+      vertex 59.5605 75.3153 10.5
+      vertex 59.855 75.0558 0
+      vertex 59.5605 75.3153 0
+    endloop
+  endfacet
+  facet normal -0.0631872 0.998002 0
+    outer loop
+      vertex 62.7968 74.2083 0
+      vertex 62.4051 74.1835 10.5
+      vertex 62.7968 74.2083 10.5
+    endloop
+  endfacet
+  facet normal -0.0631872 0.998002 0
+    outer loop
+      vertex 62.4051 74.1835 10.5
+      vertex 62.7968 74.2083 0
+      vertex 62.4051 74.1835 0
+    endloop
+  endfacet
+  facet normal 0.0351554 0.999382 -0
+    outer loop
+      vertex 62.4051 74.1835 0
+      vertex 62.0128 74.1973 10.5
+      vertex 62.4051 74.1835 10.5
+    endloop
+  endfacet
+  facet normal 0.0351554 0.999382 0
+    outer loop
+      vertex 62.0128 74.1973 10.5
+      vertex 62.4051 74.1835 0
+      vertex 62.0128 74.1973 0
+    endloop
+  endfacet
+  facet normal -0.850493 -0.525986 0
+    outer loop
+      vertex 65.8499 80.118 0
+      vertex 65.6434 80.4519 10.5
+      vertex 65.6434 80.4519 0
+    endloop
+  endfacet
+  facet normal -0.850493 -0.525986 0
+    outer loop
+      vertex 65.6434 80.4519 10.5
+      vertex 65.8499 80.118 0
+      vertex 65.8499 80.118 10.5
+    endloop
+  endfacet
+  facet normal 0.731504 0.681837 0
+    outer loop
+      vertex 59.5605 75.3153 10.5
+      vertex 59.2928 75.6025 0
+      vertex 59.2928 75.6025 10.5
+    endloop
+  endfacet
+  facet normal 0.731504 0.681837 0
+    outer loop
+      vertex 59.2928 75.6025 0
+      vertex 59.5605 75.3153 10.5
+      vertex 59.5605 75.3153 0
+    endloop
+  endfacet
+  facet normal -0.350258 0.936653 0
+    outer loop
+      vertex 63.9314 74.5095 0
+      vertex 63.5637 74.372 10.5
+      vertex 63.9314 74.5095 10.5
+    endloop
+  endfacet
+  facet normal -0.350258 0.936653 0
+    outer loop
+      vertex 63.5637 74.372 10.5
+      vertex 63.9314 74.5095 0
+      vertex 63.5637 74.372 0
+    endloop
+  endfacet
+  facet normal -0.681964 0.731386 0
+    outer loop
+      vertex 65.2168 75.3947 0
+      vertex 64.9297 75.127 10.5
+      vertex 65.2168 75.3947 10.5
+    endloop
+  endfacet
+  facet normal -0.681964 0.731386 0
+    outer loop
+      vertex 64.9297 75.127 10.5
+      vertex 65.2168 75.3947 0
+      vertex 64.9297 75.127 0
+    endloop
+  endfacet
+  facet normal -0.256537 0.966534 0
+    outer loop
+      vertex 63.5637 74.372 0
+      vertex 63.1843 74.2713 10.5
+      vertex 63.5637 74.372 10.5
+    endloop
+  endfacet
+  facet normal -0.256537 0.966534 0
+    outer loop
+      vertex 63.1843 74.2713 10.5
+      vertex 63.5637 74.372 0
+      vertex 63.1843 74.2713 0
+    endloop
+  endfacet
+  facet normal 0.132965 0.991121 -0
+    outer loop
+      vertex 62.0128 74.1973 0
+      vertex 61.6237 74.2495 10.5
+      vertex 62.0128 74.1973 10.5
+    endloop
+  endfacet
+  facet normal 0.132965 0.991121 0
+    outer loop
+      vertex 61.6237 74.2495 10.5
+      vertex 62.0128 74.1973 0
+      vertex 61.6237 74.2495 0
+    endloop
+  endfacet
+  facet normal -0.222525 0.974927 0
+    outer loop
+      vertex 26.6738 116.866 0
+      vertex -74.7383 93.7189 10.5
+      vertex 26.6738 116.866 10.5
+    endloop
+  endfacet
+  facet normal -0.222525 0.974927 0
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex 26.6738 116.866 0
+      vertex -74.7383 93.7189 0
+    endloop
+  endfacet
+  facet normal 0.22252 -0.974928 0
+    outer loop
+      vertex -27.6809 34.7107 0
+      vertex 9.87918 43.2835 3.25
+      vertex -27.6809 34.7107 3.25
+    endloop
+  endfacet
+  facet normal 0.22252 -0.974928 0
+    outer loop
+      vertex 9.87918 43.2835 3.25
+      vertex -27.6809 34.7107 0
+      vertex 9.87918 43.2835 0
+    endloop
+  endfacet
+  facet normal 0.222521 -0.974928 0
+    outer loop
+      vertex -63.666 79.8346 6
+      vertex 22.7221 99.5521 10.5
+      vertex -63.666 79.8346 10.5
+    endloop
+  endfacet
+  facet normal 0.222521 -0.974928 0
+    outer loop
+      vertex 22.7221 99.5521 10.5
+      vertex -63.666 79.8346 6
+      vertex 22.7221 99.5521 6
+    endloop
+  endfacet
+  facet normal 0.222521 -0.974928 0
+    outer loop
+      vertex -56.7458 71.1569 3.25
+      vertex 20.2523 88.7312 6
+      vertex -56.7458 71.1569 6
+    endloop
+  endfacet
+  facet normal 0.222521 -0.974928 0
+    outer loop
+      vertex 20.2523 88.7312 6
+      vertex -56.7458 71.1569 3.25
+      vertex 20.2523 88.7312 3.25
+    endloop
+  endfacet
+  facet normal 0.96284 0.270074 0
+    outer loop
+      vertex -26.0458 96.2248 10.5
+      vertex -26.1518 96.6027 0
+      vertex -26.1518 96.6027 10.5
+    endloop
+  endfacet
+  facet normal 0.96284 0.270074 0
+    outer loop
+      vertex -26.1518 96.6027 0
+      vertex -26.0458 96.2248 10.5
+      vertex -26.0458 96.2248 0
+    endloop
+  endfacet
+  facet normal 0.272434 -0.962175 0
+    outer loop
+      vertex -23.5201 101.286 0
+      vertex -23.1422 101.393 10.5
+      vertex -23.5201 101.286 10.5
+    endloop
+  endfacet
+  facet normal 0.272434 -0.962175 0
+    outer loop
+      vertex -23.1422 101.393 10.5
+      vertex -23.5201 101.286 0
+      vertex -23.1422 101.393 0
+    endloop
+  endfacet
+  facet normal 0.721856 0.692044 0
+    outer loop
+      vertex -25.0001 94.5862 10.5
+      vertex -25.2717 94.8695 0
+      vertex -25.2717 94.8695 10.5
+    endloop
+  endfacet
+  facet normal 0.721856 0.692044 0
+    outer loop
+      vertex -25.2717 94.8695 0
+      vertex -25.0001 94.5862 10.5
+      vertex -25.0001 94.5862 0
+    endloop
+  endfacet
+  facet normal 0.759724 -0.650246 0
+    outer loop
+      vertex -25.4141 99.9426 10.5
+      vertex -25.1587 100.241 0
+      vertex -25.1587 100.241 10.5
+    endloop
+  endfacet
+  facet normal 0.759724 -0.650246 0
+    outer loop
+      vertex -25.1587 100.241 0
+      vertex -25.4141 99.9426 10.5
+      vertex -25.4141 99.9426 0
+    endloop
+  endfacet
+  facet normal -0.618024 0.786159 0
+    outer loop
+      vertex -19.6288 94.4731 0
+      vertex -19.9374 94.2305 10.5
+      vertex -19.6288 94.4731 10.5
+    endloop
+  endfacet
+  facet normal -0.618024 0.786159 0
+    outer loop
+      vertex -19.9374 94.2305 10.5
+      vertex -19.6288 94.4731 0
+      vertex -19.9374 94.2305 0
+    endloop
+  endfacet
+  facet normal 0.453315 -0.89135 0
+    outer loop
+      vertex -24.2359 100.966 0
+      vertex -23.8859 101.144 10.5
+      vertex -24.2359 100.966 10.5
+    endloop
+  endfacet
+  facet normal 0.453315 -0.89135 0
+    outer loop
+      vertex -23.8859 101.144 10.5
+      vertex -24.2359 100.966 0
+      vertex -23.8859 101.144 0
+    endloop
+  endfacet
+  facet normal 0.173277 -0.984873 0
+    outer loop
+      vertex -23.1422 101.393 0
+      vertex -22.7557 101.461 10.5
+      vertex -23.1422 101.393 10.5
+    endloop
+  endfacet
+  facet normal 0.173277 -0.984873 0
+    outer loop
+      vertex -22.7557 101.461 10.5
+      vertex -23.1422 101.393 0
+      vertex -22.7557 101.461 0
+    endloop
+  endfacet
+  facet normal -0.721362 -0.692558 0
+    outer loop
+      vertex -19.2324 100.116 0
+      vertex -19.5041 100.399 10.5
+      vertex -19.5041 100.399 0
+    endloop
+  endfacet
+  facet normal -0.721362 -0.692558 0
+    outer loop
+      vertex -19.5041 100.399 10.5
+      vertex -19.2324 100.116 0
+      vertex -19.2324 100.116 10.5
+    endloop
+  endfacet
+  facet normal -0.842937 -0.538012 0
+    outer loop
+      vertex -18.7787 99.4766 0
+      vertex -18.9899 99.8075 10.5
+      vertex -18.9899 99.8075 0
+    endloop
+  endfacet
+  facet normal -0.842937 -0.538012 0
+    outer loop
+      vertex -18.9899 99.8075 10.5
+      vertex -18.7787 99.4766 0
+      vertex -18.7787 99.4766 10.5
+    endloop
+  endfacet
+  facet normal -0.402448 -0.915443 0
+    outer loop
+      vertex -20.8256 101.23 0
+      vertex -20.4662 101.072 10.5
+      vertex -20.8256 101.23 10.5
+    endloop
+  endfacet
+  facet normal -0.402448 -0.915443 -0
+    outer loop
+      vertex -20.4662 101.072 10.5
+      vertex -20.8256 101.23 0
+      vertex -20.4662 101.072 0
+    endloop
+  endfacet
+  facet normal -0.489317 -0.872106 0
+    outer loop
+      vertex -20.4662 101.072 0
+      vertex -20.124 100.88 10.5
+      vertex -20.4662 101.072 10.5
+    endloop
+  endfacet
+  facet normal -0.489317 -0.872106 -0
+    outer loop
+      vertex -20.124 100.88 10.5
+      vertex -20.4662 101.072 0
+      vertex -20.124 100.88 0
+    endloop
+  endfacet
+  facet normal 0.786159 0.618024 0
+    outer loop
+      vertex -25.2717 94.8695 10.5
+      vertex -25.5143 95.1781 0
+      vertex -25.5143 95.1781 10.5
+    endloop
+  endfacet
+  facet normal 0.786159 0.618024 0
+    outer loop
+      vertex -25.5143 95.1781 0
+      vertex -25.2717 94.8695 10.5
+      vertex -25.2717 94.8695 0
+    endloop
+  endfacet
+  facet normal 0.984655 0.174512 0
+    outer loop
+      vertex -26.1518 96.6027 10.5
+      vertex -26.2203 96.9892 0
+      vertex -26.2203 96.9892 10.5
+    endloop
+  endfacet
+  facet normal 0.984655 0.174512 0
+    outer loop
+      vertex -26.2203 96.9892 0
+      vertex -26.1518 96.6027 10.5
+      vertex -26.1518 96.6027 0
+    endloop
+  endfacet
+  facet normal -0.976444 0.21577 0
+    outer loop
+      vertex -18.3933 96.4395 0
+      vertex -18.3086 96.8228 10.5
+      vertex -18.3086 96.8228 0
+    endloop
+  endfacet
+  facet normal -0.976444 0.21577 0
+    outer loop
+      vertex -18.3086 96.8228 10.5
+      vertex -18.3933 96.4395 0
+      vertex -18.3933 96.4395 10.5
+    endloop
+  endfacet
+  facet normal 0.931708 0.363208 0
+    outer loop
+      vertex -25.9032 95.859 10.5
+      vertex -26.0458 96.2248 0
+      vertex -26.0458 96.2248 10.5
+    endloop
+  endfacet
+  facet normal 0.931708 0.363208 0
+    outer loop
+      vertex -26.0458 96.2248 0
+      vertex -25.9032 95.859 10.5
+      vertex -25.9032 95.859 0
+    endloop
+  endfacet
+  facet normal 0.118984 0.992896 -0
+    outer loop
+      vertex -22.5324 93.5026 0
+      vertex -22.9221 93.5493 10.5
+      vertex -22.5324 93.5026 10.5
+    endloop
+  endfacet
+  facet normal 0.118984 0.992896 0
+    outer loop
+      vertex -22.9221 93.5493 10.5
+      vertex -22.5324 93.5026 0
+      vertex -22.9221 93.5493 0
+    endloop
+  endfacet
+  facet normal -0.87178 0.489898 0
+    outer loop
+      vertex -18.8652 95.3647 0
+      vertex -18.6729 95.7069 10.5
+      vertex -18.6729 95.7069 0
+    endloop
+  endfacet
+  facet normal -0.87178 0.489898 0
+    outer loop
+      vertex -18.6729 95.7069 10.5
+      vertex -18.8652 95.3647 0
+      vertex -18.8652 95.3647 10.5
+    endloop
+  endfacet
+  facet normal -0.96284 -0.270074 0
+    outer loop
+      vertex -18.3524 98.3829 0
+      vertex -18.4584 98.7608 10.5
+      vertex -18.4584 98.7608 0
+    endloop
+  endfacet
+  facet normal -0.96284 -0.270074 0
+    outer loop
+      vertex -18.4584 98.7608 10.5
+      vertex -18.3524 98.3829 0
+      vertex -18.3524 98.3829 10.5
+    endloop
+  endfacet
+  facet normal 0.691246 -0.72262 0
+    outer loop
+      vertex -25.1587 100.241 0
+      vertex -24.8754 100.512 10.5
+      vertex -25.1587 100.241 10.5
+    endloop
+  endfacet
+  facet normal 0.691246 -0.72262 0
+    outer loop
+      vertex -24.8754 100.512 10.5
+      vertex -25.1587 100.241 0
+      vertex -24.8754 100.512 0
+    endloop
+  endfacet
+  facet normal -0.452708 0.891659 0
+    outer loop
+      vertex -20.2683 94.0194 0
+      vertex -20.6183 93.8417 10.5
+      vertex -20.2683 94.0194 10.5
+    endloop
+  endfacet
+  facet normal -0.452708 0.891659 0
+    outer loop
+      vertex -20.6183 93.8417 10.5
+      vertex -20.2683 94.0194 0
+      vertex -20.6183 93.8417 0
+    endloop
+  endfacet
+  facet normal -0.270074 0.96284 0
+    outer loop
+      vertex -20.9841 93.6991 0
+      vertex -21.362 93.5931 10.5
+      vertex -20.9841 93.6991 10.5
+    endloop
+  endfacet
+  facet normal -0.270074 0.96284 0
+    outer loop
+      vertex -21.362 93.5931 10.5
+      vertex -20.9841 93.6991 0
+      vertex -21.362 93.5931 0
+    endloop
+  endfacet
+  facet normal -0.537831 0.843052 0
+    outer loop
+      vertex -19.9374 94.2305 0
+      vertex -20.2683 94.0194 10.5
+      vertex -19.9374 94.2305 10.5
+    endloop
+  endfacet
+  facet normal -0.537831 0.843052 0
+    outer loop
+      vertex -20.2683 94.0194 10.5
+      vertex -19.9374 94.2305 0
+      vertex -20.2683 94.0194 0
+    endloop
+  endfacet
+  facet normal 0.36188 -0.932225 0
+    outer loop
+      vertex -23.8859 101.144 0
+      vertex -23.5201 101.286 10.5
+      vertex -23.8859 101.144 10.5
+    endloop
+  endfacet
+  facet normal 0.36188 -0.932225 0
+    outer loop
+      vertex -23.5201 101.286 10.5
+      vertex -23.8859 101.144 0
+      vertex -23.5201 101.286 0
+    endloop
+  endfacet
+  facet normal -0.992896 0.118984 0
+    outer loop
+      vertex -18.3086 96.8228 0
+      vertex -18.2619 97.2125 10.5
+      vertex -18.2619 97.2125 0
+    endloop
+  endfacet
+  facet normal -0.992896 0.118984 0
+    outer loop
+      vertex -18.2619 97.2125 10.5
+      vertex -18.3086 96.8228 0
+      vertex -18.3086 96.8228 10.5
+    endloop
+  endfacet
+  facet normal -0.891659 -0.452708 0
+    outer loop
+      vertex -18.601 99.1266 0
+      vertex -18.7787 99.4766 10.5
+      vertex -18.7787 99.4766 0
+    endloop
+  endfacet
+  facet normal -0.891659 -0.452708 0
+    outer loop
+      vertex -18.7787 99.4766 10.5
+      vertex -18.601 99.1266 0
+      vertex -18.601 99.1266 10.5
+    endloop
+  endfacet
+  facet normal 0.618653 -0.785664 0
+    outer loop
+      vertex -24.8754 100.512 0
+      vertex -24.5668 100.755 10.5
+      vertex -24.8754 100.512 10.5
+    endloop
+  endfacet
+  facet normal 0.618653 -0.785664 0
+    outer loop
+      vertex -24.5668 100.755 10.5
+      vertex -24.8754 100.512 0
+      vertex -24.5668 100.755 0
+    endloop
+  endfacet
+  facet normal 0.992896 -0.118984 0
+    outer loop
+      vertex -26.2423 97.7731 10.5
+      vertex -26.1956 98.1628 0
+      vertex -26.1956 98.1628 10.5
+    endloop
+  endfacet
+  facet normal 0.992896 -0.118984 0
+    outer loop
+      vertex -26.1956 98.1628 0
+      vertex -26.2423 97.7731 10.5
+      vertex -26.2423 97.7731 0
+    endloop
+  endfacet
+  facet normal -0.363208 0.931708 0
+    outer loop
+      vertex -20.6183 93.8417 0
+      vertex -20.9841 93.6991 10.5
+      vertex -20.6183 93.8417 10.5
+    endloop
+  endfacet
+  facet normal -0.363208 0.931708 0
+    outer loop
+      vertex -20.9841 93.6991 10.5
+      vertex -20.6183 93.8417 0
+      vertex -20.9841 93.6991 0
+    endloop
+  endfacet
+  facet normal -0.214069 -0.976818 0
+    outer loop
+      vertex -21.5821 101.436 0
+      vertex -21.1988 101.352 10.5
+      vertex -21.5821 101.436 10.5
+    endloop
+  endfacet
+  facet normal -0.214069 -0.976818 -0
+    outer loop
+      vertex -21.1988 101.352 10.5
+      vertex -21.5821 101.436 0
+      vertex -21.1988 101.352 0
+    endloop
+  endfacet
+  facet normal -0.984655 -0.174512 0
+    outer loop
+      vertex -18.2839 97.9964 0
+      vertex -18.3524 98.3829 10.5
+      vertex -18.3524 98.3829 0
+    endloop
+  endfacet
+  facet normal -0.984655 -0.174512 0
+    outer loop
+      vertex -18.3524 98.3829 10.5
+      vertex -18.2839 97.9964 0
+      vertex -18.2839 97.9964 10.5
+    endloop
+  endfacet
+  facet normal -0.310721 -0.950501 0
+    outer loop
+      vertex -21.1988 101.352 0
+      vertex -20.8256 101.23 10.5
+      vertex -21.1988 101.352 10.5
+    endloop
+  endfacet
+  facet normal -0.310721 -0.950501 -0
+    outer loop
+      vertex -20.8256 101.23 10.5
+      vertex -21.1988 101.352 0
+      vertex -20.8256 101.23 0
+    endloop
+  endfacet
+  facet normal -0.999782 0.0208872 0
+    outer loop
+      vertex -18.2619 97.2125 0
+      vertex -18.2537 97.605 10.5
+      vertex -18.2537 97.605 0
+    endloop
+  endfacet
+  facet normal -0.999782 0.0208872 0
+    outer loop
+      vertex -18.2537 97.605 10.5
+      vertex -18.2619 97.2125 0
+      vertex -18.2619 97.2125 10.5
+    endloop
+  endfacet
+  facet normal 0.310261 0.950651 -0
+    outer loop
+      vertex -23.3054 93.634 0
+      vertex -23.6786 93.7558 10.5
+      vertex -23.3054 93.634 10.5
+    endloop
+  endfacet
+  facet normal 0.310261 0.950651 0
+    outer loop
+      vertex -23.6786 93.7558 10.5
+      vertex -23.3054 93.634 0
+      vertex -23.6786 93.7558 0
+    endloop
+  endfacet
+  facet normal 0.999782 -0.0208872 0
+    outer loop
+      vertex -26.2505 97.3806 10.5
+      vertex -26.2423 97.7731 0
+      vertex -26.2423 97.7731 10.5
+    endloop
+  endfacet
+  facet normal 0.999782 -0.0208872 0
+    outer loop
+      vertex -26.2423 97.7731 0
+      vertex -26.2505 97.3806 10.5
+      vertex -26.2505 97.3806 0
+    endloop
+  endfacet
+  facet normal 0.891659 0.452708 0
+    outer loop
+      vertex -25.7255 95.509 10.5
+      vertex -25.9032 95.859 0
+      vertex -25.9032 95.859 10.5
+    endloop
+  endfacet
+  facet normal 0.891659 0.452708 0
+    outer loop
+      vertex -25.9032 95.859 0
+      vertex -25.7255 95.509 10.5
+      vertex -25.7255 95.509 0
+    endloop
+  endfacet
+  facet normal 0.650498 0.759508 -0
+    outer loop
+      vertex -24.7019 94.3308 0
+      vertex -25.0001 94.5862 10.5
+      vertex -24.7019 94.3308 10.5
+    endloop
+  endfacet
+  facet normal 0.650498 0.759508 0
+    outer loop
+      vertex -25.0001 94.5862 10.5
+      vertex -24.7019 94.3308 0
+      vertex -25.0001 94.5862 0
+    endloop
+  endfacet
+  facet normal -0.786186 -0.61799 0
+    outer loop
+      vertex -18.9899 99.8075 0
+      vertex -19.2324 100.116 10.5
+      vertex -19.2324 100.116 0
+    endloop
+  endfacet
+  facet normal -0.786186 -0.61799 0
+    outer loop
+      vertex -19.2324 100.116 10.5
+      vertex -18.9899 99.8075 0
+      vertex -18.9899 99.8075 10.5
+    endloop
+  endfacet
+  facet normal 0.489898 0.87178 -0
+    outer loop
+      vertex -24.038 93.9136 0
+      vertex -24.3802 94.1059 10.5
+      vertex -24.038 93.9136 10.5
+    endloop
+  endfacet
+  facet normal 0.489898 0.87178 0
+    outer loop
+      vertex -24.3802 94.1059 10.5
+      vertex -24.038 93.9136 0
+      vertex -24.3802 94.1059 0
+    endloop
+  endfacet
+  facet normal 0.53765 -0.843168 0
+    outer loop
+      vertex -24.5668 100.755 0
+      vertex -24.2359 100.966 10.5
+      vertex -24.5668 100.755 10.5
+    endloop
+  endfacet
+  facet normal 0.53765 -0.843168 0
+    outer loop
+      vertex -24.2359 100.966 10.5
+      vertex -24.5668 100.755 0
+      vertex -24.2359 100.966 0
+    endloop
+  endfacet
+  facet normal 0.87178 -0.489898 0
+    outer loop
+      vertex -25.8313 99.2787 10.5
+      vertex -25.639 99.6209 0
+      vertex -25.639 99.6209 10.5
+    endloop
+  endfacet
+  facet normal 0.87178 -0.489898 0
+    outer loop
+      vertex -25.639 99.6209 0
+      vertex -25.8313 99.2787 10.5
+      vertex -25.8313 99.2787 0
+    endloop
+  endfacet
+  facet normal 0.21577 0.976444 -0
+    outer loop
+      vertex -22.9221 93.5493 0
+      vertex -23.3054 93.634 10.5
+      vertex -22.9221 93.5493 10.5
+    endloop
+  endfacet
+  facet normal 0.21577 0.976444 0
+    outer loop
+      vertex -23.3054 93.634 10.5
+      vertex -22.9221 93.5493 0
+      vertex -23.3054 93.634 0
+    endloop
+  endfacet
+  facet normal 0.0208872 0.999782 -0
+    outer loop
+      vertex -22.1399 93.4944 0
+      vertex -22.5324 93.5026 10.5
+      vertex -22.1399 93.4944 10.5
+    endloop
+  endfacet
+  facet normal 0.0208872 0.999782 0
+    outer loop
+      vertex -22.5324 93.5026 10.5
+      vertex -22.1399 93.4944 0
+      vertex -22.5324 93.5026 0
+    endloop
+  endfacet
+  facet normal 0.976444 -0.21577 0
+    outer loop
+      vertex -26.1956 98.1628 10.5
+      vertex -26.1109 98.5461 0
+      vertex -26.1109 98.5461 10.5
+    endloop
+  endfacet
+  facet normal 0.976444 -0.21577 0
+    outer loop
+      vertex -26.1109 98.5461 0
+      vertex -26.1956 98.1628 10.5
+      vertex -26.1956 98.1628 0
+    endloop
+  endfacet
+  facet normal 0.819579 -0.572966 0
+    outer loop
+      vertex -25.639 99.6209 10.5
+      vertex -25.4141 99.9426 0
+      vertex -25.4141 99.9426 10.5
+    endloop
+  endfacet
+  facet normal 0.819579 -0.572966 0
+    outer loop
+      vertex -25.4141 99.9426 0
+      vertex -25.639 99.6209 10.5
+      vertex -25.639 99.6209 0
+    endloop
+  endfacet
+  facet normal 0.91563 -0.402021 0
+    outer loop
+      vertex -25.9891 98.9193 10.5
+      vertex -25.8313 99.2787 0
+      vertex -25.8313 99.2787 10.5
+    endloop
+  endfacet
+  facet normal 0.91563 -0.402021 0
+    outer loop
+      vertex -25.8313 99.2787 0
+      vertex -25.9891 98.9193 10.5
+      vertex -25.9891 98.9193 0
+    endloop
+  endfacet
+  facet normal 0.572966 0.819579 -0
+    outer loop
+      vertex -24.3802 94.1059 0
+      vertex -24.7019 94.3308 10.5
+      vertex -24.3802 94.1059 10.5
+    endloop
+  endfacet
+  facet normal 0.572966 0.819579 0
+    outer loop
+      vertex -24.7019 94.3308 10.5
+      vertex -24.3802 94.1059 0
+      vertex -24.7019 94.3308 0
+    endloop
+  endfacet
+  facet normal 0.950651 -0.310261 0
+    outer loop
+      vertex -26.1109 98.5461 10.5
+      vertex -25.9891 98.9193 0
+      vertex -25.9891 98.9193 10.5
+    endloop
+  endfacet
+  facet normal 0.950651 -0.310261 0
+    outer loop
+      vertex -25.9891 98.9193 0
+      vertex -26.1109 98.5461 10.5
+      vertex -26.1109 98.5461 0
+    endloop
+  endfacet
+  facet normal -0.931708 -0.363208 0
+    outer loop
+      vertex -18.4584 98.7608 0
+      vertex -18.601 99.1266 10.5
+      vertex -18.601 99.1266 0
+    endloop
+  endfacet
+  facet normal -0.931708 -0.363208 0
+    outer loop
+      vertex -18.601 99.1266 10.5
+      vertex -18.4584 98.7608 0
+      vertex -18.4584 98.7608 10.5
+    endloop
+  endfacet
+  facet normal 0.842937 0.538012 0
+    outer loop
+      vertex -25.5143 95.1781 10.5
+      vertex -25.7255 95.509 0
+      vertex -25.7255 95.509 10.5
+    endloop
+  endfacet
+  facet normal 0.842937 0.538012 0
+    outer loop
+      vertex -25.7255 95.509 0
+      vertex -25.5143 95.1781 10.5
+      vertex -25.5143 95.1781 0
+    endloop
+  endfacet
+  facet normal -0.0203779 -0.999792 0
+    outer loop
+      vertex -22.3643 101.491 0
+      vertex -21.9718 101.483 10.5
+      vertex -22.3643 101.491 10.5
+    endloop
+  endfacet
+  facet normal -0.0203779 -0.999792 -0
+    outer loop
+      vertex -21.9718 101.483 10.5
+      vertex -22.3643 101.491 0
+      vertex -21.9718 101.483 0
+    endloop
+  endfacet
+  facet normal 0.402021 0.91563 -0
+    outer loop
+      vertex -23.6786 93.7558 0
+      vertex -24.038 93.9136 10.5
+      vertex -23.6786 93.7558 10.5
+    endloop
+  endfacet
+  facet normal 0.402021 0.91563 0
+    outer loop
+      vertex -24.038 93.9136 10.5
+      vertex -23.6786 93.7558 0
+      vertex -24.038 93.9136 0
+    endloop
+  endfacet
+  facet normal 0.0764238 -0.997075 0
+    outer loop
+      vertex -22.7557 101.461 0
+      vertex -22.3643 101.491 10.5
+      vertex -22.7557 101.461 10.5
+    endloop
+  endfacet
+  facet normal 0.0764238 -0.997075 0
+    outer loop
+      vertex -22.3643 101.491 10.5
+      vertex -22.7557 101.461 0
+      vertex -22.3643 101.491 0
+    endloop
+  endfacet
+  facet normal -0.651504 -0.758645 0
+    outer loop
+      vertex -19.8022 100.655 0
+      vertex -19.5041 100.399 10.5
+      vertex -19.8022 100.655 10.5
+    endloop
+  endfacet
+  facet normal -0.651504 -0.758645 -0
+    outer loop
+      vertex -19.5041 100.399 10.5
+      vertex -19.8022 100.655 0
+      vertex -19.5041 100.399 0
+    endloop
+  endfacet
+  facet normal 0.997036 0.0769303 0
+    outer loop
+      vertex -26.2203 96.9892 10.5
+      vertex -26.2505 97.3806 0
+      vertex -26.2505 97.3806 10.5
+    endloop
+  endfacet
+  facet normal 0.997036 0.0769303 0
+    outer loop
+      vertex -26.2505 97.3806 0
+      vertex -26.2203 96.9892 10.5
+      vertex -26.2203 96.9892 0
+    endloop
+  endfacet
+  facet normal -0.573018 -0.819543 0
+    outer loop
+      vertex -20.124 100.88 0
+      vertex -19.8022 100.655 10.5
+      vertex -20.124 100.88 10.5
+    endloop
+  endfacet
+  facet normal -0.573018 -0.819543 -0
+    outer loop
+      vertex -19.8022 100.655 10.5
+      vertex -20.124 100.88 0
+      vertex -19.8022 100.655 0
+    endloop
+  endfacet
+  facet normal -0.174512 0.984655 0
+    outer loop
+      vertex -21.362 93.5931 0
+      vertex -21.7485 93.5246 10.5
+      vertex -21.362 93.5931 10.5
+    endloop
+  endfacet
+  facet normal -0.174512 0.984655 0
+    outer loop
+      vertex -21.7485 93.5246 10.5
+      vertex -21.362 93.5931 0
+      vertex -21.7485 93.5246 0
+    endloop
+  endfacet
+  facet normal -0.819662 0.572847 0
+    outer loop
+      vertex -19.0901 95.0429 0
+      vertex -18.8652 95.3647 10.5
+      vertex -18.8652 95.3647 0
+    endloop
+  endfacet
+  facet normal -0.819662 0.572847 0
+    outer loop
+      vertex -18.8652 95.3647 10.5
+      vertex -19.0901 95.0429 0
+      vertex -19.0901 95.0429 10.5
+    endloop
+  endfacet
+  facet normal -0.7594 0.650624 0
+    outer loop
+      vertex -19.3455 94.7448 0
+      vertex -19.0901 95.0429 10.5
+      vertex -19.0901 95.0429 0
+    endloop
+  endfacet
+  facet normal -0.7594 0.650624 0
+    outer loop
+      vertex -19.0901 95.0429 10.5
+      vertex -19.3455 94.7448 0
+      vertex -19.3455 94.7448 10.5
+    endloop
+  endfacet
+  facet normal -0.119738 -0.992806 0
+    outer loop
+      vertex -21.9718 101.483 0
+      vertex -21.5821 101.436 10.5
+      vertex -21.9718 101.483 10.5
+    endloop
+  endfacet
+  facet normal -0.119738 -0.992806 -0
+    outer loop
+      vertex -21.5821 101.436 10.5
+      vertex -21.9718 101.483 0
+      vertex -21.5821 101.436 0
+    endloop
+  endfacet
+  facet normal -0.0769303 0.997036 0
+    outer loop
+      vertex -21.7485 93.5246 0
+      vertex -22.1399 93.4944 10.5
+      vertex -21.7485 93.5246 10.5
+    endloop
+  endfacet
+  facet normal -0.0769303 0.997036 0
+    outer loop
+      vertex -22.1399 93.4944 10.5
+      vertex -21.7485 93.5246 0
+      vertex -22.1399 93.4944 0
+    endloop
+  endfacet
+  facet normal -0.950651 0.310261 0
+    outer loop
+      vertex -18.5151 96.0663 0
+      vertex -18.3933 96.4395 10.5
+      vertex -18.3933 96.4395 0
+    endloop
+  endfacet
+  facet normal -0.950651 0.310261 0
+    outer loop
+      vertex -18.3933 96.4395 10.5
+      vertex -18.5151 96.0663 0
+      vertex -18.5151 96.0663 10.5
+    endloop
+  endfacet
+  facet normal -0.997036 -0.0769303 0
+    outer loop
+      vertex -18.2537 97.605 0
+      vertex -18.2839 97.9964 10.5
+      vertex -18.2839 97.9964 0
+    endloop
+  endfacet
+  facet normal -0.997036 -0.0769303 0
+    outer loop
+      vertex -18.2839 97.9964 10.5
+      vertex -18.2537 97.605 0
+      vertex -18.2537 97.605 10.5
+    endloop
+  endfacet
+  facet normal -0.91563 0.402021 0
+    outer loop
+      vertex -18.6729 95.7069 0
+      vertex -18.5151 96.0663 10.5
+      vertex -18.5151 96.0663 0
+    endloop
+  endfacet
+  facet normal -0.91563 0.402021 0
+    outer loop
+      vertex -18.5151 96.0663 10.5
+      vertex -18.6729 95.7069 0
+      vertex -18.6729 95.7069 10.5
+    endloop
+  endfacet
+  facet normal -0.692176 0.721728 0
+    outer loop
+      vertex -19.3455 94.7448 0
+      vertex -19.6288 94.4731 10.5
+      vertex -19.3455 94.7448 10.5
+    endloop
+  endfacet
+  facet normal -0.692176 0.721728 0
+    outer loop
+      vertex -19.6288 94.4731 10.5
+      vertex -19.3455 94.7448 0
+      vertex -19.6288 94.4731 0
+    endloop
+  endfacet
+  facet normal -0.900969 0.433884 0
+    outer loop
+      vertex -119.871 3.85793e-07 0
+      vertex -74.7383 93.7189 10.5
+      vertex -74.7383 93.7189 0
+    endloop
+  endfacet
+  facet normal -0.900969 0.433884 0
+    outer loop
+      vertex -74.7383 93.7189 10.5
+      vertex -119.871 3.85793e-07 0
+      vertex -119.871 3.85793e-07 10.5
+    endloop
+  endfacet
+  facet normal 0.900969 -0.433884 0
+    outer loop
+      vertex -44.3967 0 3.25
+      vertex -27.6809 34.7107 0
+      vertex -27.6809 34.7107 3.25
+    endloop
+  endfacet
+  facet normal 0.900969 -0.433884 0
+    outer loop
+      vertex -27.6809 34.7107 0
+      vertex -44.3967 0 3.25
+      vertex -44.3967 0 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -119.871 0 0
+      vertex -119.871 3.85793e-07 10.5
+      vertex -119.871 3.85793e-07 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -119.871 3.85793e-07 10.5
+      vertex -119.871 0 0
+      vertex -119.871 0 10.5
+    endloop
+  endfacet
+  facet normal 0.90097 -0.433881 0
+    outer loop
+      vertex -102.112 0 10.5
+      vertex -63.666 79.8346 6
+      vertex -63.666 79.8346 10.5
+    endloop
+  endfacet
+  facet normal 0.90097 -0.433881 0
+    outer loop
+      vertex -63.666 79.8346 6
+      vertex -102.112 0 10.5
+      vertex -102.112 0 6
+    endloop
+  endfacet
+  facet normal 0.900969 -0.433883 0
+    outer loop
+      vertex -91.0131 0 6
+      vertex -56.7458 71.1569 3.25
+      vertex -56.7458 71.1569 6
+    endloop
+  endfacet
+  facet normal 0.900969 -0.433883 0
+    outer loop
+      vertex -56.7458 71.1569 3.25
+      vertex -91.0131 0 6
+      vertex -91.0131 0 3.25
+    endloop
+  endfacet
+  facet normal 0.389241 0.921136 -0
+    outer loop
+      vertex -91.4708 39.6317 0
+      vertex -91.8324 39.7845 10.5
+      vertex -91.4708 39.6317 10.5
+    endloop
+  endfacet
+  facet normal 0.389241 0.921136 0
+    outer loop
+      vertex -91.8324 39.7845 10.5
+      vertex -91.4708 39.6317 0
+      vertex -91.8324 39.7845 0
+    endloop
+  endfacet
+  facet normal 0.921227 -0.389025 0
+    outer loop
+      vertex -93.8535 44.7623 10.5
+      vertex -93.7008 45.1239 0
+      vertex -93.7008 45.1239 10.5
+    endloop
+  endfacet
+  facet normal 0.921227 -0.389025 0
+    outer loop
+      vertex -93.7008 45.1239 0
+      vertex -93.8535 44.7623 10.5
+      vertex -93.8535 44.7623 0
+    endloop
+  endfacet
+  facet normal -0.0912018 0.995832 0
+    outer loop
+      vertex -89.5377 39.4277 0
+      vertex -89.9286 39.3919 10.5
+      vertex -89.5377 39.4277 10.5
+    endloop
+  endfacet
+  facet normal -0.0912018 0.995832 0
+    outer loop
+      vertex -89.9286 39.3919 10.5
+      vertex -89.5377 39.4277 0
+      vertex -89.9286 39.3919 0
+    endloop
+  endfacet
+  facet normal 0.982117 0.188271 0
+    outer loop
+      vertex -93.9837 42.4437 10.5
+      vertex -94.0576 42.8292 0
+      vertex -94.0576 42.8292 10.5
+    endloop
+  endfacet
+  facet normal 0.982117 0.188271 0
+    outer loop
+      vertex -94.0576 42.8292 0
+      vertex -93.9837 42.4437 10.5
+      vertex -93.9837 42.4437 0
+    endloop
+  endfacet
+  facet normal -0.999975 0.00713358 0
+    outer loop
+      vertex -86.1032 43.1641 0
+      vertex -86.1004 43.5566 10.5
+      vertex -86.1004 43.5566 0
+    endloop
+  endfacet
+  facet normal -0.999975 0.00713358 0
+    outer loop
+      vertex -86.1004 43.5566 10.5
+      vertex -86.1032 43.1641 0
+      vertex -86.1032 43.1641 10.5
+    endloop
+  endfacet
+  facet normal 0.979387 -0.201991 0
+    outer loop
+      vertex -94.0494 44.003 10.5
+      vertex -93.9701 44.3875 0
+      vertex -93.9701 44.3875 10.5
+    endloop
+  endfacet
+  facet normal 0.979387 -0.201991 0
+    outer loop
+      vertex -93.9701 44.3875 0
+      vertex -94.0494 44.003 10.5
+      vertex -94.0494 44.003 0
+    endloop
+  endfacet
+  facet normal 0.878566 -0.47762 0
+    outer loop
+      vertex -93.7008 45.1239 10.5
+      vertex -93.5133 45.4688 0
+      vertex -93.5133 45.4688 10.5
+    endloop
+  endfacet
+  facet normal 0.878566 -0.47762 0
+    outer loop
+      vertex -93.5133 45.4688 0
+      vertex -93.7008 45.1239 10.5
+      vertex -93.7008 45.1239 0
+    endloop
+  endfacet
+  facet normal 0.0909261 -0.995858 0
+    outer loop
+      vertex -90.6561 47.3491 0
+      vertex -90.2651 47.3848 10.5
+      vertex -90.6561 47.3491 10.5
+    endloop
+  endfacet
+  facet normal 0.0909261 -0.995858 0
+    outer loop
+      vertex -90.2651 47.3848 10.5
+      vertex -90.6561 47.3491 0
+      vertex -90.2651 47.3848 0
+    endloop
+  endfacet
+  facet normal -0.10495 -0.994478 0
+    outer loop
+      vertex -89.8726 47.3821 0
+      vertex -89.4822 47.3409 10.5
+      vertex -89.8726 47.3821 10.5
+    endloop
+  endfacet
+  facet normal -0.10495 -0.994478 -0
+    outer loop
+      vertex -89.4822 47.3409 10.5
+      vertex -89.8726 47.3821 0
+      vertex -89.4822 47.3409 0
+    endloop
+  endfacet
+  facet normal 0.465158 -0.885227 0
+    outer loop
+      vertex -92.1292 46.8336 0
+      vertex -91.7817 47.0162 10.5
+      vertex -92.1292 46.8336 10.5
+    endloop
+  endfacet
+  facet normal 0.465158 -0.885227 0
+    outer loop
+      vertex -91.7817 47.0162 10.5
+      vertex -92.1292 46.8336 0
+      vertex -91.7817 47.0162 0
+    endloop
+  endfacet
+  facet normal 0.376261 -0.926514 0
+    outer loop
+      vertex -91.7817 47.0162 0
+      vertex -91.418 47.1639 10.5
+      vertex -91.7817 47.0162 10.5
+    endloop
+  endfacet
+  facet normal 0.376261 -0.926514 0
+    outer loop
+      vertex -91.418 47.1639 10.5
+      vertex -91.7817 47.0162 0
+      vertex -91.418 47.1639 0
+    endloop
+  endfacet
+  facet normal 0.00713176 0.999975 -0
+    outer loop
+      vertex -89.9286 39.3919 0
+      vertex -90.3212 39.3947 10.5
+      vertex -89.9286 39.3919 10.5
+    endloop
+  endfacet
+  facet normal 0.00713176 0.999975 0
+    outer loop
+      vertex -90.3212 39.3947 10.5
+      vertex -89.9286 39.3919 0
+      vertex -90.3212 39.3947 0
+    endloop
+  endfacet
+  facet normal 0.47762 0.878566 -0
+    outer loop
+      vertex -91.8324 39.7845 0
+      vertex -92.1773 39.972 10.5
+      vertex -91.8324 39.7845 10.5
+    endloop
+  endfacet
+  facet normal 0.47762 0.878566 0
+    outer loop
+      vertex -92.1773 39.972 10.5
+      vertex -91.8324 39.7845 0
+      vertex -92.1773 39.972 0
+    endloop
+  endfacet
+  facet normal -0.777452 -0.628942 0
+    outer loop
+      vertex -86.8674 45.7486 0
+      vertex -87.1143 46.0538 10.5
+      vertex -87.1143 46.0538 0
+    endloop
+  endfacet
+  facet normal -0.777452 -0.628942 0
+    outer loop
+      vertex -87.1143 46.0538 10.5
+      vertex -86.8674 45.7486 0
+      vertex -86.8674 45.7486 10.5
+    endloop
+  endfacet
+  facet normal 0.296824 0.954932 -0
+    outer loop
+      vertex -91.096 39.5152 0
+      vertex -91.4708 39.6317 10.5
+      vertex -91.096 39.5152 10.5
+    endloop
+  endfacet
+  facet normal 0.296824 0.954932 0
+    outer loop
+      vertex -91.4708 39.6317 10.5
+      vertex -91.096 39.5152 0
+      vertex -91.4708 39.6317 0
+    endloop
+  endfacet
+  facet normal -0.702121 0.712057 0
+    outer loop
+      vertex -87.152 40.6814 0
+      vertex -87.4315 40.4058 10.5
+      vertex -87.152 40.6814 10.5
+    endloop
+  endfacet
+  facet normal -0.702121 0.712057 0
+    outer loop
+      vertex -87.4315 40.4058 10.5
+      vertex -87.152 40.6814 0
+      vertex -87.4315 40.4058 0
+    endloop
+  endfacet
+  facet normal -0.926603 -0.376042 0
+    outer loop
+      vertex -86.3214 44.7095 0
+      vertex -86.469 45.0732 10.5
+      vertex -86.469 45.0732 0
+    endloop
+  endfacet
+  facet normal -0.926603 -0.376042 0
+    outer loop
+      vertex -86.469 45.0732 10.5
+      vertex -86.3214 44.7095 0
+      vertex -86.3214 44.7095 10.5
+    endloop
+  endfacet
+  facet normal -0.389241 -0.921136 0
+    outer loop
+      vertex -88.723 47.145 0
+      vertex -88.3614 46.9922 10.5
+      vertex -88.723 47.145 10.5
+    endloop
+  endfacet
+  facet normal -0.389241 -0.921136 -0
+    outer loop
+      vertex -88.3614 46.9922 10.5
+      vertex -88.723 47.145 0
+      vertex -88.3614 46.9922 0
+    endloop
+  endfacet
+  facet normal 0.995856 0.0909492 0
+    outer loop
+      vertex -94.0576 42.8292 10.5
+      vertex -94.0933 43.2201 0
+      vertex -94.0933 43.2201 10.5
+    endloop
+  endfacet
+  facet normal 0.995856 0.0909492 0
+    outer loop
+      vertex -94.0933 43.2201 0
+      vertex -94.0576 42.8292 10.5
+      vertex -94.0576 42.8292 0
+    endloop
+  endfacet
+  facet normal -0.979377 0.202041 0
+    outer loop
+      vertex -86.2237 42.3893 0
+      vertex -86.1444 42.7737 10.5
+      vertex -86.1444 42.7737 0
+    endloop
+  endfacet
+  facet normal -0.979377 0.202041 0
+    outer loop
+      vertex -86.1444 42.7737 10.5
+      vertex -86.2237 42.3893 0
+      vertex -86.2237 42.3893 10.5
+    endloop
+  endfacet
+  facet normal -0.921227 0.389025 0
+    outer loop
+      vertex -86.493 41.6528 0
+      vertex -86.3403 42.0144 10.5
+      vertex -86.3403 42.0144 0
+    endloop
+  endfacet
+  facet normal -0.921227 0.389025 0
+    outer loop
+      vertex -86.3403 42.0144 10.5
+      vertex -86.493 41.6528 0
+      vertex -86.493 41.6528 10.5
+    endloop
+  endfacet
+  facet normal -0.994478 0.10495 0
+    outer loop
+      vertex -86.1444 42.7737 0
+      vertex -86.1032 43.1641 10.5
+      vertex -86.1032 43.1641 0
+    endloop
+  endfacet
+  facet normal -0.994478 0.10495 0
+    outer loop
+      vertex -86.1032 43.1641 10.5
+      vertex -86.1444 42.7737 0
+      vertex -86.1444 42.7737 10.5
+    endloop
+  endfacet
+  facet normal 0.95486 -0.297056 0
+    outer loop
+      vertex -93.9701 44.3875 10.5
+      vertex -93.8535 44.7623 0
+      vertex -93.8535 44.7623 10.5
+    endloop
+  endfacet
+  facet normal 0.95486 -0.297056 0
+    outer loop
+      vertex -93.8535 44.7623 0
+      vertex -93.9701 44.3875 10.5
+      vertex -93.9701 44.3875 0
+    endloop
+  endfacet
+  facet normal -0.712057 -0.702121 0
+    outer loop
+      vertex -87.1143 46.0538 0
+      vertex -87.3899 46.3333 10.5
+      vertex -87.3899 46.3333 0
+    endloop
+  endfacet
+  facet normal -0.712057 -0.702121 0
+    outer loop
+      vertex -87.3899 46.3333 10.5
+      vertex -87.1143 46.0538 0
+      vertex -87.1143 46.0538 10.5
+    endloop
+  endfacet
+  facet normal -0.202041 -0.979377 0
+    outer loop
+      vertex -89.4822 47.3409 0
+      vertex -89.0978 47.2616 10.5
+      vertex -89.4822 47.3409 10.5
+    endloop
+  endfacet
+  facet normal -0.202041 -0.979377 -0
+    outer loop
+      vertex -89.0978 47.2616 10.5
+      vertex -89.4822 47.3409 0
+      vertex -89.0978 47.2616 0
+    endloop
+  endfacet
+  facet normal 0.999976 -0.00687707 0
+    outer loop
+      vertex -94.0933 43.2201 10.5
+      vertex -94.0906 43.6127 0
+      vertex -94.0906 43.6127 10.5
+    endloop
+  endfacet
+  facet normal 0.999976 -0.00687707 0
+    outer loop
+      vertex -94.0906 43.6127 0
+      vertex -94.0933 43.2201 10.5
+      vertex -94.0933 43.2201 0
+    endloop
+  endfacet
+  facet normal 0.71193 0.702251 0
+    outer loop
+      vertex -92.8038 40.4435 10.5
+      vertex -93.0795 40.723 0
+      vertex -93.0795 40.723 10.5
+    endloop
+  endfacet
+  facet normal 0.71193 0.702251 0
+    outer loop
+      vertex -93.0795 40.723 0
+      vertex -92.8038 40.4435 10.5
+      vertex -92.8038 40.4435 0
+    endloop
+  endfacet
+  facet normal -0.954882 0.296984 0
+    outer loop
+      vertex -86.3403 42.0144 0
+      vertex -86.2237 42.3893 10.5
+      vertex -86.2237 42.3893 0
+    endloop
+  endfacet
+  facet normal -0.954882 0.296984 0
+    outer loop
+      vertex -86.2237 42.3893 10.5
+      vertex -86.3403 42.0144 0
+      vertex -86.3403 42.0144 10.5
+    endloop
+  endfacet
+  facet normal 0.628942 -0.777452 0
+    outer loop
+      vertex -92.7623 46.3709 0
+      vertex -92.4571 46.6178 10.5
+      vertex -92.7623 46.3709 10.5
+    endloop
+  endfacet
+  facet normal 0.628942 -0.777452 0
+    outer loop
+      vertex -92.4571 46.6178 10.5
+      vertex -92.7623 46.3709 0
+      vertex -92.4571 46.6178 0
+    endloop
+  endfacet
+  facet normal -0.477424 -0.878673 0
+    outer loop
+      vertex -88.3614 46.9922 0
+      vertex -88.0165 46.8048 10.5
+      vertex -88.3614 46.9922 10.5
+    endloop
+  endfacet
+  facet normal -0.477424 -0.878673 -0
+    outer loop
+      vertex -88.0165 46.8048 10.5
+      vertex -88.3614 46.9922 0
+      vertex -88.0165 46.8048 0
+    endloop
+  endfacet
+  facet normal 0.549752 -0.835328 0
+    outer loop
+      vertex -92.4571 46.6178 0
+      vertex -92.1292 46.8336 10.5
+      vertex -92.4571 46.6178 10.5
+    endloop
+  endfacet
+  facet normal 0.549752 -0.835328 0
+    outer loop
+      vertex -92.1292 46.8336 10.5
+      vertex -92.4571 46.6178 0
+      vertex -92.1292 46.8336 0
+    endloop
+  endfacet
+  facet normal -0.639708 -0.768618 0
+    outer loop
+      vertex -87.6916 46.5844 0
+      vertex -87.3899 46.3333 10.5
+      vertex -87.6916 46.5844 10.5
+    endloop
+  endfacet
+  facet normal -0.639708 -0.768618 -0
+    outer loop
+      vertex -87.3899 46.3333 10.5
+      vertex -87.6916 46.5844 0
+      vertex -87.3899 46.3333 0
+    endloop
+  endfacet
+  facet normal -0.549752 0.835328 0
+    outer loop
+      vertex -87.7367 40.1589 0
+      vertex -88.0646 39.9431 10.5
+      vertex -87.7367 40.1589 10.5
+    endloop
+  endfacet
+  facet normal -0.549752 0.835328 0
+    outer loop
+      vertex -88.0646 39.9431 10.5
+      vertex -87.7367 40.1589 0
+      vertex -88.0646 39.9431 0
+    endloop
+  endfacet
+  facet normal 0.639984 0.768388 -0
+    outer loop
+      vertex -92.5022 40.1923 0
+      vertex -92.8038 40.4435 10.5
+      vertex -92.5022 40.1923 10.5
+    endloop
+  endfacet
+  facet normal 0.639984 0.768388 0
+    outer loop
+      vertex -92.8038 40.4435 10.5
+      vertex -92.5022 40.1923 0
+      vertex -92.8038 40.4435 0
+    endloop
+  endfacet
+  facet normal 0.201991 0.979387 -0
+    outer loop
+      vertex -90.7115 39.4359 0
+      vertex -91.096 39.5152 10.5
+      vertex -90.7115 39.4359 10.5
+    endloop
+  endfacet
+  facet normal 0.201991 0.979387 0
+    outer loop
+      vertex -91.096 39.5152 10.5
+      vertex -90.7115 39.4359 0
+      vertex -91.096 39.5152 0
+    endloop
+  endfacet
+  facet normal -0.188025 0.982164 0
+    outer loop
+      vertex -89.1522 39.5015 0
+      vertex -89.5377 39.4277 10.5
+      vertex -89.1522 39.5015 10.5
+    endloop
+  endfacet
+  facet normal -0.188025 0.982164 0
+    outer loop
+      vertex -89.5377 39.4277 10.5
+      vertex -89.1522 39.5015 0
+      vertex -89.5377 39.4277 0
+    endloop
+  endfacet
+  facet normal -0.00687882 -0.999976 0
+    outer loop
+      vertex -90.2651 47.3848 0
+      vertex -89.8726 47.3821 10.5
+      vertex -90.2651 47.3848 10.5
+    endloop
+  endfacet
+  facet normal -0.00687882 -0.999976 -0
+    outer loop
+      vertex -89.8726 47.3821 10.5
+      vertex -90.2651 47.3848 0
+      vertex -89.8726 47.3821 0
+    endloop
+  endfacet
+  facet normal -0.376261 0.926514 0
+    outer loop
+      vertex -88.4121 39.7605 0
+      vertex -88.7758 39.6128 10.5
+      vertex -88.4121 39.7605 10.5
+    endloop
+  endfacet
+  facet normal -0.376261 0.926514 0
+    outer loop
+      vertex -88.7758 39.6128 10.5
+      vertex -88.4121 39.7605 0
+      vertex -88.7758 39.6128 0
+    endloop
+  endfacet
+  facet normal 0.994475 -0.104977 0
+    outer loop
+      vertex -94.0906 43.6127 10.5
+      vertex -94.0494 44.003 0
+      vertex -94.0494 44.003 10.5
+    endloop
+  endfacet
+  facet normal 0.994475 -0.104977 0
+    outer loop
+      vertex -94.0494 44.003 0
+      vertex -94.0906 43.6127 10.5
+      vertex -94.0906 43.6127 0
+    endloop
+  endfacet
+  facet normal 0.926514 0.376261 0
+    outer loop
+      vertex -93.7247 41.7036 10.5
+      vertex -93.8724 42.0673 0
+      vertex -93.8724 42.0673 10.5
+    endloop
+  endfacet
+  facet normal 0.926514 0.376261 0
+    outer loop
+      vertex -93.8724 42.0673 0
+      vertex -93.7247 41.7036 10.5
+      vertex -93.7247 41.7036 0
+    endloop
+  endfacet
+  facet normal -0.628942 0.777452 0
+    outer loop
+      vertex -87.4315 40.4058 0
+      vertex -87.7367 40.1589 10.5
+      vertex -87.4315 40.4058 10.5
+    endloop
+  endfacet
+  facet normal -0.628942 0.777452 0
+    outer loop
+      vertex -87.7367 40.1589 10.5
+      vertex -87.4315 40.4058 0
+      vertex -87.7367 40.1589 0
+    endloop
+  endfacet
+  facet normal -0.768493 0.639859 0
+    outer loop
+      vertex -87.152 40.6814 0
+      vertex -86.9008 40.9831 10.5
+      vertex -86.9008 40.9831 0
+    endloop
+  endfacet
+  facet normal -0.768493 0.639859 0
+    outer loop
+      vertex -86.9008 40.9831 10.5
+      vertex -87.152 40.6814 0
+      vertex -87.152 40.6814 10.5
+    endloop
+  endfacet
+  facet normal 0.777577 0.628788 0
+    outer loop
+      vertex -93.0795 40.723 10.5
+      vertex -93.3263 41.0282 0
+      vertex -93.3263 41.0282 10.5
+    endloop
+  endfacet
+  facet normal 0.777577 0.628788 0
+    outer loop
+      vertex -93.3263 41.0282 0
+      vertex -93.0795 40.723 10.5
+      vertex -93.0795 40.723 0
+    endloop
+  endfacet
+  facet normal 0.958955 0.283559 0
+    outer loop
+      vertex -93.8724 42.0673 10.5
+      vertex -93.9837 42.4437 0
+      vertex -93.9837 42.4437 10.5
+    endloop
+  endfacet
+  facet normal 0.958955 0.283559 0
+    outer loop
+      vertex -93.9837 42.4437 0
+      vertex -93.8724 42.0673 10.5
+      vertex -93.8724 42.0673 0
+    endloop
+  endfacet
+  facet normal 0.885227 0.465158 0
+    outer loop
+      vertex -93.5421 41.3561 10.5
+      vertex -93.7247 41.7036 0
+      vertex -93.7247 41.7036 10.5
+    endloop
+  endfacet
+  facet normal 0.885227 0.465158 0
+    outer loop
+      vertex -93.7247 41.7036 0
+      vertex -93.5421 41.3561 10.5
+      vertex -93.5421 41.3561 0
+    endloop
+  endfacet
+  facet normal -0.283559 0.958955 0
+    outer loop
+      vertex -88.7758 39.6128 0
+      vertex -89.1522 39.5015 10.5
+      vertex -88.7758 39.6128 10.5
+    endloop
+  endfacet
+  facet normal -0.283559 0.958955 0
+    outer loop
+      vertex -89.1522 39.5015 10.5
+      vertex -88.7758 39.6128 0
+      vertex -89.1522 39.5015 0
+    endloop
+  endfacet
+  facet normal 0.835328 0.549752 0
+    outer loop
+      vertex -93.3263 41.0282 10.5
+      vertex -93.5421 41.3561 0
+      vertex -93.5421 41.3561 10.5
+    endloop
+  endfacet
+  facet normal 0.835328 0.549752 0
+    outer loop
+      vertex -93.5421 41.3561 0
+      vertex -93.3263 41.0282 10.5
+      vertex -93.3263 41.0282 0
+    endloop
+  endfacet
+  facet normal -0.297056 -0.95486 0
+    outer loop
+      vertex -89.0978 47.2616 0
+      vertex -88.723 47.145 10.5
+      vertex -89.0978 47.2616 10.5
+    endloop
+  endfacet
+  facet normal -0.297056 -0.95486 -0
+    outer loop
+      vertex -88.723 47.145 10.5
+      vertex -89.0978 47.2616 0
+      vertex -88.723 47.145 0
+    endloop
+  endfacet
+  facet normal 0.104977 0.994475 -0
+    outer loop
+      vertex -90.3212 39.3947 0
+      vertex -90.7115 39.4359 10.5
+      vertex -90.3212 39.3947 10.5
+    endloop
+  endfacet
+  facet normal 0.104977 0.994475 0
+    outer loop
+      vertex -90.7115 39.4359 10.5
+      vertex -90.3212 39.3947 0
+      vertex -90.7115 39.4359 0
+    endloop
+  endfacet
+  facet normal 0.768618 -0.639708 0
+    outer loop
+      vertex -93.2929 45.7936 10.5
+      vertex -93.0418 46.0953 0
+      vertex -93.0418 46.0953 10.5
+    endloop
+  endfacet
+  facet normal 0.768618 -0.639708 0
+    outer loop
+      vertex -93.0418 46.0953 0
+      vertex -93.2929 45.7936 10.5
+      vertex -93.2929 45.7936 0
+    endloop
+  endfacet
+  facet normal -0.465158 0.885227 0
+    outer loop
+      vertex -88.0646 39.9431 0
+      vertex -88.4121 39.7605 10.5
+      vertex -88.0646 39.9431 10.5
+    endloop
+  endfacet
+  facet normal -0.465158 0.885227 0
+    outer loop
+      vertex -88.4121 39.7605 10.5
+      vertex -88.0646 39.9431 0
+      vertex -88.4121 39.7605 0
+    endloop
+  endfacet
+  facet normal 0.827476 -0.561501 0
+    outer loop
+      vertex -93.5133 45.4688 10.5
+      vertex -93.2929 45.7936 0
+      vertex -93.2929 45.7936 10.5
+    endloop
+  endfacet
+  facet normal 0.827476 -0.561501 0
+    outer loop
+      vertex -93.2929 45.7936 0
+      vertex -93.5133 45.4688 10.5
+      vertex -93.5133 45.4688 0
+    endloop
+  endfacet
+  facet normal 0.188271 -0.982117 0
+    outer loop
+      vertex -91.0416 47.2752 0
+      vertex -90.6561 47.3491 10.5
+      vertex -91.0416 47.2752 10.5
+    endloop
+  endfacet
+  facet normal 0.188271 -0.982117 0
+    outer loop
+      vertex -90.6561 47.3491 10.5
+      vertex -91.0416 47.2752 0
+      vertex -90.6561 47.3491 0
+    endloop
+  endfacet
+  facet normal 0.561209 0.827674 -0
+    outer loop
+      vertex -92.1773 39.972 0
+      vertex -92.5022 40.1923 10.5
+      vertex -92.1773 39.972 10.5
+    endloop
+  endfacet
+  facet normal 0.561209 0.827674 0
+    outer loop
+      vertex -92.5022 40.1923 10.5
+      vertex -92.1773 39.972 0
+      vertex -92.5022 40.1923 0
+    endloop
+  endfacet
+  facet normal 0.283559 -0.958955 0
+    outer loop
+      vertex -91.418 47.1639 0
+      vertex -91.0416 47.2752 10.5
+      vertex -91.418 47.1639 10.5
+    endloop
+  endfacet
+  facet normal 0.283559 -0.958955 0
+    outer loop
+      vertex -91.0416 47.2752 10.5
+      vertex -91.418 47.1639 0
+      vertex -91.0416 47.2752 0
+    endloop
+  endfacet
+  facet normal -0.878508 0.477727 0
+    outer loop
+      vertex -86.6805 41.308 0
+      vertex -86.493 41.6528 10.5
+      vertex -86.493 41.6528 0
+    endloop
+  endfacet
+  facet normal -0.878508 0.477727 0
+    outer loop
+      vertex -86.493 41.6528 10.5
+      vertex -86.6805 41.308 0
+      vertex -86.6805 41.308 10.5
+    endloop
+  endfacet
+  facet normal -0.958885 -0.283793 0
+    outer loop
+      vertex -86.21 44.3331 0
+      vertex -86.3214 44.7095 10.5
+      vertex -86.3214 44.7095 0
+    endloop
+  endfacet
+  facet normal -0.958885 -0.283793 0
+    outer loop
+      vertex -86.3214 44.7095 10.5
+      vertex -86.21 44.3331 0
+      vertex -86.21 44.3331 10.5
+    endloop
+  endfacet
+  facet normal -0.982173 -0.187978 0
+    outer loop
+      vertex -86.1362 43.9475 0
+      vertex -86.21 44.3331 10.5
+      vertex -86.21 44.3331 0
+    endloop
+  endfacet
+  facet normal -0.982173 -0.187978 0
+    outer loop
+      vertex -86.21 44.3331 10.5
+      vertex -86.1362 43.9475 0
+      vertex -86.1362 43.9475 10.5
+    endloop
+  endfacet
+  facet normal 0.702121 -0.712057 0
+    outer loop
+      vertex -93.0418 46.0953 0
+      vertex -92.7623 46.3709 10.5
+      vertex -93.0418 46.0953 10.5
+    endloop
+  endfacet
+  facet normal 0.702121 -0.712057 0
+    outer loop
+      vertex -92.7623 46.3709 10.5
+      vertex -93.0418 46.0953 0
+      vertex -92.7623 46.3709 0
+    endloop
+  endfacet
+  facet normal -0.827674 0.561209 0
+    outer loop
+      vertex -86.9008 40.9831 0
+      vertex -86.6805 41.308 10.5
+      vertex -86.6805 41.308 0
+    endloop
+  endfacet
+  facet normal -0.827674 0.561209 0
+    outer loop
+      vertex -86.6805 41.308 10.5
+      vertex -86.9008 40.9831 0
+      vertex -86.9008 40.9831 10.5
+    endloop
+  endfacet
+  facet normal -0.835328 -0.549752 0
+    outer loop
+      vertex -86.6516 45.4207 0
+      vertex -86.8674 45.7486 10.5
+      vertex -86.8674 45.7486 0
+    endloop
+  endfacet
+  facet normal -0.835328 -0.549752 0
+    outer loop
+      vertex -86.8674 45.7486 10.5
+      vertex -86.6516 45.4207 0
+      vertex -86.6516 45.4207 10.5
+    endloop
+  endfacet
+  facet normal -0.561383 -0.827556 0
+    outer loop
+      vertex -88.0165 46.8048 0
+      vertex -87.6916 46.5844 10.5
+      vertex -88.0165 46.8048 10.5
+    endloop
+  endfacet
+  facet normal -0.561383 -0.827556 -0
+    outer loop
+      vertex -87.6916 46.5844 10.5
+      vertex -88.0165 46.8048 0
+      vertex -87.6916 46.5844 0
+    endloop
+  endfacet
+  facet normal -0.885227 -0.465158 0
+    outer loop
+      vertex -86.469 45.0732 0
+      vertex -86.6516 45.4207 10.5
+      vertex -86.6516 45.4207 0
+    endloop
+  endfacet
+  facet normal -0.885227 -0.465158 0
+    outer loop
+      vertex -86.6516 45.4207 10.5
+      vertex -86.469 45.0732 0
+      vertex -86.469 45.0732 10.5
+    endloop
+  endfacet
+  facet normal -0.995832 -0.0912018 0
+    outer loop
+      vertex -86.1004 43.5566 0
+      vertex -86.1362 43.9475 10.5
+      vertex -86.1362 43.9475 0
+    endloop
+  endfacet
+  facet normal -0.995832 -0.0912018 0
+    outer loop
+      vertex -86.1362 43.9475 10.5
+      vertex -86.1004 43.5566 0
+      vertex -86.1004 43.5566 10.5
+    endloop
+  endfacet
+  facet normal -0.900969 -0.433884 0
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -119.871 -3.85793e-07 0
+    endloop
+  endfacet
+  facet normal -0.900969 -0.433884 0
+    outer loop
+      vertex -119.871 -3.85793e-07 10.5
+      vertex -74.7383 -93.7189 0
+      vertex -74.7383 -93.7189 10.5
+    endloop
+  endfacet
+  facet normal 0.900969 0.433884 0
+    outer loop
+      vertex -27.6809 -34.7107 3.25
+      vertex -44.3967 0 0
+      vertex -44.3967 0 3.25
+    endloop
+  endfacet
+  facet normal 0.900969 0.433884 0
+    outer loop
+      vertex -44.3967 0 0
+      vertex -27.6809 -34.7107 3.25
+      vertex -27.6809 -34.7107 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -119.871 -3.85793e-07 0
+      vertex -119.871 0 10.5
+      vertex -119.871 0 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -119.871 0 10.5
+      vertex -119.871 -3.85793e-07 0
+      vertex -119.871 -3.85793e-07 10.5
+    endloop
+  endfacet
+  facet normal 0.90097 0.433881 0
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex -102.112 0 6
+      vertex -102.112 0 10.5
+    endloop
+  endfacet
+  facet normal 0.90097 0.433881 0
+    outer loop
+      vertex -102.112 0 6
+      vertex -63.666 -79.8346 10.5
+      vertex -63.666 -79.8346 6
+    endloop
+  endfacet
+  facet normal 0.900969 0.433883 0
+    outer loop
+      vertex -56.7458 -71.1569 6
+      vertex -91.0131 0 3.25
+      vertex -91.0131 0 6
+    endloop
+  endfacet
+  facet normal 0.900969 0.433883 0
+    outer loop
+      vertex -91.0131 0 3.25
+      vertex -56.7458 -71.1569 6
+      vertex -56.7458 -71.1569 3.25
+    endloop
+  endfacet
+  facet normal -0.477424 0.878673 0
+    outer loop
+      vertex -88.0165 -46.8048 0
+      vertex -88.3614 -46.9922 10.5
+      vertex -88.0165 -46.8048 10.5
+    endloop
+  endfacet
+  facet normal -0.477424 0.878673 0
+    outer loop
+      vertex -88.3614 -46.9922 10.5
+      vertex -88.0165 -46.8048 0
+      vertex -88.3614 -46.9922 0
+    endloop
+  endfacet
+  facet normal 0.878566 0.47762 0
+    outer loop
+      vertex -93.5133 -45.4688 10.5
+      vertex -93.7008 -45.1239 0
+      vertex -93.7008 -45.1239 10.5
+    endloop
+  endfacet
+  facet normal 0.878566 0.47762 0
+    outer loop
+      vertex -93.7008 -45.1239 0
+      vertex -93.5133 -45.4688 10.5
+      vertex -93.5133 -45.4688 0
+    endloop
+  endfacet
+  facet normal -0.835328 0.549752 0
+    outer loop
+      vertex -86.8674 -45.7486 0
+      vertex -86.6516 -45.4207 10.5
+      vertex -86.6516 -45.4207 0
+    endloop
+  endfacet
+  facet normal -0.835328 0.549752 0
+    outer loop
+      vertex -86.6516 -45.4207 10.5
+      vertex -86.8674 -45.7486 0
+      vertex -86.8674 -45.7486 10.5
+    endloop
+  endfacet
+  facet normal 0.465158 0.885227 -0
+    outer loop
+      vertex -91.7817 -47.0162 0
+      vertex -92.1292 -46.8336 10.5
+      vertex -91.7817 -47.0162 10.5
+    endloop
+  endfacet
+  facet normal 0.465158 0.885227 0
+    outer loop
+      vertex -92.1292 -46.8336 10.5
+      vertex -91.7817 -47.0162 0
+      vertex -92.1292 -46.8336 0
+    endloop
+  endfacet
+  facet normal -0.628942 -0.777452 0
+    outer loop
+      vertex -87.7367 -40.1589 0
+      vertex -87.4315 -40.4058 10.5
+      vertex -87.7367 -40.1589 10.5
+    endloop
+  endfacet
+  facet normal -0.628942 -0.777452 -0
+    outer loop
+      vertex -87.4315 -40.4058 10.5
+      vertex -87.7367 -40.1589 0
+      vertex -87.4315 -40.4058 0
+    endloop
+  endfacet
+  facet normal 0.768618 0.639708 0
+    outer loop
+      vertex -93.0418 -46.0953 10.5
+      vertex -93.2929 -45.7936 0
+      vertex -93.2929 -45.7936 10.5
+    endloop
+  endfacet
+  facet normal 0.768618 0.639708 0
+    outer loop
+      vertex -93.2929 -45.7936 0
+      vertex -93.0418 -46.0953 10.5
+      vertex -93.0418 -46.0953 0
+    endloop
+  endfacet
+  facet normal 0.921227 0.389025 0
+    outer loop
+      vertex -93.7008 -45.1239 10.5
+      vertex -93.8535 -44.7623 0
+      vertex -93.8535 -44.7623 10.5
+    endloop
+  endfacet
+  facet normal 0.921227 0.389025 0
+    outer loop
+      vertex -93.8535 -44.7623 0
+      vertex -93.7008 -45.1239 10.5
+      vertex -93.7008 -45.1239 0
+    endloop
+  endfacet
+  facet normal 0.835328 -0.549752 0
+    outer loop
+      vertex -93.5421 -41.3561 10.5
+      vertex -93.3263 -41.0282 0
+      vertex -93.3263 -41.0282 10.5
+    endloop
+  endfacet
+  facet normal 0.835328 -0.549752 0
+    outer loop
+      vertex -93.3263 -41.0282 0
+      vertex -93.5421 -41.3561 10.5
+      vertex -93.5421 -41.3561 0
+    endloop
+  endfacet
+  facet normal 0.71193 -0.702251 0
+    outer loop
+      vertex -93.0795 -40.723 10.5
+      vertex -92.8038 -40.4435 0
+      vertex -92.8038 -40.4435 10.5
+    endloop
+  endfacet
+  facet normal 0.71193 -0.702251 0
+    outer loop
+      vertex -92.8038 -40.4435 0
+      vertex -93.0795 -40.723 10.5
+      vertex -93.0795 -40.723 0
+    endloop
+  endfacet
+  facet normal 0.982117 -0.188271 0
+    outer loop
+      vertex -94.0576 -42.8292 10.5
+      vertex -93.9837 -42.4437 0
+      vertex -93.9837 -42.4437 10.5
+    endloop
+  endfacet
+  facet normal 0.982117 -0.188271 0
+    outer loop
+      vertex -93.9837 -42.4437 0
+      vertex -94.0576 -42.8292 10.5
+      vertex -94.0576 -42.8292 0
+    endloop
+  endfacet
+  facet normal 0.958955 -0.283559 0
+    outer loop
+      vertex -93.9837 -42.4437 10.5
+      vertex -93.8724 -42.0673 0
+      vertex -93.8724 -42.0673 10.5
+    endloop
+  endfacet
+  facet normal 0.958955 -0.283559 0
+    outer loop
+      vertex -93.8724 -42.0673 0
+      vertex -93.9837 -42.4437 10.5
+      vertex -93.9837 -42.4437 0
+    endloop
+  endfacet
+  facet normal -0.777452 0.628942 0
+    outer loop
+      vertex -87.1143 -46.0538 0
+      vertex -86.8674 -45.7486 10.5
+      vertex -86.8674 -45.7486 0
+    endloop
+  endfacet
+  facet normal -0.777452 0.628942 0
+    outer loop
+      vertex -86.8674 -45.7486 10.5
+      vertex -87.1143 -46.0538 0
+      vertex -87.1143 -46.0538 10.5
+    endloop
+  endfacet
+  facet normal -0.389241 0.921136 0
+    outer loop
+      vertex -88.3614 -46.9922 0
+      vertex -88.723 -47.145 10.5
+      vertex -88.3614 -46.9922 10.5
+    endloop
+  endfacet
+  facet normal -0.389241 0.921136 0
+    outer loop
+      vertex -88.723 -47.145 10.5
+      vertex -88.3614 -46.9922 0
+      vertex -88.723 -47.145 0
+    endloop
+  endfacet
+  facet normal 0.00713176 -0.999975 0
+    outer loop
+      vertex -90.3212 -39.3947 0
+      vertex -89.9286 -39.3919 10.5
+      vertex -90.3212 -39.3947 10.5
+    endloop
+  endfacet
+  facet normal 0.00713176 -0.999975 0
+    outer loop
+      vertex -89.9286 -39.3919 10.5
+      vertex -90.3212 -39.3947 0
+      vertex -89.9286 -39.3919 0
+    endloop
+  endfacet
+  facet normal -0.561383 0.827556 0
+    outer loop
+      vertex -87.6916 -46.5844 0
+      vertex -88.0165 -46.8048 10.5
+      vertex -87.6916 -46.5844 10.5
+    endloop
+  endfacet
+  facet normal -0.561383 0.827556 0
+    outer loop
+      vertex -88.0165 -46.8048 10.5
+      vertex -87.6916 -46.5844 0
+      vertex -88.0165 -46.8048 0
+    endloop
+  endfacet
+  facet normal -0.994478 -0.10495 0
+    outer loop
+      vertex -86.1032 -43.1641 0
+      vertex -86.1444 -42.7737 10.5
+      vertex -86.1444 -42.7737 0
+    endloop
+  endfacet
+  facet normal -0.994478 -0.10495 0
+    outer loop
+      vertex -86.1444 -42.7737 10.5
+      vertex -86.1032 -43.1641 0
+      vertex -86.1032 -43.1641 10.5
+    endloop
+  endfacet
+  facet normal -0.283559 -0.958955 0
+    outer loop
+      vertex -89.1522 -39.5015 0
+      vertex -88.7758 -39.6128 10.5
+      vertex -89.1522 -39.5015 10.5
+    endloop
+  endfacet
+  facet normal -0.283559 -0.958955 -0
+    outer loop
+      vertex -88.7758 -39.6128 10.5
+      vertex -89.1522 -39.5015 0
+      vertex -88.7758 -39.6128 0
+    endloop
+  endfacet
+  facet normal 0.47762 -0.878566 0
+    outer loop
+      vertex -92.1773 -39.972 0
+      vertex -91.8324 -39.7845 10.5
+      vertex -92.1773 -39.972 10.5
+    endloop
+  endfacet
+  facet normal 0.47762 -0.878566 0
+    outer loop
+      vertex -91.8324 -39.7845 10.5
+      vertex -92.1773 -39.972 0
+      vertex -91.8324 -39.7845 0
+    endloop
+  endfacet
+  facet normal 0.549752 0.835328 -0
+    outer loop
+      vertex -92.1292 -46.8336 0
+      vertex -92.4571 -46.6178 10.5
+      vertex -92.1292 -46.8336 10.5
+    endloop
+  endfacet
+  facet normal 0.549752 0.835328 0
+    outer loop
+      vertex -92.4571 -46.6178 10.5
+      vertex -92.1292 -46.8336 0
+      vertex -92.4571 -46.6178 0
+    endloop
+  endfacet
+  facet normal -0.768493 -0.639859 0
+    outer loop
+      vertex -86.9008 -40.9831 0
+      vertex -87.152 -40.6814 10.5
+      vertex -87.152 -40.6814 0
+    endloop
+  endfacet
+  facet normal -0.768493 -0.639859 0
+    outer loop
+      vertex -87.152 -40.6814 10.5
+      vertex -86.9008 -40.9831 0
+      vertex -86.9008 -40.9831 10.5
+    endloop
+  endfacet
+  facet normal -0.878508 -0.477727 0
+    outer loop
+      vertex -86.493 -41.6528 0
+      vertex -86.6805 -41.308 10.5
+      vertex -86.6805 -41.308 0
+    endloop
+  endfacet
+  facet normal -0.878508 -0.477727 0
+    outer loop
+      vertex -86.6805 -41.308 10.5
+      vertex -86.493 -41.6528 0
+      vertex -86.493 -41.6528 10.5
+    endloop
+  endfacet
+  facet normal -0.702121 -0.712057 0
+    outer loop
+      vertex -87.4315 -40.4058 0
+      vertex -87.152 -40.6814 10.5
+      vertex -87.4315 -40.4058 10.5
+    endloop
+  endfacet
+  facet normal -0.702121 -0.712057 -0
+    outer loop
+      vertex -87.152 -40.6814 10.5
+      vertex -87.4315 -40.4058 0
+      vertex -87.152 -40.6814 0
+    endloop
+  endfacet
+  facet normal 0.827476 0.561501 0
+    outer loop
+      vertex -93.2929 -45.7936 10.5
+      vertex -93.5133 -45.4688 0
+      vertex -93.5133 -45.4688 10.5
+    endloop
+  endfacet
+  facet normal 0.827476 0.561501 0
+    outer loop
+      vertex -93.5133 -45.4688 0
+      vertex -93.2929 -45.7936 10.5
+      vertex -93.2929 -45.7936 0
+    endloop
+  endfacet
+  facet normal 0.104977 -0.994475 0
+    outer loop
+      vertex -90.7115 -39.4359 0
+      vertex -90.3212 -39.3947 10.5
+      vertex -90.7115 -39.4359 10.5
+    endloop
+  endfacet
+  facet normal 0.104977 -0.994475 0
+    outer loop
+      vertex -90.3212 -39.3947 10.5
+      vertex -90.7115 -39.4359 0
+      vertex -90.3212 -39.3947 0
+    endloop
+  endfacet
+  facet normal 0.639984 -0.768388 0
+    outer loop
+      vertex -92.8038 -40.4435 0
+      vertex -92.5022 -40.1923 10.5
+      vertex -92.8038 -40.4435 10.5
+    endloop
+  endfacet
+  facet normal 0.639984 -0.768388 0
+    outer loop
+      vertex -92.5022 -40.1923 10.5
+      vertex -92.8038 -40.4435 0
+      vertex -92.5022 -40.1923 0
+    endloop
+  endfacet
+  facet normal 0.628942 0.777452 -0
+    outer loop
+      vertex -92.4571 -46.6178 0
+      vertex -92.7623 -46.3709 10.5
+      vertex -92.4571 -46.6178 10.5
+    endloop
+  endfacet
+  facet normal 0.628942 0.777452 0
+    outer loop
+      vertex -92.7623 -46.3709 10.5
+      vertex -92.4571 -46.6178 0
+      vertex -92.7623 -46.3709 0
+    endloop
+  endfacet
+  facet normal -0.10495 0.994478 0
+    outer loop
+      vertex -89.4822 -47.3409 0
+      vertex -89.8726 -47.3821 10.5
+      vertex -89.4822 -47.3409 10.5
+    endloop
+  endfacet
+  facet normal -0.10495 0.994478 0
+    outer loop
+      vertex -89.8726 -47.3821 10.5
+      vertex -89.4822 -47.3409 0
+      vertex -89.8726 -47.3821 0
+    endloop
+  endfacet
+  facet normal -0.827674 -0.561209 0
+    outer loop
+      vertex -86.6805 -41.308 0
+      vertex -86.9008 -40.9831 10.5
+      vertex -86.9008 -40.9831 0
+    endloop
+  endfacet
+  facet normal -0.827674 -0.561209 0
+    outer loop
+      vertex -86.9008 -40.9831 10.5
+      vertex -86.6805 -41.308 0
+      vertex -86.6805 -41.308 10.5
+    endloop
+  endfacet
+  facet normal 0.999976 0.00687707 0
+    outer loop
+      vertex -94.0906 -43.6127 10.5
+      vertex -94.0933 -43.2201 0
+      vertex -94.0933 -43.2201 10.5
+    endloop
+  endfacet
+  facet normal 0.999976 0.00687707 0
+    outer loop
+      vertex -94.0933 -43.2201 0
+      vertex -94.0906 -43.6127 10.5
+      vertex -94.0906 -43.6127 0
+    endloop
+  endfacet
+  facet normal 0.389241 -0.921136 0
+    outer loop
+      vertex -91.8324 -39.7845 0
+      vertex -91.4708 -39.6317 10.5
+      vertex -91.8324 -39.7845 10.5
+    endloop
+  endfacet
+  facet normal 0.389241 -0.921136 0
+    outer loop
+      vertex -91.4708 -39.6317 10.5
+      vertex -91.8324 -39.7845 0
+      vertex -91.4708 -39.6317 0
+    endloop
+  endfacet
+  facet normal 0.995856 -0.0909492 0
+    outer loop
+      vertex -94.0933 -43.2201 10.5
+      vertex -94.0576 -42.8292 0
+      vertex -94.0576 -42.8292 10.5
+    endloop
+  endfacet
+  facet normal 0.995856 -0.0909492 0
+    outer loop
+      vertex -94.0576 -42.8292 0
+      vertex -94.0933 -43.2201 10.5
+      vertex -94.0933 -43.2201 0
+    endloop
+  endfacet
+  facet normal 0.201991 -0.979387 0
+    outer loop
+      vertex -91.096 -39.5152 0
+      vertex -90.7115 -39.4359 10.5
+      vertex -91.096 -39.5152 10.5
+    endloop
+  endfacet
+  facet normal 0.201991 -0.979387 0
+    outer loop
+      vertex -90.7115 -39.4359 10.5
+      vertex -91.096 -39.5152 0
+      vertex -90.7115 -39.4359 0
+    endloop
+  endfacet
+  facet normal -0.995832 0.0912018 0
+    outer loop
+      vertex -86.1362 -43.9475 0
+      vertex -86.1004 -43.5566 10.5
+      vertex -86.1004 -43.5566 0
+    endloop
+  endfacet
+  facet normal -0.995832 0.0912018 0
+    outer loop
+      vertex -86.1004 -43.5566 10.5
+      vertex -86.1362 -43.9475 0
+      vertex -86.1362 -43.9475 10.5
+    endloop
+  endfacet
+  facet normal -0.202041 0.979377 0
+    outer loop
+      vertex -89.0978 -47.2616 0
+      vertex -89.4822 -47.3409 10.5
+      vertex -89.0978 -47.2616 10.5
+    endloop
+  endfacet
+  facet normal -0.202041 0.979377 0
+    outer loop
+      vertex -89.4822 -47.3409 10.5
+      vertex -89.0978 -47.2616 0
+      vertex -89.4822 -47.3409 0
+    endloop
+  endfacet
+  facet normal -0.639708 0.768618 0
+    outer loop
+      vertex -87.3899 -46.3333 0
+      vertex -87.6916 -46.5844 10.5
+      vertex -87.3899 -46.3333 10.5
+    endloop
+  endfacet
+  facet normal -0.639708 0.768618 0
+    outer loop
+      vertex -87.6916 -46.5844 10.5
+      vertex -87.3899 -46.3333 0
+      vertex -87.6916 -46.5844 0
+    endloop
+  endfacet
+  facet normal -0.885227 0.465158 0
+    outer loop
+      vertex -86.6516 -45.4207 0
+      vertex -86.469 -45.0732 10.5
+      vertex -86.469 -45.0732 0
+    endloop
+  endfacet
+  facet normal -0.885227 0.465158 0
+    outer loop
+      vertex -86.469 -45.0732 10.5
+      vertex -86.6516 -45.4207 0
+      vertex -86.6516 -45.4207 10.5
+    endloop
+  endfacet
+  facet normal 0.777577 -0.628788 0
+    outer loop
+      vertex -93.3263 -41.0282 10.5
+      vertex -93.0795 -40.723 0
+      vertex -93.0795 -40.723 10.5
+    endloop
+  endfacet
+  facet normal 0.777577 -0.628788 0
+    outer loop
+      vertex -93.0795 -40.723 0
+      vertex -93.3263 -41.0282 10.5
+      vertex -93.3263 -41.0282 0
+    endloop
+  endfacet
+  facet normal -0.958885 0.283793 0
+    outer loop
+      vertex -86.3214 -44.7095 0
+      vertex -86.21 -44.3331 10.5
+      vertex -86.21 -44.3331 0
+    endloop
+  endfacet
+  facet normal -0.958885 0.283793 0
+    outer loop
+      vertex -86.21 -44.3331 10.5
+      vertex -86.3214 -44.7095 0
+      vertex -86.3214 -44.7095 10.5
+    endloop
+  endfacet
+  facet normal 0.702121 0.712057 -0
+    outer loop
+      vertex -92.7623 -46.3709 0
+      vertex -93.0418 -46.0953 10.5
+      vertex -92.7623 -46.3709 10.5
+    endloop
+  endfacet
+  facet normal 0.702121 0.712057 0
+    outer loop
+      vertex -93.0418 -46.0953 10.5
+      vertex -92.7623 -46.3709 0
+      vertex -93.0418 -46.0953 0
+    endloop
+  endfacet
+  facet normal 0.283559 0.958955 -0
+    outer loop
+      vertex -91.0416 -47.2752 0
+      vertex -91.418 -47.1639 10.5
+      vertex -91.0416 -47.2752 10.5
+    endloop
+  endfacet
+  facet normal 0.283559 0.958955 0
+    outer loop
+      vertex -91.418 -47.1639 10.5
+      vertex -91.0416 -47.2752 0
+      vertex -91.418 -47.1639 0
+    endloop
+  endfacet
+  facet normal -0.999975 -0.00713358 0
+    outer loop
+      vertex -86.1004 -43.5566 0
+      vertex -86.1032 -43.1641 10.5
+      vertex -86.1032 -43.1641 0
+    endloop
+  endfacet
+  facet normal -0.999975 -0.00713358 0
+    outer loop
+      vertex -86.1032 -43.1641 10.5
+      vertex -86.1004 -43.5566 0
+      vertex -86.1004 -43.5566 10.5
+    endloop
+  endfacet
+  facet normal -0.979377 -0.202041 0
+    outer loop
+      vertex -86.1444 -42.7737 0
+      vertex -86.2237 -42.3893 10.5
+      vertex -86.2237 -42.3893 0
+    endloop
+  endfacet
+  facet normal -0.979377 -0.202041 0
+    outer loop
+      vertex -86.2237 -42.3893 10.5
+      vertex -86.1444 -42.7737 0
+      vertex -86.1444 -42.7737 10.5
+    endloop
+  endfacet
+  facet normal -0.00687882 0.999976 0
+    outer loop
+      vertex -89.8726 -47.3821 0
+      vertex -90.2651 -47.3848 10.5
+      vertex -89.8726 -47.3821 10.5
+    endloop
+  endfacet
+  facet normal -0.00687882 0.999976 0
+    outer loop
+      vertex -90.2651 -47.3848 10.5
+      vertex -89.8726 -47.3821 0
+      vertex -90.2651 -47.3848 0
+    endloop
+  endfacet
+  facet normal 0.376261 0.926514 -0
+    outer loop
+      vertex -91.418 -47.1639 0
+      vertex -91.7817 -47.0162 10.5
+      vertex -91.418 -47.1639 10.5
+    endloop
+  endfacet
+  facet normal 0.376261 0.926514 0
+    outer loop
+      vertex -91.7817 -47.0162 10.5
+      vertex -91.418 -47.1639 0
+      vertex -91.7817 -47.0162 0
+    endloop
+  endfacet
+  facet normal 0.188271 0.982117 -0
+    outer loop
+      vertex -90.6561 -47.3491 0
+      vertex -91.0416 -47.2752 10.5
+      vertex -90.6561 -47.3491 10.5
+    endloop
+  endfacet
+  facet normal 0.188271 0.982117 0
+    outer loop
+      vertex -91.0416 -47.2752 10.5
+      vertex -90.6561 -47.3491 0
+      vertex -91.0416 -47.2752 0
+    endloop
+  endfacet
+  facet normal -0.926603 0.376042 0
+    outer loop
+      vertex -86.469 -45.0732 0
+      vertex -86.3214 -44.7095 10.5
+      vertex -86.3214 -44.7095 0
+    endloop
+  endfacet
+  facet normal -0.926603 0.376042 0
+    outer loop
+      vertex -86.3214 -44.7095 10.5
+      vertex -86.469 -45.0732 0
+      vertex -86.469 -45.0732 10.5
+    endloop
+  endfacet
+  facet normal 0.0909261 0.995858 -0
+    outer loop
+      vertex -90.2651 -47.3848 0
+      vertex -90.6561 -47.3491 10.5
+      vertex -90.2651 -47.3848 10.5
+    endloop
+  endfacet
+  facet normal 0.0909261 0.995858 0
+    outer loop
+      vertex -90.6561 -47.3491 10.5
+      vertex -90.2651 -47.3848 0
+      vertex -90.6561 -47.3491 0
+    endloop
+  endfacet
+  facet normal 0.561209 -0.827674 0
+    outer loop
+      vertex -92.5022 -40.1923 0
+      vertex -92.1773 -39.972 10.5
+      vertex -92.5022 -40.1923 10.5
+    endloop
+  endfacet
+  facet normal 0.561209 -0.827674 0
+    outer loop
+      vertex -92.1773 -39.972 10.5
+      vertex -92.5022 -40.1923 0
+      vertex -92.1773 -39.972 0
+    endloop
+  endfacet
+  facet normal -0.712057 0.702121 0
+    outer loop
+      vertex -87.3899 -46.3333 0
+      vertex -87.1143 -46.0538 10.5
+      vertex -87.1143 -46.0538 0
+    endloop
+  endfacet
+  facet normal -0.712057 0.702121 0
+    outer loop
+      vertex -87.1143 -46.0538 10.5
+      vertex -87.3899 -46.3333 0
+      vertex -87.3899 -46.3333 10.5
+    endloop
+  endfacet
+  facet normal 0.979387 0.201991 0
+    outer loop
+      vertex -93.9701 -44.3875 10.5
+      vertex -94.0494 -44.003 0
+      vertex -94.0494 -44.003 10.5
+    endloop
+  endfacet
+  facet normal 0.979387 0.201991 0
+    outer loop
+      vertex -94.0494 -44.003 0
+      vertex -93.9701 -44.3875 10.5
+      vertex -93.9701 -44.3875 0
+    endloop
+  endfacet
+  facet normal -0.982173 0.187978 0
+    outer loop
+      vertex -86.21 -44.3331 0
+      vertex -86.1362 -43.9475 10.5
+      vertex -86.1362 -43.9475 0
+    endloop
+  endfacet
+  facet normal -0.982173 0.187978 0
+    outer loop
+      vertex -86.1362 -43.9475 10.5
+      vertex -86.21 -44.3331 0
+      vertex -86.21 -44.3331 10.5
+    endloop
+  endfacet
+  facet normal 0.95486 0.297056 0
+    outer loop
+      vertex -93.8535 -44.7623 10.5
+      vertex -93.9701 -44.3875 0
+      vertex -93.9701 -44.3875 10.5
+    endloop
+  endfacet
+  facet normal 0.95486 0.297056 0
+    outer loop
+      vertex -93.9701 -44.3875 0
+      vertex -93.8535 -44.7623 10.5
+      vertex -93.8535 -44.7623 0
+    endloop
+  endfacet
+  facet normal 0.885227 -0.465158 0
+    outer loop
+      vertex -93.7247 -41.7036 10.5
+      vertex -93.5421 -41.3561 0
+      vertex -93.5421 -41.3561 10.5
+    endloop
+  endfacet
+  facet normal 0.885227 -0.465158 0
+    outer loop
+      vertex -93.5421 -41.3561 0
+      vertex -93.7247 -41.7036 10.5
+      vertex -93.7247 -41.7036 0
+    endloop
+  endfacet
+  facet normal -0.297056 0.95486 0
+    outer loop
+      vertex -88.723 -47.145 0
+      vertex -89.0978 -47.2616 10.5
+      vertex -88.723 -47.145 10.5
+    endloop
+  endfacet
+  facet normal -0.297056 0.95486 0
+    outer loop
+      vertex -89.0978 -47.2616 10.5
+      vertex -88.723 -47.145 0
+      vertex -89.0978 -47.2616 0
+    endloop
+  endfacet
+  facet normal 0.926514 -0.376261 0
+    outer loop
+      vertex -93.8724 -42.0673 10.5
+      vertex -93.7247 -41.7036 0
+      vertex -93.7247 -41.7036 10.5
+    endloop
+  endfacet
+  facet normal 0.926514 -0.376261 0
+    outer loop
+      vertex -93.7247 -41.7036 0
+      vertex -93.8724 -42.0673 10.5
+      vertex -93.8724 -42.0673 0
+    endloop
+  endfacet
+  facet normal -0.921227 -0.389025 0
+    outer loop
+      vertex -86.3403 -42.0144 0
+      vertex -86.493 -41.6528 10.5
+      vertex -86.493 -41.6528 0
+    endloop
+  endfacet
+  facet normal -0.921227 -0.389025 0
+    outer loop
+      vertex -86.493 -41.6528 10.5
+      vertex -86.3403 -42.0144 0
+      vertex -86.3403 -42.0144 10.5
+    endloop
+  endfacet
+  facet normal -0.376261 -0.926514 0
+    outer loop
+      vertex -88.7758 -39.6128 0
+      vertex -88.4121 -39.7605 10.5
+      vertex -88.7758 -39.6128 10.5
+    endloop
+  endfacet
+  facet normal -0.376261 -0.926514 -0
+    outer loop
+      vertex -88.4121 -39.7605 10.5
+      vertex -88.7758 -39.6128 0
+      vertex -88.4121 -39.7605 0
+    endloop
+  endfacet
+  facet normal -0.465158 -0.885227 0
+    outer loop
+      vertex -88.4121 -39.7605 0
+      vertex -88.0646 -39.9431 10.5
+      vertex -88.4121 -39.7605 10.5
+    endloop
+  endfacet
+  facet normal -0.465158 -0.885227 -0
+    outer loop
+      vertex -88.0646 -39.9431 10.5
+      vertex -88.4121 -39.7605 0
+      vertex -88.0646 -39.9431 0
+    endloop
+  endfacet
+  facet normal 0.994475 0.104977 0
+    outer loop
+      vertex -94.0494 -44.003 10.5
+      vertex -94.0906 -43.6127 0
+      vertex -94.0906 -43.6127 10.5
+    endloop
+  endfacet
+  facet normal 0.994475 0.104977 0
+    outer loop
+      vertex -94.0906 -43.6127 0
+      vertex -94.0494 -44.003 10.5
+      vertex -94.0494 -44.003 0
+    endloop
+  endfacet
+  facet normal -0.954882 -0.296984 0
+    outer loop
+      vertex -86.2237 -42.3893 0
+      vertex -86.3403 -42.0144 10.5
+      vertex -86.3403 -42.0144 0
+    endloop
+  endfacet
+  facet normal -0.954882 -0.296984 0
+    outer loop
+      vertex -86.3403 -42.0144 10.5
+      vertex -86.2237 -42.3893 0
+      vertex -86.2237 -42.3893 10.5
+    endloop
+  endfacet
+  facet normal -0.0912018 -0.995832 0
+    outer loop
+      vertex -89.9286 -39.3919 0
+      vertex -89.5377 -39.4277 10.5
+      vertex -89.9286 -39.3919 10.5
+    endloop
+  endfacet
+  facet normal -0.0912018 -0.995832 -0
+    outer loop
+      vertex -89.5377 -39.4277 10.5
+      vertex -89.9286 -39.3919 0
+      vertex -89.5377 -39.4277 0
+    endloop
+  endfacet
+  facet normal 0.296824 -0.954932 0
+    outer loop
+      vertex -91.4708 -39.6317 0
+      vertex -91.096 -39.5152 10.5
+      vertex -91.4708 -39.6317 10.5
+    endloop
+  endfacet
+  facet normal 0.296824 -0.954932 0
+    outer loop
+      vertex -91.096 -39.5152 10.5
+      vertex -91.4708 -39.6317 0
+      vertex -91.096 -39.5152 0
+    endloop
+  endfacet
+  facet normal -0.188025 -0.982164 0
+    outer loop
+      vertex -89.5377 -39.4277 0
+      vertex -89.1522 -39.5015 10.5
+      vertex -89.5377 -39.4277 10.5
+    endloop
+  endfacet
+  facet normal -0.188025 -0.982164 -0
+    outer loop
+      vertex -89.1522 -39.5015 10.5
+      vertex -89.5377 -39.4277 0
+      vertex -89.1522 -39.5015 0
+    endloop
+  endfacet
+  facet normal -0.549752 -0.835328 0
+    outer loop
+      vertex -88.0646 -39.9431 0
+      vertex -87.7367 -40.1589 10.5
+      vertex -88.0646 -39.9431 10.5
+    endloop
+  endfacet
+  facet normal -0.549752 -0.835328 -0
+    outer loop
+      vertex -87.7367 -40.1589 10.5
+      vertex -88.0646 -39.9431 0
+      vertex -87.7367 -40.1589 0
+    endloop
+  endfacet
+  facet normal -0.222525 -0.974927 0
+    outer loop
+      vertex -74.7383 -93.7189 0
+      vertex 26.6738 -116.866 10.5
+      vertex -74.7383 -93.7189 10.5
+    endloop
+  endfacet
+  facet normal -0.222525 -0.974927 -0
+    outer loop
+      vertex 26.6738 -116.866 10.5
+      vertex -74.7383 -93.7189 0
+      vertex 26.6738 -116.866 0
+    endloop
+  endfacet
+  facet normal 0.22252 0.974928 -0
+    outer loop
+      vertex 9.87918 -43.2835 0
+      vertex -27.6809 -34.7107 3.25
+      vertex 9.87918 -43.2835 3.25
+    endloop
+  endfacet
+  facet normal 0.22252 0.974928 0
+    outer loop
+      vertex -27.6809 -34.7107 3.25
+      vertex 9.87918 -43.2835 0
+      vertex -27.6809 -34.7107 0
+    endloop
+  endfacet
+  facet normal 0.222521 0.974928 -0
+    outer loop
+      vertex 22.7221 -99.5521 6
+      vertex -63.666 -79.8346 10.5
+      vertex 22.7221 -99.5521 10.5
+    endloop
+  endfacet
+  facet normal 0.222521 0.974928 0
+    outer loop
+      vertex -63.666 -79.8346 10.5
+      vertex 22.7221 -99.5521 6
+      vertex -63.666 -79.8346 6
+    endloop
+  endfacet
+  facet normal 0.222521 0.974928 -0
+    outer loop
+      vertex 20.2523 -88.7312 3.25
+      vertex -56.7458 -71.1569 6
+      vertex 20.2523 -88.7312 6
+    endloop
+  endfacet
+  facet normal 0.222521 0.974928 0
+    outer loop
+      vertex -56.7458 -71.1569 6
+      vertex 20.2523 -88.7312 3.25
+      vertex -56.7458 -71.1569 3.25
+    endloop
+  endfacet
+  facet normal -0.984655 0.174512 0
+    outer loop
+      vertex -18.3524 -98.3829 0
+      vertex -18.2839 -97.9964 10.5
+      vertex -18.2839 -97.9964 0
+    endloop
+  endfacet
+  facet normal -0.984655 0.174512 0
+    outer loop
+      vertex -18.2839 -97.9964 10.5
+      vertex -18.3524 -98.3829 0
+      vertex -18.3524 -98.3829 10.5
+    endloop
+  endfacet
+  facet normal 0.173277 0.984873 -0
+    outer loop
+      vertex -22.7557 -101.461 0
+      vertex -23.1422 -101.393 10.5
+      vertex -22.7557 -101.461 10.5
+    endloop
+  endfacet
+  facet normal 0.173277 0.984873 0
+    outer loop
+      vertex -23.1422 -101.393 10.5
+      vertex -22.7557 -101.461 0
+      vertex -23.1422 -101.393 0
+    endloop
+  endfacet
+  facet normal -0.950651 -0.310261 0
+    outer loop
+      vertex -18.3933 -96.4395 0
+      vertex -18.5151 -96.0663 10.5
+      vertex -18.5151 -96.0663 0
+    endloop
+  endfacet
+  facet normal -0.950651 -0.310261 0
+    outer loop
+      vertex -18.5151 -96.0663 10.5
+      vertex -18.3933 -96.4395 0
+      vertex -18.3933 -96.4395 10.5
+    endloop
+  endfacet
+  facet normal -0.402448 0.915443 0
+    outer loop
+      vertex -20.4662 -101.072 0
+      vertex -20.8256 -101.23 10.5
+      vertex -20.4662 -101.072 10.5
+    endloop
+  endfacet
+  facet normal -0.402448 0.915443 0
+    outer loop
+      vertex -20.8256 -101.23 10.5
+      vertex -20.4662 -101.072 0
+      vertex -20.8256 -101.23 0
+    endloop
+  endfacet
+  facet normal 0.21577 -0.976444 0
+    outer loop
+      vertex -23.3054 -93.634 0
+      vertex -22.9221 -93.5493 10.5
+      vertex -23.3054 -93.634 10.5
+    endloop
+  endfacet
+  facet normal 0.21577 -0.976444 0
+    outer loop
+      vertex -22.9221 -93.5493 10.5
+      vertex -23.3054 -93.634 0
+      vertex -22.9221 -93.5493 0
+    endloop
+  endfacet
+  facet normal -0.0203779 0.999792 0
+    outer loop
+      vertex -21.9718 -101.483 0
+      vertex -22.3643 -101.491 10.5
+      vertex -21.9718 -101.483 10.5
+    endloop
+  endfacet
+  facet normal -0.0203779 0.999792 0
+    outer loop
+      vertex -22.3643 -101.491 10.5
+      vertex -21.9718 -101.483 0
+      vertex -22.3643 -101.491 0
+    endloop
+  endfacet
+  facet normal 0.272434 0.962175 -0
+    outer loop
+      vertex -23.1422 -101.393 0
+      vertex -23.5201 -101.286 10.5
+      vertex -23.1422 -101.393 10.5
+    endloop
+  endfacet
+  facet normal 0.272434 0.962175 0
+    outer loop
+      vertex -23.5201 -101.286 10.5
+      vertex -23.1422 -101.393 0
+      vertex -23.5201 -101.286 0
+    endloop
+  endfacet
+  facet normal 0.950651 0.310261 0
+    outer loop
+      vertex -25.9891 -98.9193 10.5
+      vertex -26.1109 -98.5461 0
+      vertex -26.1109 -98.5461 10.5
+    endloop
+  endfacet
+  facet normal 0.950651 0.310261 0
+    outer loop
+      vertex -26.1109 -98.5461 0
+      vertex -25.9891 -98.9193 10.5
+      vertex -25.9891 -98.9193 0
+    endloop
+  endfacet
+  facet normal 0.992896 0.118984 0
+    outer loop
+      vertex -26.1956 -98.1628 10.5
+      vertex -26.2423 -97.7731 0
+      vertex -26.2423 -97.7731 10.5
+    endloop
+  endfacet
+  facet normal 0.992896 0.118984 0
+    outer loop
+      vertex -26.2423 -97.7731 0
+      vertex -26.1956 -98.1628 10.5
+      vertex -26.1956 -98.1628 0
+    endloop
+  endfacet
+  facet normal 0.759724 0.650246 0
+    outer loop
+      vertex -25.1587 -100.241 10.5
+      vertex -25.4141 -99.9426 0
+      vertex -25.4141 -99.9426 10.5
+    endloop
+  endfacet
+  facet normal 0.759724 0.650246 0
+    outer loop
+      vertex -25.4141 -99.9426 0
+      vertex -25.1587 -100.241 10.5
+      vertex -25.1587 -100.241 0
+    endloop
+  endfacet
+  facet normal 0.819579 0.572966 0
+    outer loop
+      vertex -25.4141 -99.9426 10.5
+      vertex -25.639 -99.6209 0
+      vertex -25.639 -99.6209 10.5
+    endloop
+  endfacet
+  facet normal 0.819579 0.572966 0
+    outer loop
+      vertex -25.639 -99.6209 0
+      vertex -25.4141 -99.9426 10.5
+      vertex -25.4141 -99.9426 0
+    endloop
+  endfacet
+  facet normal -0.976444 -0.21577 0
+    outer loop
+      vertex -18.3086 -96.8228 0
+      vertex -18.3933 -96.4395 10.5
+      vertex -18.3933 -96.4395 0
+    endloop
+  endfacet
+  facet normal -0.976444 -0.21577 0
+    outer loop
+      vertex -18.3933 -96.4395 10.5
+      vertex -18.3086 -96.8228 0
+      vertex -18.3086 -96.8228 10.5
+    endloop
+  endfacet
+  facet normal -0.96284 0.270074 0
+    outer loop
+      vertex -18.4584 -98.7608 0
+      vertex -18.3524 -98.3829 10.5
+      vertex -18.3524 -98.3829 0
+    endloop
+  endfacet
+  facet normal -0.96284 0.270074 0
+    outer loop
+      vertex -18.3524 -98.3829 10.5
+      vertex -18.4584 -98.7608 0
+      vertex -18.4584 -98.7608 10.5
+    endloop
+  endfacet
+  facet normal 0.786159 -0.618024 0
+    outer loop
+      vertex -25.5143 -95.1781 10.5
+      vertex -25.2717 -94.8695 0
+      vertex -25.2717 -94.8695 10.5
+    endloop
+  endfacet
+  facet normal 0.786159 -0.618024 0
+    outer loop
+      vertex -25.2717 -94.8695 0
+      vertex -25.5143 -95.1781 10.5
+      vertex -25.5143 -95.1781 0
+    endloop
+  endfacet
+  facet normal -0.997036 0.0769303 0
+    outer loop
+      vertex -18.2839 -97.9964 0
+      vertex -18.2537 -97.605 10.5
+      vertex -18.2537 -97.605 0
+    endloop
+  endfacet
+  facet normal -0.997036 0.0769303 0
+    outer loop
+      vertex -18.2537 -97.605 10.5
+      vertex -18.2839 -97.9964 0
+      vertex -18.2839 -97.9964 10.5
+    endloop
+  endfacet
+  facet normal -0.537831 -0.843052 0
+    outer loop
+      vertex -20.2683 -94.0194 0
+      vertex -19.9374 -94.2305 10.5
+      vertex -20.2683 -94.0194 10.5
+    endloop
+  endfacet
+  facet normal -0.537831 -0.843052 -0
+    outer loop
+      vertex -19.9374 -94.2305 10.5
+      vertex -20.2683 -94.0194 0
+      vertex -19.9374 -94.2305 0
+    endloop
+  endfacet
+  facet normal 0.572966 -0.819579 0
+    outer loop
+      vertex -24.7019 -94.3308 0
+      vertex -24.3802 -94.1059 10.5
+      vertex -24.7019 -94.3308 10.5
+    endloop
+  endfacet
+  facet normal 0.572966 -0.819579 0
+    outer loop
+      vertex -24.3802 -94.1059 10.5
+      vertex -24.7019 -94.3308 0
+      vertex -24.3802 -94.1059 0
+    endloop
+  endfacet
+  facet normal 0.984655 -0.174512 0
+    outer loop
+      vertex -26.2203 -96.9892 10.5
+      vertex -26.1518 -96.6027 0
+      vertex -26.1518 -96.6027 10.5
+    endloop
+  endfacet
+  facet normal 0.984655 -0.174512 0
+    outer loop
+      vertex -26.1518 -96.6027 0
+      vertex -26.2203 -96.9892 10.5
+      vertex -26.2203 -96.9892 0
+    endloop
+  endfacet
+  facet normal -0.310721 0.950501 0
+    outer loop
+      vertex -20.8256 -101.23 0
+      vertex -21.1988 -101.352 10.5
+      vertex -20.8256 -101.23 10.5
+    endloop
+  endfacet
+  facet normal -0.310721 0.950501 0
+    outer loop
+      vertex -21.1988 -101.352 10.5
+      vertex -20.8256 -101.23 0
+      vertex -21.1988 -101.352 0
+    endloop
+  endfacet
+  facet normal 0.0208872 -0.999782 0
+    outer loop
+      vertex -22.5324 -93.5026 0
+      vertex -22.1399 -93.4944 10.5
+      vertex -22.5324 -93.5026 10.5
+    endloop
+  endfacet
+  facet normal 0.0208872 -0.999782 0
+    outer loop
+      vertex -22.1399 -93.4944 10.5
+      vertex -22.5324 -93.5026 0
+      vertex -22.1399 -93.4944 0
+    endloop
+  endfacet
+  facet normal -0.174512 -0.984655 0
+    outer loop
+      vertex -21.7485 -93.5246 0
+      vertex -21.362 -93.5931 10.5
+      vertex -21.7485 -93.5246 10.5
+    endloop
+  endfacet
+  facet normal -0.174512 -0.984655 -0
+    outer loop
+      vertex -21.362 -93.5931 10.5
+      vertex -21.7485 -93.5246 0
+      vertex -21.362 -93.5931 0
+    endloop
+  endfacet
+  facet normal 0.118984 -0.992896 0
+    outer loop
+      vertex -22.9221 -93.5493 0
+      vertex -22.5324 -93.5026 10.5
+      vertex -22.9221 -93.5493 10.5
+    endloop
+  endfacet
+  facet normal 0.118984 -0.992896 0
+    outer loop
+      vertex -22.5324 -93.5026 10.5
+      vertex -22.9221 -93.5493 0
+      vertex -22.5324 -93.5026 0
+    endloop
+  endfacet
+  facet normal 0.0764238 0.997075 -0
+    outer loop
+      vertex -22.3643 -101.491 0
+      vertex -22.7557 -101.461 10.5
+      vertex -22.3643 -101.491 10.5
+    endloop
+  endfacet
+  facet normal 0.0764238 0.997075 0
+    outer loop
+      vertex -22.7557 -101.461 10.5
+      vertex -22.3643 -101.491 0
+      vertex -22.7557 -101.461 0
+    endloop
+  endfacet
+  facet normal 0.842937 -0.538012 0
+    outer loop
+      vertex -25.7255 -95.509 10.5
+      vertex -25.5143 -95.1781 0
+      vertex -25.5143 -95.1781 10.5
+    endloop
+  endfacet
+  facet normal 0.842937 -0.538012 0
+    outer loop
+      vertex -25.5143 -95.1781 0
+      vertex -25.7255 -95.509 10.5
+      vertex -25.7255 -95.509 0
+    endloop
+  endfacet
+  facet normal 0.999782 0.0208872 0
+    outer loop
+      vertex -26.2423 -97.7731 10.5
+      vertex -26.2505 -97.3806 0
+      vertex -26.2505 -97.3806 10.5
+    endloop
+  endfacet
+  facet normal 0.999782 0.0208872 0
+    outer loop
+      vertex -26.2505 -97.3806 0
+      vertex -26.2423 -97.7731 10.5
+      vertex -26.2423 -97.7731 0
+    endloop
+  endfacet
+  facet normal -0.214069 0.976818 0
+    outer loop
+      vertex -21.1988 -101.352 0
+      vertex -21.5821 -101.436 10.5
+      vertex -21.1988 -101.352 10.5
+    endloop
+  endfacet
+  facet normal -0.214069 0.976818 0
+    outer loop
+      vertex -21.5821 -101.436 10.5
+      vertex -21.1988 -101.352 0
+      vertex -21.5821 -101.436 0
+    endloop
+  endfacet
+  facet normal -0.842937 0.538012 0
+    outer loop
+      vertex -18.9899 -99.8075 0
+      vertex -18.7787 -99.4766 10.5
+      vertex -18.7787 -99.4766 0
+    endloop
+  endfacet
+  facet normal -0.842937 0.538012 0
+    outer loop
+      vertex -18.7787 -99.4766 10.5
+      vertex -18.9899 -99.8075 0
+      vertex -18.9899 -99.8075 10.5
+    endloop
+  endfacet
+  facet normal -0.0769303 -0.997036 0
+    outer loop
+      vertex -22.1399 -93.4944 0
+      vertex -21.7485 -93.5246 10.5
+      vertex -22.1399 -93.4944 10.5
+    endloop
+  endfacet
+  facet normal -0.0769303 -0.997036 -0
+    outer loop
+      vertex -21.7485 -93.5246 10.5
+      vertex -22.1399 -93.4944 0
+      vertex -21.7485 -93.5246 0
+    endloop
+  endfacet
+  facet normal 0.618653 0.785664 -0
+    outer loop
+      vertex -24.5668 -100.755 0
+      vertex -24.8754 -100.512 10.5
+      vertex -24.5668 -100.755 10.5
+    endloop
+  endfacet
+  facet normal 0.618653 0.785664 0
+    outer loop
+      vertex -24.8754 -100.512 10.5
+      vertex -24.5668 -100.755 0
+      vertex -24.8754 -100.512 0
+    endloop
+  endfacet
+  facet normal 0.96284 -0.270074 0
+    outer loop
+      vertex -26.1518 -96.6027 10.5
+      vertex -26.0458 -96.2248 0
+      vertex -26.0458 -96.2248 10.5
+    endloop
+  endfacet
+  facet normal 0.96284 -0.270074 0
+    outer loop
+      vertex -26.0458 -96.2248 0
+      vertex -26.1518 -96.6027 10.5
+      vertex -26.1518 -96.6027 0
+    endloop
+  endfacet
+  facet normal 0.691246 0.72262 -0
+    outer loop
+      vertex -24.8754 -100.512 0
+      vertex -25.1587 -100.241 10.5
+      vertex -24.8754 -100.512 10.5
+    endloop
+  endfacet
+  facet normal 0.691246 0.72262 0
+    outer loop
+      vertex -25.1587 -100.241 10.5
+      vertex -24.8754 -100.512 0
+      vertex -25.1587 -100.241 0
+    endloop
+  endfacet
+  facet normal 0.891659 -0.452708 0
+    outer loop
+      vertex -25.9032 -95.859 10.5
+      vertex -25.7255 -95.509 0
+      vertex -25.7255 -95.509 10.5
+    endloop
+  endfacet
+  facet normal 0.891659 -0.452708 0
+    outer loop
+      vertex -25.7255 -95.509 0
+      vertex -25.9032 -95.859 10.5
+      vertex -25.9032 -95.859 0
+    endloop
+  endfacet
+  facet normal -0.692176 -0.721728 0
+    outer loop
+      vertex -19.6288 -94.4731 0
+      vertex -19.3455 -94.7448 10.5
+      vertex -19.6288 -94.4731 10.5
+    endloop
+  endfacet
+  facet normal -0.692176 -0.721728 -0
+    outer loop
+      vertex -19.3455 -94.7448 10.5
+      vertex -19.6288 -94.4731 0
+      vertex -19.3455 -94.7448 0
+    endloop
+  endfacet
+  facet normal -0.891659 0.452708 0
+    outer loop
+      vertex -18.7787 -99.4766 0
+      vertex -18.601 -99.1266 10.5
+      vertex -18.601 -99.1266 0
+    endloop
+  endfacet
+  facet normal -0.891659 0.452708 0
+    outer loop
+      vertex -18.601 -99.1266 10.5
+      vertex -18.7787 -99.4766 0
+      vertex -18.7787 -99.4766 10.5
+    endloop
+  endfacet
+  facet normal -0.999782 -0.0208872 0
+    outer loop
+      vertex -18.2537 -97.605 0
+      vertex -18.2619 -97.2125 10.5
+      vertex -18.2619 -97.2125 0
+    endloop
+  endfacet
+  facet normal -0.999782 -0.0208872 0
+    outer loop
+      vertex -18.2619 -97.2125 10.5
+      vertex -18.2537 -97.605 0
+      vertex -18.2537 -97.605 10.5
+    endloop
+  endfacet
+  facet normal -0.91563 -0.402021 0
+    outer loop
+      vertex -18.5151 -96.0663 0
+      vertex -18.6729 -95.7069 10.5
+      vertex -18.6729 -95.7069 0
+    endloop
+  endfacet
+  facet normal -0.91563 -0.402021 0
+    outer loop
+      vertex -18.6729 -95.7069 10.5
+      vertex -18.5151 -96.0663 0
+      vertex -18.5151 -96.0663 10.5
+    endloop
+  endfacet
+  facet normal 0.976444 0.21577 0
+    outer loop
+      vertex -26.1109 -98.5461 10.5
+      vertex -26.1956 -98.1628 0
+      vertex -26.1956 -98.1628 10.5
+    endloop
+  endfacet
+  facet normal 0.976444 0.21577 0
+    outer loop
+      vertex -26.1956 -98.1628 0
+      vertex -26.1109 -98.5461 10.5
+      vertex -26.1109 -98.5461 0
+    endloop
+  endfacet
+  facet normal -0.819662 -0.572847 0
+    outer loop
+      vertex -18.8652 -95.3647 0
+      vertex -19.0901 -95.0429 10.5
+      vertex -19.0901 -95.0429 0
+    endloop
+  endfacet
+  facet normal -0.819662 -0.572847 0
+    outer loop
+      vertex -19.0901 -95.0429 10.5
+      vertex -18.8652 -95.3647 0
+      vertex -18.8652 -95.3647 10.5
+    endloop
+  endfacet
+  facet normal -0.119738 0.992806 0
+    outer loop
+      vertex -21.5821 -101.436 0
+      vertex -21.9718 -101.483 10.5
+      vertex -21.5821 -101.436 10.5
+    endloop
+  endfacet
+  facet normal -0.119738 0.992806 0
+    outer loop
+      vertex -21.9718 -101.483 10.5
+      vertex -21.5821 -101.436 0
+      vertex -21.9718 -101.483 0
+    endloop
+  endfacet
+  facet normal -0.573018 0.819543 0
+    outer loop
+      vertex -19.8022 -100.655 0
+      vertex -20.124 -100.88 10.5
+      vertex -19.8022 -100.655 10.5
+    endloop
+  endfacet
+  facet normal -0.573018 0.819543 0
+    outer loop
+      vertex -20.124 -100.88 10.5
+      vertex -19.8022 -100.655 0
+      vertex -20.124 -100.88 0
+    endloop
+  endfacet
+  facet normal -0.618024 -0.786159 0
+    outer loop
+      vertex -19.9374 -94.2305 0
+      vertex -19.6288 -94.4731 10.5
+      vertex -19.9374 -94.2305 10.5
+    endloop
+  endfacet
+  facet normal -0.618024 -0.786159 -0
+    outer loop
+      vertex -19.6288 -94.4731 10.5
+      vertex -19.9374 -94.2305 0
+      vertex -19.6288 -94.4731 0
+    endloop
+  endfacet
+  facet normal -0.452708 -0.891659 0
+    outer loop
+      vertex -20.6183 -93.8417 0
+      vertex -20.2683 -94.0194 10.5
+      vertex -20.6183 -93.8417 10.5
+    endloop
+  endfacet
+  facet normal -0.452708 -0.891659 -0
+    outer loop
+      vertex -20.2683 -94.0194 10.5
+      vertex -20.6183 -93.8417 0
+      vertex -20.2683 -94.0194 0
+    endloop
+  endfacet
+  facet normal -0.786186 0.61799 0
+    outer loop
+      vertex -19.2324 -100.116 0
+      vertex -18.9899 -99.8075 10.5
+      vertex -18.9899 -99.8075 0
+    endloop
+  endfacet
+  facet normal -0.786186 0.61799 0
+    outer loop
+      vertex -18.9899 -99.8075 10.5
+      vertex -19.2324 -100.116 0
+      vertex -19.2324 -100.116 10.5
+    endloop
+  endfacet
+  facet normal -0.489317 0.872106 0
+    outer loop
+      vertex -20.124 -100.88 0
+      vertex -20.4662 -101.072 10.5
+      vertex -20.124 -100.88 10.5
+    endloop
+  endfacet
+  facet normal -0.489317 0.872106 0
+    outer loop
+      vertex -20.4662 -101.072 10.5
+      vertex -20.124 -100.88 0
+      vertex -20.4662 -101.072 0
+    endloop
+  endfacet
+  facet normal -0.651504 0.758645 0
+    outer loop
+      vertex -19.5041 -100.399 0
+      vertex -19.8022 -100.655 10.5
+      vertex -19.5041 -100.399 10.5
+    endloop
+  endfacet
+  facet normal -0.651504 0.758645 0
+    outer loop
+      vertex -19.8022 -100.655 10.5
+      vertex -19.5041 -100.399 0
+      vertex -19.8022 -100.655 0
+    endloop
+  endfacet
+  facet normal -0.87178 -0.489898 0
+    outer loop
+      vertex -18.6729 -95.7069 0
+      vertex -18.8652 -95.3647 10.5
+      vertex -18.8652 -95.3647 0
+    endloop
+  endfacet
+  facet normal -0.87178 -0.489898 0
+    outer loop
+      vertex -18.8652 -95.3647 10.5
+      vertex -18.6729 -95.7069 0
+      vertex -18.6729 -95.7069 10.5
+    endloop
+  endfacet
+  facet normal -0.721362 0.692558 0
+    outer loop
+      vertex -19.5041 -100.399 0
+      vertex -19.2324 -100.116 10.5
+      vertex -19.2324 -100.116 0
+    endloop
+  endfacet
+  facet normal -0.721362 0.692558 0
+    outer loop
+      vertex -19.2324 -100.116 10.5
+      vertex -19.5041 -100.399 0
+      vertex -19.5041 -100.399 10.5
+    endloop
+  endfacet
+  facet normal 0.997036 -0.0769303 0
+    outer loop
+      vertex -26.2505 -97.3806 10.5
+      vertex -26.2203 -96.9892 0
+      vertex -26.2203 -96.9892 10.5
+    endloop
+  endfacet
+  facet normal 0.997036 -0.0769303 0
+    outer loop
+      vertex -26.2203 -96.9892 0
+      vertex -26.2505 -97.3806 10.5
+      vertex -26.2505 -97.3806 0
+    endloop
+  endfacet
+  facet normal -0.992896 -0.118984 0
+    outer loop
+      vertex -18.2619 -97.2125 0
+      vertex -18.3086 -96.8228 10.5
+      vertex -18.3086 -96.8228 0
+    endloop
+  endfacet
+  facet normal -0.992896 -0.118984 0
+    outer loop
+      vertex -18.3086 -96.8228 10.5
+      vertex -18.2619 -97.2125 0
+      vertex -18.2619 -97.2125 10.5
+    endloop
+  endfacet
+  facet normal 0.453315 0.89135 -0
+    outer loop
+      vertex -23.8859 -101.144 0
+      vertex -24.2359 -100.966 10.5
+      vertex -23.8859 -101.144 10.5
+    endloop
+  endfacet
+  facet normal 0.453315 0.89135 0
+    outer loop
+      vertex -24.2359 -100.966 10.5
+      vertex -23.8859 -101.144 0
+      vertex -24.2359 -100.966 0
+    endloop
+  endfacet
+  facet normal -0.7594 -0.650624 0
+    outer loop
+      vertex -19.0901 -95.0429 0
+      vertex -19.3455 -94.7448 10.5
+      vertex -19.3455 -94.7448 0
+    endloop
+  endfacet
+  facet normal -0.7594 -0.650624 0
+    outer loop
+      vertex -19.3455 -94.7448 10.5
+      vertex -19.0901 -95.0429 0
+      vertex -19.0901 -95.0429 10.5
+    endloop
+  endfacet
+  facet normal 0.36188 0.932225 -0
+    outer loop
+      vertex -23.5201 -101.286 0
+      vertex -23.8859 -101.144 10.5
+      vertex -23.5201 -101.286 10.5
+    endloop
+  endfacet
+  facet normal 0.36188 0.932225 0
+    outer loop
+      vertex -23.8859 -101.144 10.5
+      vertex -23.5201 -101.286 0
+      vertex -23.8859 -101.144 0
+    endloop
+  endfacet
+  facet normal 0.91563 0.402021 0
+    outer loop
+      vertex -25.8313 -99.2787 10.5
+      vertex -25.9891 -98.9193 0
+      vertex -25.9891 -98.9193 10.5
+    endloop
+  endfacet
+  facet normal 0.91563 0.402021 0
+    outer loop
+      vertex -25.9891 -98.9193 0
+      vertex -25.8313 -99.2787 10.5
+      vertex -25.8313 -99.2787 0
+    endloop
+  endfacet
+  facet normal -0.931708 0.363208 0
+    outer loop
+      vertex -18.601 -99.1266 0
+      vertex -18.4584 -98.7608 10.5
+      vertex -18.4584 -98.7608 0
+    endloop
+  endfacet
+  facet normal -0.931708 0.363208 0
+    outer loop
+      vertex -18.4584 -98.7608 10.5
+      vertex -18.601 -99.1266 0
+      vertex -18.601 -99.1266 10.5
+    endloop
+  endfacet
+  facet normal 0.87178 0.489898 0
+    outer loop
+      vertex -25.639 -99.6209 10.5
+      vertex -25.8313 -99.2787 0
+      vertex -25.8313 -99.2787 10.5
+    endloop
+  endfacet
+  facet normal 0.87178 0.489898 0
+    outer loop
+      vertex -25.8313 -99.2787 0
+      vertex -25.639 -99.6209 10.5
+      vertex -25.639 -99.6209 0
+    endloop
+  endfacet
+  facet normal -0.270074 -0.96284 0
+    outer loop
+      vertex -21.362 -93.5931 0
+      vertex -20.9841 -93.6991 10.5
+      vertex -21.362 -93.5931 10.5
+    endloop
+  endfacet
+  facet normal -0.270074 -0.96284 -0
+    outer loop
+      vertex -20.9841 -93.6991 10.5
+      vertex -21.362 -93.5931 0
+      vertex -20.9841 -93.6991 0
+    endloop
+  endfacet
+  facet normal 0.489898 -0.87178 0
+    outer loop
+      vertex -24.3802 -94.1059 0
+      vertex -24.038 -93.9136 10.5
+      vertex -24.3802 -94.1059 10.5
+    endloop
+  endfacet
+  facet normal 0.489898 -0.87178 0
+    outer loop
+      vertex -24.038 -93.9136 10.5
+      vertex -24.3802 -94.1059 0
+      vertex -24.038 -93.9136 0
+    endloop
+  endfacet
+  facet normal 0.402021 -0.91563 0
+    outer loop
+      vertex -24.038 -93.9136 0
+      vertex -23.6786 -93.7558 10.5
+      vertex -24.038 -93.9136 10.5
+    endloop
+  endfacet
+  facet normal 0.402021 -0.91563 0
+    outer loop
+      vertex -23.6786 -93.7558 10.5
+      vertex -24.038 -93.9136 0
+      vertex -23.6786 -93.7558 0
+    endloop
+  endfacet
+  facet normal 0.53765 0.843168 -0
+    outer loop
+      vertex -24.2359 -100.966 0
+      vertex -24.5668 -100.755 10.5
+      vertex -24.2359 -100.966 10.5
+    endloop
+  endfacet
+  facet normal 0.53765 0.843168 0
+    outer loop
+      vertex -24.5668 -100.755 10.5
+      vertex -24.2359 -100.966 0
+      vertex -24.5668 -100.755 0
+    endloop
+  endfacet
+  facet normal -0.363208 -0.931708 0
+    outer loop
+      vertex -20.9841 -93.6991 0
+      vertex -20.6183 -93.8417 10.5
+      vertex -20.9841 -93.6991 10.5
+    endloop
+  endfacet
+  facet normal -0.363208 -0.931708 -0
+    outer loop
+      vertex -20.6183 -93.8417 10.5
+      vertex -20.9841 -93.6991 0
+      vertex -20.6183 -93.8417 0
+    endloop
+  endfacet
+  facet normal 0.721856 -0.692044 0
+    outer loop
+      vertex -25.2717 -94.8695 10.5
+      vertex -25.0001 -94.5862 0
+      vertex -25.0001 -94.5862 10.5
+    endloop
+  endfacet
+  facet normal 0.721856 -0.692044 0
+    outer loop
+      vertex -25.0001 -94.5862 0
+      vertex -25.2717 -94.8695 10.5
+      vertex -25.2717 -94.8695 0
+    endloop
+  endfacet
+  facet normal 0.931708 -0.363208 0
+    outer loop
+      vertex -26.0458 -96.2248 10.5
+      vertex -25.9032 -95.859 0
+      vertex -25.9032 -95.859 10.5
+    endloop
+  endfacet
+  facet normal 0.931708 -0.363208 0
+    outer loop
+      vertex -25.9032 -95.859 0
+      vertex -26.0458 -96.2248 10.5
+      vertex -26.0458 -96.2248 0
+    endloop
+  endfacet
+  facet normal 0.650498 -0.759508 0
+    outer loop
+      vertex -25.0001 -94.5862 0
+      vertex -24.7019 -94.3308 10.5
+      vertex -25.0001 -94.5862 10.5
+    endloop
+  endfacet
+  facet normal 0.650498 -0.759508 0
+    outer loop
+      vertex -24.7019 -94.3308 10.5
+      vertex -25.0001 -94.5862 0
+      vertex -24.7019 -94.3308 0
+    endloop
+  endfacet
+  facet normal 0.310261 -0.950651 0
+    outer loop
+      vertex -23.6786 -93.7558 0
+      vertex -23.3054 -93.634 10.5
+      vertex -23.6786 -93.7558 10.5
+    endloop
+  endfacet
+  facet normal 0.310261 -0.950651 0
+    outer loop
+      vertex -23.3054 -93.634 10.5
+      vertex -23.6786 -93.7558 0
+      vertex -23.3054 -93.634 0
+    endloop
+  endfacet
+  facet normal 0.623492 -0.78183 0
+    outer loop
+      vertex 26.6738 -116.866 0
+      vertex 108 -52.0101 10.5
+      vertex 26.6738 -116.866 10.5
+    endloop
+  endfacet
+  facet normal 0.623492 -0.78183 0
+    outer loop
+      vertex 108 -52.0101 10.5
+      vertex 26.6738 -116.866 0
+      vertex 108 -52.0101 0
+    endloop
+  endfacet
+  facet normal -0.623489 0.781832 0
+    outer loop
+      vertex 40 -19.263 0
+      vertex 9.87918 -43.2835 3.25
+      vertex 40 -19.263 3.25
+    endloop
+  endfacet
+  facet normal -0.623489 0.781832 0
+    outer loop
+      vertex 9.87918 -43.2835 3.25
+      vertex 40 -19.263 0
+      vertex 9.87918 -43.2835 0
+    endloop
+  endfacet
+  facet normal -0.623489 0.781832 0
+    outer loop
+      vertex 92 -44.3049 6
+      vertex 22.7221 -99.5521 10.5
+      vertex 92 -44.3049 10.5
+    endloop
+  endfacet
+  facet normal -0.623489 0.781832 0
+    outer loop
+      vertex 22.7221 -99.5521 10.5
+      vertex 92 -44.3049 6
+      vertex 22.7221 -99.5521 6
+    endloop
+  endfacet
+  facet normal -0.623489 0.781832 0
+    outer loop
+      vertex 82 -39.4891 3.25
+      vertex 20.2523 -88.7312 6
+      vertex 82 -39.4891 6
+    endloop
+  endfacet
+  facet normal -0.623489 0.781832 0
+    outer loop
+      vertex 20.2523 -88.7312 6
+      vertex 82 -39.4891 3.25
+      vertex 20.2523 -88.7312 3.25
+    endloop
+  endfacet
+  facet normal -0.750284 -0.661116 0
+    outer loop
+      vertex 65.4763 -75.6892 0
+      vertex 65.2168 -75.3947 10.5
+      vertex 65.2168 -75.3947 0
+    endloop
+  endfacet
+  facet normal -0.750284 -0.661116 0
+    outer loop
+      vertex 65.2168 -75.3947 10.5
+      vertex 65.4763 -75.6892 0
+      vertex 65.4763 -75.6892 10.5
+    endloop
+  endfacet
+  facet normal -0.66099 0.750395 0
+    outer loop
+      vertex 65.1375 -81.051 0
+      vertex 64.8429 -81.3105 10.5
+      vertex 65.1375 -81.051 10.5
+    endloop
+  endfacet
+  facet normal -0.66099 0.750395 0
+    outer loop
+      vertex 64.8429 -81.3105 10.5
+      vertex 65.1375 -81.051 0
+      vertex 64.8429 -81.3105 0
+    endloop
+  endfacet
+  facet normal -0.350258 -0.936653 0
+    outer loop
+      vertex 63.5637 -74.372 0
+      vertex 63.9314 -74.5095 10.5
+      vertex 63.5637 -74.372 10.5
+    endloop
+  endfacet
+  facet normal -0.350258 -0.936653 -0
+    outer loop
+      vertex 63.9314 -74.5095 10.5
+      vertex 63.5637 -74.372 0
+      vertex 63.9314 -74.5095 0
+    endloop
+  endfacet
+  facet normal -0.966534 0.256537 0
+    outer loop
+      vertex 66.1601 -79.3979 0
+      vertex 66.2608 -79.0185 10.5
+      vertex 66.2608 -79.0185 0
+    endloop
+  endfacet
+  facet normal -0.966534 0.256537 0
+    outer loop
+      vertex 66.2608 -79.0185 10.5
+      vertex 66.1601 -79.3979 0
+      vertex 66.1601 -79.3979 10.5
+    endloop
+  endfacet
+  facet normal 0.897865 -0.44027 0
+    outer loop
+      vertex 58.6753 -76.6007 10.5
+      vertex 58.8481 -76.2483 0
+      vertex 58.8481 -76.2483 10.5
+    endloop
+  endfacet
+  facet normal 0.897865 -0.44027 0
+    outer loop
+      vertex 58.8481 -76.2483 0
+      vertex 58.6753 -76.6007 10.5
+      vertex 58.6753 -76.6007 0
+    endloop
+  endfacet
+  facet normal -0.794618 0.60711 0
+    outer loop
+      vertex 65.4051 -80.7638 0
+      vertex 65.6434 -80.4519 10.5
+      vertex 65.6434 -80.4519 0
+    endloop
+  endfacet
+  facet normal -0.794618 0.60711 0
+    outer loop
+      vertex 65.6434 -80.4519 10.5
+      vertex 65.4051 -80.7638 0
+      vertex 65.4051 -80.7638 10.5
+    endloop
+  endfacet
+  facet normal -0.584439 0.811438 0
+    outer loop
+      vertex 64.8429 -81.3105 0
+      vertex 64.5244 -81.5399 10.5
+      vertex 64.8429 -81.3105 10.5
+    endloop
+  endfacet
+  facet normal -0.584439 0.811438 0
+    outer loop
+      vertex 64.5244 -81.5399 10.5
+      vertex 64.8429 -81.3105 0
+      vertex 64.5244 -81.5399 0
+    endloop
+  endfacet
+  facet normal 0.350034 0.936737 -0
+    outer loop
+      vertex 61.1343 -81.9942 0
+      vertex 60.7666 -81.8568 10.5
+      vertex 61.1343 -81.9942 10.5
+    endloop
+  endfacet
+  facet normal 0.350034 0.936737 0
+    outer loop
+      vertex 60.7666 -81.8568 10.5
+      vertex 61.1343 -81.9942 0
+      vertex 60.7666 -81.8568 0
+    endloop
+  endfacet
+  facet normal 0.5261 0.850423 -0
+    outer loop
+      vertex 60.4141 -81.684 0
+      vertex 60.0803 -81.4775 10.5
+      vertex 60.4141 -81.684 10.5
+    endloop
+  endfacet
+  facet normal 0.5261 0.850423 0
+    outer loop
+      vertex 60.0803 -81.4775 10.5
+      vertex 60.4141 -81.684 0
+      vertex 60.0803 -81.4775 0
+    endloop
+  endfacet
+  facet normal -0.0351554 0.999382 0
+    outer loop
+      vertex 62.6852 -82.169 0
+      vertex 62.2929 -82.1828 10.5
+      vertex 62.6852 -82.169 10.5
+    endloop
+  endfacet
+  facet normal -0.0351554 0.999382 0
+    outer loop
+      vertex 62.2929 -82.1828 10.5
+      vertex 62.6852 -82.169 0
+      vertex 62.2929 -82.1828 0
+    endloop
+  endfacet
+  facet normal 0.0631712 0.998003 -0
+    outer loop
+      vertex 62.2929 -82.1828 0
+      vertex 61.9011 -82.158 10.5
+      vertex 62.2929 -82.1828 10.5
+    endloop
+  endfacet
+  facet normal 0.0631712 0.998003 0
+    outer loop
+      vertex 61.9011 -82.158 10.5
+      vertex 62.2929 -82.1828 0
+      vertex 61.9011 -82.158 0
+    endloop
+  endfacet
+  facet normal -0.440169 -0.897915 0
+    outer loop
+      vertex 63.9314 -74.5095 0
+      vertex 64.2839 -74.6823 10.5
+      vertex 63.9314 -74.5095 10.5
+    endloop
+  endfacet
+  facet normal -0.440169 -0.897915 -0
+    outer loop
+      vertex 64.2839 -74.6823 10.5
+      vertex 63.9314 -74.5095 0
+      vertex 64.2839 -74.6823 0
+    endloop
+  endfacet
+  facet normal -0.811438 -0.584439 0
+    outer loop
+      vertex 65.7057 -76.0077 0
+      vertex 65.4763 -75.6892 10.5
+      vertex 65.4763 -75.6892 0
+    endloop
+  endfacet
+  facet normal -0.811438 -0.584439 0
+    outer loop
+      vertex 65.4763 -75.6892 10.5
+      vertex 65.7057 -76.0077 0
+      vertex 65.7057 -76.0077 10.5
+    endloop
+  endfacet
+  facet normal 0.973364 0.229267 0
+    outer loop
+      vertex 58.5053 -79.2905 10.5
+      vertex 58.4153 -78.9084 0
+      vertex 58.4153 -78.9084 10.5
+    endloop
+  endfacet
+  facet normal 0.973364 0.229267 0
+    outer loop
+      vertex 58.4153 -78.9084 0
+      vertex 58.5053 -79.2905 10.5
+      vertex 58.5053 -79.2905 0
+    endloop
+  endfacet
+  facet normal -0.681964 -0.731386 0
+    outer loop
+      vertex 64.9297 -75.127 0
+      vertex 65.2168 -75.3947 10.5
+      vertex 64.9297 -75.127 10.5
+    endloop
+  endfacet
+  facet normal -0.681964 -0.731386 -0
+    outer loop
+      vertex 65.2168 -75.3947 10.5
+      vertex 64.9297 -75.127 0
+      vertex 65.2168 -75.3947 0
+    endloop
+  endfacet
+  facet normal 0.323556 -0.946209 0
+    outer loop
+      vertex 60.8702 -74.4665 0
+      vertex 61.2416 -74.3395 10.5
+      vertex 60.8702 -74.4665 10.5
+    endloop
+  endfacet
+  facet normal 0.323556 -0.946209 0
+    outer loop
+      vertex 61.2416 -74.3395 10.5
+      vertex 60.8702 -74.4665 0
+      vertex 61.2416 -74.3395 0
+    endloop
+  endfacet
+  facet normal 0.998019 -0.0629175 0
+    outer loop
+      vertex 58.3494 -78.1271 10.5
+      vertex 58.3741 -77.7353 0
+      vertex 58.3741 -77.7353 10.5
+    endloop
+  endfacet
+  facet normal 0.998019 -0.0629175 0
+    outer loop
+      vertex 58.3741 -77.7353 0
+      vertex 58.3494 -78.1271 10.5
+      vertex 58.3494 -78.1271 0
+    endloop
+  endfacet
+  facet normal 0.750284 0.661116 0
+    outer loop
+      vertex 59.4812 -80.9716 10.5
+      vertex 59.2217 -80.6771 0
+      vertex 59.2217 -80.6771 10.5
+    endloop
+  endfacet
+  facet normal 0.750284 0.661116 0
+    outer loop
+      vertex 59.2217 -80.6771 0
+      vertex 59.4812 -80.9716 10.5
+      vertex 59.4812 -80.9716 0
+    endloop
+  endfacet
+  facet normal -0.936737 0.350034 0
+    outer loop
+      vertex 66.0227 -79.7656 0
+      vertex 66.1601 -79.3979 10.5
+      vertex 66.1601 -79.3979 0
+    endloop
+  endfacet
+  facet normal -0.936737 0.350034 0
+    outer loop
+      vertex 66.1601 -79.3979 10.5
+      vertex 66.0227 -79.7656 0
+      vertex 66.0227 -79.7656 10.5
+    endloop
+  endfacet
+  facet normal 0.794741 -0.606949 0
+    outer loop
+      vertex 59.0546 -75.9144 10.5
+      vertex 59.2928 -75.6025 0
+      vertex 59.2928 -75.6025 10.5
+    endloop
+  endfacet
+  facet normal 0.794741 -0.606949 0
+    outer loop
+      vertex 59.2928 -75.6025 0
+      vertex 59.0546 -75.9144 10.5
+      vertex 59.0546 -75.9144 0
+    endloop
+  endfacet
+  facet normal 0.661116 -0.750284 0
+    outer loop
+      vertex 59.5605 -75.3153 0
+      vertex 59.855 -75.0558 10.5
+      vertex 59.5605 -75.3153 10.5
+    endloop
+  endfacet
+  facet normal 0.661116 -0.750284 0
+    outer loop
+      vertex 59.855 -75.0558 10.5
+      vertex 59.5605 -75.3153 0
+      vertex 59.855 -75.0558 0
+    endloop
+  endfacet
+  facet normal 0.850493 -0.525986 0
+    outer loop
+      vertex 58.8481 -76.2483 10.5
+      vertex 59.0546 -75.9144 0
+      vertex 59.0546 -75.9144 10.5
+    endloop
+  endfacet
+  facet normal 0.850493 -0.525986 0
+    outer loop
+      vertex 59.0546 -75.9144 0
+      vertex 58.8481 -76.2483 10.5
+      vertex 58.8481 -76.2483 0
+    endloop
+  endfacet
+  facet normal -0.731631 0.681701 0
+    outer loop
+      vertex 65.1375 -81.051 0
+      vertex 65.4051 -80.7638 10.5
+      vertex 65.4051 -80.7638 0
+    endloop
+  endfacet
+  facet normal -0.731631 0.681701 0
+    outer loop
+      vertex 65.4051 -80.7638 10.5
+      vertex 65.1375 -81.051 0
+      vertex 65.1375 -81.051 10.5
+    endloop
+  endfacet
+  facet normal 0.946131 0.323784 0
+    outer loop
+      vertex 58.6324 -79.6619 10.5
+      vertex 58.5053 -79.2905 0
+      vertex 58.5053 -79.2905 10.5
+    endloop
+  endfacet
+  facet normal 0.946131 0.323784 0
+    outer loop
+      vertex 58.5053 -79.2905 0
+      vertex 58.6324 -79.6619 10.5
+      vertex 58.6324 -79.6619 0
+    endloop
+  endfacet
+  facet normal 0.606826 0.794835 -0
+    outer loop
+      vertex 60.0803 -81.4775 0
+      vertex 59.7683 -81.2393 10.5
+      vertex 60.0803 -81.4775 10.5
+    endloop
+  endfacet
+  facet normal 0.606826 0.794835 0
+    outer loop
+      vertex 59.7683 -81.2393 10.5
+      vertex 60.0803 -81.4775 0
+      vertex 59.7683 -81.2393 0
+    endloop
+  endfacet
+  facet normal -0.897865 0.44027 0
+    outer loop
+      vertex 65.8499 -80.118 0
+      vertex 66.0227 -79.7656 10.5
+      vertex 66.0227 -79.7656 0
+    endloop
+  endfacet
+  facet normal -0.897865 0.44027 0
+    outer loop
+      vertex 66.0227 -79.7656 10.5
+      vertex 65.8499 -80.118 0
+      vertex 65.8499 -80.118 10.5
+    endloop
+  endfacet
+  facet normal -0.946209 -0.323556 0
+    outer loop
+      vertex 66.1926 -77.0758 0
+      vertex 66.0656 -76.7044 10.5
+      vertex 66.0656 -76.7044 0
+    endloop
+  endfacet
+  facet normal -0.946209 -0.323556 0
+    outer loop
+      vertex 66.0656 -76.7044 10.5
+      vertex 66.1926 -77.0758 0
+      vertex 66.1926 -77.0758 10.5
+    endloop
+  endfacet
+  facet normal 0.731504 -0.681837 0
+    outer loop
+      vertex 59.2928 -75.6025 10.5
+      vertex 59.5605 -75.3153 0
+      vertex 59.5605 -75.3153 10.5
+    endloop
+  endfacet
+  facet normal 0.731504 -0.681837 0
+    outer loop
+      vertex 59.5605 -75.3153 0
+      vertex 59.2928 -75.6025 10.5
+      vertex 59.2928 -75.6025 0
+    endloop
+  endfacet
+  facet normal -0.229267 0.973364 0
+    outer loop
+      vertex 63.4563 -82.0268 0
+      vertex 63.0742 -82.1168 10.5
+      vertex 63.4563 -82.0268 10.5
+    endloop
+  endfacet
+  facet normal -0.229267 0.973364 0
+    outer loop
+      vertex 63.0742 -82.1168 10.5
+      vertex 63.4563 -82.0268 0
+      vertex 63.0742 -82.1168 0
+    endloop
+  endfacet
+  facet normal 0.811438 0.584439 0
+    outer loop
+      vertex 59.2217 -80.6771 10.5
+      vertex 58.9923 -80.3586 0
+      vertex 58.9923 -80.3586 10.5
+    endloop
+  endfacet
+  facet normal 0.811438 0.584439 0
+    outer loop
+      vertex 58.9923 -80.3586 0
+      vertex 59.2217 -80.6771 10.5
+      vertex 59.2217 -80.6771 0
+    endloop
+  endfacet
+  facet normal -0.132998 0.991116 0
+    outer loop
+      vertex 63.0742 -82.1168 0
+      vertex 62.6852 -82.169 10.5
+      vertex 63.0742 -82.1168 10.5
+    endloop
+  endfacet
+  facet normal -0.132998 0.991116 0
+    outer loop
+      vertex 62.6852 -82.169 10.5
+      vertex 63.0742 -82.1168 0
+      vertex 62.6852 -82.169 0
+    endloop
+  endfacet
+  facet normal 0.909947 0.414724 0
+    outer loop
+      vertex 58.7952 -80.0191 10.5
+      vertex 58.6324 -79.6619 0
+      vertex 58.6324 -79.6619 10.5
+    endloop
+  endfacet
+  facet normal 0.909947 0.414724 0
+    outer loop
+      vertex 58.6324 -79.6619 0
+      vertex 58.7952 -80.0191 10.5
+      vertex 58.7952 -80.0191 0
+    endloop
+  endfacet
+  facet normal 0.132965 -0.991121 0
+    outer loop
+      vertex 61.6237 -74.2495 0
+      vertex 62.0128 -74.1973 10.5
+      vertex 61.6237 -74.2495 10.5
+    endloop
+  endfacet
+  facet normal 0.132965 -0.991121 0
+    outer loop
+      vertex 62.0128 -74.1973 10.5
+      vertex 61.6237 -74.2495 0
+      vertex 62.0128 -74.1973 0
+    endloop
+  endfacet
+  facet normal -0.909947 -0.414724 0
+    outer loop
+      vertex 66.0656 -76.7044 0
+      vertex 65.9028 -76.3472 10.5
+      vertex 65.9028 -76.3472 0
+    endloop
+  endfacet
+  facet normal -0.909947 -0.414724 0
+    outer loop
+      vertex 65.9028 -76.3472 10.5
+      vertex 66.0656 -76.7044 0
+      vertex 66.0656 -76.7044 10.5
+    endloop
+  endfacet
+  facet normal -0.606826 -0.794835 0
+    outer loop
+      vertex 64.6177 -74.8888 0
+      vertex 64.9297 -75.127 10.5
+      vertex 64.6177 -74.8888 10.5
+    endloop
+  endfacet
+  facet normal -0.606826 -0.794835 -0
+    outer loop
+      vertex 64.9297 -75.127 10.5
+      vertex 64.6177 -74.8888 0
+      vertex 64.9297 -75.127 0
+    endloop
+  endfacet
+  facet normal -0.256537 -0.966534 0
+    outer loop
+      vertex 63.1843 -74.2713 0
+      vertex 63.5637 -74.372 10.5
+      vertex 63.1843 -74.2713 10.5
+    endloop
+  endfacet
+  facet normal -0.256537 -0.966534 -0
+    outer loop
+      vertex 63.5637 -74.372 10.5
+      vertex 63.1843 -74.2713 0
+      vertex 63.5637 -74.372 0
+    endloop
+  endfacet
+  facet normal 0.440169 0.897915 -0
+    outer loop
+      vertex 60.7666 -81.8568 0
+      vertex 60.4141 -81.684 10.5
+      vertex 60.7666 -81.8568 10.5
+    endloop
+  endfacet
+  facet normal 0.440169 0.897915 0
+    outer loop
+      vertex 60.4141 -81.684 10.5
+      vertex 60.7666 -81.8568 0
+      vertex 60.4141 -81.684 0
+    endloop
+  endfacet
+  facet normal -0.0631872 -0.998002 0
+    outer loop
+      vertex 62.4051 -74.1835 0
+      vertex 62.7968 -74.2083 10.5
+      vertex 62.4051 -74.1835 10.5
+    endloop
+  endfacet
+  facet normal -0.0631872 -0.998002 -0
+    outer loop
+      vertex 62.7968 -74.2083 10.5
+      vertex 62.4051 -74.1835 0
+      vertex 62.7968 -74.2083 0
+    endloop
+  endfacet
+  facet normal -0.850493 0.525986 0
+    outer loop
+      vertex 65.6434 -80.4519 0
+      vertex 65.8499 -80.118 10.5
+      vertex 65.8499 -80.118 0
+    endloop
+  endfacet
+  facet normal -0.850493 0.525986 0
+    outer loop
+      vertex 65.8499 -80.118 10.5
+      vertex 65.6434 -80.4519 0
+      vertex 65.6434 -80.4519 10.5
+    endloop
+  endfacet
+  facet normal -0.998002 0.0631872 0
+    outer loop
+      vertex 66.3238 -78.631 0
+      vertex 66.3486 -78.2393 10.5
+      vertex 66.3486 -78.2393 0
+    endloop
+  endfacet
+  facet normal -0.998002 0.0631872 0
+    outer loop
+      vertex 66.3486 -78.2393 10.5
+      vertex 66.3238 -78.631 0
+      vertex 66.3238 -78.631 10.5
+    endloop
+  endfacet
+  facet normal 0.229267 -0.973364 0
+    outer loop
+      vertex 61.2416 -74.3395 0
+      vertex 61.6237 -74.2495 10.5
+      vertex 61.2416 -74.3395 10.5
+    endloop
+  endfacet
+  facet normal 0.229267 -0.973364 0
+    outer loop
+      vertex 61.6237 -74.2495 10.5
+      vertex 61.2416 -74.3395 0
+      vertex 61.6237 -74.2495 0
+    endloop
+  endfacet
+  facet normal 0.415031 -0.909807 0
+    outer loop
+      vertex 60.5131 -74.6294 0
+      vertex 60.8702 -74.4665 10.5
+      vertex 60.5131 -74.6294 10.5
+    endloop
+  endfacet
+  facet normal 0.415031 -0.909807 0
+    outer loop
+      vertex 60.8702 -74.4665 10.5
+      vertex 60.5131 -74.6294 0
+      vertex 60.8702 -74.4665 0
+    endloop
+  endfacet
+  facet normal -0.973307 -0.229508 0
+    outer loop
+      vertex 66.2827 -77.4579 0
+      vertex 66.1926 -77.0758 10.5
+      vertex 66.1926 -77.0758 0
+    endloop
+  endfacet
+  facet normal -0.973307 -0.229508 0
+    outer loop
+      vertex 66.1926 -77.0758 10.5
+      vertex 66.2827 -77.4579 0
+      vertex 66.2827 -77.4579 10.5
+    endloop
+  endfacet
+  facet normal -0.98704 0.160474 0
+    outer loop
+      vertex 66.2608 -79.0185 0
+      vertex 66.3238 -78.631 10.5
+      vertex 66.3238 -78.631 0
+    endloop
+  endfacet
+  facet normal -0.98704 0.160474 0
+    outer loop
+      vertex 66.3238 -78.631 10.5
+      vertex 66.2608 -79.0185 0
+      vertex 66.2608 -79.0185 10.5
+    endloop
+  endfacet
+  facet normal -0.999382 -0.0351465 0
+    outer loop
+      vertex 66.3486 -78.2393 0
+      vertex 66.3348 -77.8469 10.5
+      vertex 66.3348 -77.8469 0
+    endloop
+  endfacet
+  facet normal -0.999382 -0.0351465 0
+    outer loop
+      vertex 66.3348 -77.8469 10.5
+      vertex 66.3486 -78.2393 0
+      vertex 66.3486 -78.2393 10.5
+    endloop
+  endfacet
+  facet normal -0.160474 -0.98704 0
+    outer loop
+      vertex 62.7968 -74.2083 0
+      vertex 63.1843 -74.2713 10.5
+      vertex 62.7968 -74.2083 10.5
+    endloop
+  endfacet
+  facet normal -0.160474 -0.98704 -0
+    outer loop
+      vertex 63.1843 -74.2713 10.5
+      vertex 62.7968 -74.2083 0
+      vertex 63.1843 -74.2713 0
+    endloop
+  endfacet
+  facet normal -0.99115 -0.132748 0
+    outer loop
+      vertex 66.3348 -77.8469 0
+      vertex 66.2827 -77.4579 10.5
+      vertex 66.2827 -77.4579 0
+    endloop
+  endfacet
+  facet normal -0.99115 -0.132748 0
+    outer loop
+      vertex 66.2827 -77.4579 10.5
+      vertex 66.3348 -77.8469 0
+      vertex 66.3348 -77.8469 10.5
+    endloop
+  endfacet
+  facet normal 0.681964 0.731386 -0
+    outer loop
+      vertex 59.7683 -81.2393 0
+      vertex 59.4812 -80.9716 10.5
+      vertex 59.7683 -81.2393 10.5
+    endloop
+  endfacet
+  facet normal 0.681964 0.731386 0
+    outer loop
+      vertex 59.4812 -80.9716 10.5
+      vertex 59.7683 -81.2393 0
+      vertex 59.4812 -80.9716 0
+    endloop
+  endfacet
+  facet normal -0.5261 -0.850423 0
+    outer loop
+      vertex 64.2839 -74.6823 0
+      vertex 64.6177 -74.8888 10.5
+      vertex 64.2839 -74.6823 10.5
+    endloop
+  endfacet
+  facet normal -0.5261 -0.850423 -0
+    outer loop
+      vertex 64.6177 -74.8888 10.5
+      vertex 64.2839 -74.6823 0
+      vertex 64.6177 -74.8888 0
+    endloop
+  endfacet
+  facet normal -0.414935 0.909851 0
+    outer loop
+      vertex 64.1849 -81.7369 0
+      vertex 63.8277 -81.8998 10.5
+      vertex 64.1849 -81.7369 10.5
+    endloop
+  endfacet
+  facet normal -0.414935 0.909851 0
+    outer loop
+      vertex 63.8277 -81.8998 10.5
+      vertex 64.1849 -81.7369 0
+      vertex 63.8277 -81.8998 0
+    endloop
+  endfacet
+  facet normal 0.0351554 -0.999382 0
+    outer loop
+      vertex 62.0128 -74.1973 0
+      vertex 62.4051 -74.1835 10.5
+      vertex 62.0128 -74.1973 10.5
+    endloop
+  endfacet
+  facet normal 0.0351554 -0.999382 0
+    outer loop
+      vertex 62.4051 -74.1835 10.5
+      vertex 62.0128 -74.1973 0
+      vertex 62.4051 -74.1835 0
+    endloop
+  endfacet
+  facet normal -0.50189 0.864932 0
+    outer loop
+      vertex 64.5244 -81.5399 0
+      vertex 64.1849 -81.7369 10.5
+      vertex 64.5244 -81.5399 10.5
+    endloop
+  endfacet
+  facet normal -0.50189 0.864932 0
+    outer loop
+      vertex 64.1849 -81.7369 10.5
+      vertex 64.5244 -81.5399 0
+      vertex 64.1849 -81.7369 0
+    endloop
+  endfacet
+  facet normal 0.256775 0.966471 -0
+    outer loop
+      vertex 61.5137 -82.095 0
+      vertex 61.1343 -81.9942 10.5
+      vertex 61.5137 -82.095 10.5
+    endloop
+  endfacet
+  facet normal 0.256775 0.966471 0
+    outer loop
+      vertex 61.1343 -81.9942 10.5
+      vertex 61.5137 -82.095 0
+      vertex 61.1343 -81.9942 0
+    endloop
+  endfacet
+  facet normal -0.864821 -0.50208 0
+    outer loop
+      vertex 65.9028 -76.3472 0
+      vertex 65.7057 -76.0077 10.5
+      vertex 65.7057 -76.0077 0
+    endloop
+  endfacet
+  facet normal -0.864821 -0.50208 0
+    outer loop
+      vertex 65.7057 -76.0077 10.5
+      vertex 65.9028 -76.3472 0
+      vertex 65.9028 -76.3472 10.5
+    endloop
+  endfacet
+  facet normal 0.160514 0.987034 -0
+    outer loop
+      vertex 61.9011 -82.158 0
+      vertex 61.5137 -82.095 10.5
+      vertex 61.9011 -82.158 10.5
+    endloop
+  endfacet
+  facet normal 0.160514 0.987034 0
+    outer loop
+      vertex 61.5137 -82.095 10.5
+      vertex 61.9011 -82.158 0
+      vertex 61.5137 -82.095 0
+    endloop
+  endfacet
+  facet normal 0.584318 -0.811525 0
+    outer loop
+      vertex 59.855 -75.0558 0
+      vertex 60.1736 -74.8264 10.5
+      vertex 59.855 -75.0558 10.5
+    endloop
+  endfacet
+  facet normal 0.584318 -0.811525 0
+    outer loop
+      vertex 60.1736 -74.8264 10.5
+      vertex 59.855 -75.0558 0
+      vertex 60.1736 -74.8264 0
+    endloop
+  endfacet
+  facet normal 0.987 -0.160722 0
+    outer loop
+      vertex 58.3741 -77.7353 10.5
+      vertex 58.4372 -77.3478 0
+      vertex 58.4372 -77.3478 10.5
+    endloop
+  endfacet
+  facet normal 0.987 -0.160722 0
+    outer loop
+      vertex 58.4372 -77.3478 0
+      vertex 58.3741 -77.7353 10.5
+      vertex 58.3741 -77.7353 0
+    endloop
+  endfacet
+  facet normal 0.966534 -0.256537 0
+    outer loop
+      vertex 58.4372 -77.3478 10.5
+      vertex 58.5379 -76.9684 0
+      vertex 58.5379 -76.9684 10.5
+    endloop
+  endfacet
+  facet normal 0.966534 -0.256537 0
+    outer loop
+      vertex 58.5379 -76.9684 0
+      vertex 58.4372 -77.3478 10.5
+      vertex 58.4372 -77.3478 0
+    endloop
+  endfacet
+  facet normal -0.323556 0.946209 0
+    outer loop
+      vertex 63.8277 -81.8998 0
+      vertex 63.4563 -82.0268 10.5
+      vertex 63.8277 -81.8998 10.5
+    endloop
+  endfacet
+  facet normal -0.323556 0.946209 0
+    outer loop
+      vertex 63.4563 -82.0268 10.5
+      vertex 63.8277 -81.8998 0
+      vertex 63.4563 -82.0268 0
+    endloop
+  endfacet
+  facet normal 0.50189 -0.864932 0
+    outer loop
+      vertex 60.1736 -74.8264 0
+      vertex 60.5131 -74.6294 10.5
+      vertex 60.1736 -74.8264 10.5
+    endloop
+  endfacet
+  facet normal 0.50189 -0.864932 0
+    outer loop
+      vertex 60.5131 -74.6294 10.5
+      vertex 60.1736 -74.8264 0
+      vertex 60.5131 -74.6294 0
+    endloop
+  endfacet
+  facet normal 0.991121 0.132965 0
+    outer loop
+      vertex 58.4153 -78.9084 10.5
+      vertex 58.3631 -78.5193 0
+      vertex 58.3631 -78.5193 10.5
+    endloop
+  endfacet
+  facet normal 0.991121 0.132965 0
+    outer loop
+      vertex 58.3631 -78.5193 0
+      vertex 58.4153 -78.9084 10.5
+      vertex 58.4153 -78.9084 0
+    endloop
+  endfacet
+  facet normal 0.864821 0.50208 0
+    outer loop
+      vertex 58.9923 -80.3586 10.5
+      vertex 58.7952 -80.0191 0
+      vertex 58.7952 -80.0191 10.5
+    endloop
+  endfacet
+  facet normal 0.864821 0.50208 0
+    outer loop
+      vertex 58.7952 -80.0191 0
+      vertex 58.9923 -80.3586 10.5
+      vertex 58.9923 -80.3586 0
+    endloop
+  endfacet
+  facet normal 0.99939 0.0349099 0
+    outer loop
+      vertex 58.3631 -78.5193 10.5
+      vertex 58.3494 -78.1271 0
+      vertex 58.3494 -78.1271 10.5
+    endloop
+  endfacet
+  facet normal 0.99939 0.0349099 0
+    outer loop
+      vertex 58.3494 -78.1271 0
+      vertex 58.3631 -78.5193 10.5
+      vertex 58.3631 -78.5193 0
+    endloop
+  endfacet
+  facet normal 0.936737 -0.350034 0
+    outer loop
+      vertex 58.5379 -76.9684 10.5
+      vertex 58.6753 -76.6007 0
+      vertex 58.6753 -76.6007 10.5
+    endloop
+  endfacet
+  facet normal 0.936737 -0.350034 0
+    outer loop
+      vertex 58.6753 -76.6007 0
+      vertex 58.5379 -76.9684 10.5
+      vertex 58.5379 -76.9684 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 108 -52.0101 10.5
+      vertex 108 52.0101 0
+      vertex 108 52.0101 10.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 108 52.0101 0
+      vertex 108 -52.0101 10.5
+      vertex 108 -52.0101 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 40 -19.263 0
+      vertex 40 19.263 3.25
+      vertex 40 19.263 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 40 19.263 3.25
+      vertex 40 -19.263 0
+      vertex 40 -19.263 3.25
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 92 -44.3049 6
+      vertex 92 44.3049 10.5
+      vertex 92 44.3049 6
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 92 44.3049 10.5
+      vertex 92 -44.3049 6
+      vertex 92 -44.3049 10.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 82 -39.4891 3.25
+      vertex 82 39.4891 6
+      vertex 82 39.4891 3.25
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 82 39.4891 6
+      vertex 82 -39.4891 3.25
+      vertex 82 -39.4891 6
+    endloop
+  endfacet
+  facet normal 0.049061 -0.998796 0
+    outer loop
+      vertex 99.6079 3.98074 0
+      vertex 100 4 10.5
+      vertex 99.6079 3.98074 10.5
+    endloop
+  endfacet
+  facet normal 0.049061 -0.998796 0
+    outer loop
+      vertex 100 4 10.5
+      vertex 99.6079 3.98074 0
+      vertex 100 4 0
+    endloop
+  endfacet
+  facet normal -0.998828 -0.0484042 0
+    outer loop
+      vertex 104 0 0
+      vertex 103.981 0.392068 10.5
+      vertex 103.981 0.392068 0
+    endloop
+  endfacet
+  facet normal -0.998828 -0.0484042 0
+    outer loop
+      vertex 103.981 0.392068 10.5
+      vertex 104 0 0
+      vertex 104 0 10.5
+    endloop
+  endfacet
+  facet normal 0.514084 -0.85774 0
+    outer loop
+      vertex 97.7777 3.32588 0
+      vertex 98.1144 3.52768 10.5
+      vertex 97.7777 3.32588 10.5
+    endloop
+  endfacet
+  facet normal 0.514084 -0.85774 0
+    outer loop
+      vertex 98.1144 3.52768 10.5
+      vertex 97.7777 3.32588 0
+      vertex 98.1144 3.52768 0
+    endloop
+  endfacet
+  facet normal -0.803006 -0.59597 0
+    outer loop
+      vertex 103.326 2.22228 0
+      vertex 103.092 2.53757 10.5
+      vertex 103.092 2.53757 0
+    endloop
+  endfacet
+  facet normal -0.803006 -0.59597 0
+    outer loop
+      vertex 103.092 2.53757 10.5
+      vertex 103.326 2.22228 0
+      vertex 103.326 2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0.904025 0.42748 0
+    outer loop
+      vertex 96.4723 -1.88559 10.5
+      vertex 96.3045 -1.53073 0
+      vertex 96.3045 -1.53073 10.5
+    endloop
+  endfacet
+  facet normal 0.904025 0.42748 0
+    outer loop
+      vertex 96.3045 -1.53073 0
+      vertex 96.4723 -1.88559 10.5
+      vertex 96.4723 -1.88559 0
+    endloop
+  endfacet
+  facet normal -0.970259 -0.242069 0
+    outer loop
+      vertex 103.923 0.780361 0
+      vertex 103.828 1.16114 10.5
+      vertex 103.828 1.16114 0
+    endloop
+  endfacet
+  facet normal -0.970259 -0.242069 0
+    outer loop
+      vertex 103.828 1.16114 10.5
+      vertex 103.923 0.780361 0
+      vertex 103.923 0.780361 10.5
+    endloop
+  endfacet
+  facet normal -0.998828 0.0484042 0
+    outer loop
+      vertex 103.981 -0.392068 0
+      vertex 104 0 10.5
+      vertex 104 0 0
+    endloop
+  endfacet
+  facet normal -0.998828 0.0484042 0
+    outer loop
+      vertex 104 0 10.5
+      vertex 103.981 -0.392068 0
+      vertex 103.981 -0.392068 10.5
+    endloop
+  endfacet
+  facet normal -0.514871 0.857268 0
+    outer loop
+      vertex 102.222 -3.32588 0
+      vertex 101.886 -3.52768 10.5
+      vertex 102.222 -3.32588 10.5
+    endloop
+  endfacet
+  facet normal -0.514871 0.857268 0
+    outer loop
+      vertex 101.886 -3.52768 10.5
+      vertex 102.222 -3.32588 0
+      vertex 101.886 -3.52768 0
+    endloop
+  endfacet
+  facet normal -0.336556 0.941664 0
+    outer loop
+      vertex 101.531 -3.69552 0
+      vertex 101.161 -3.82776 10.5
+      vertex 101.531 -3.69552 10.5
+    endloop
+  endfacet
+  facet normal -0.336556 0.941664 0
+    outer loop
+      vertex 101.161 -3.82776 10.5
+      vertex 101.531 -3.69552 0
+      vertex 101.161 -3.82776 0
+    endloop
+  endfacet
+  facet normal -0.803006 0.59597 0
+    outer loop
+      vertex 103.092 -2.53757 0
+      vertex 103.326 -2.22228 10.5
+      vertex 103.326 -2.22228 0
+    endloop
+  endfacet
+  facet normal -0.803006 0.59597 0
+    outer loop
+      vertex 103.326 -2.22228 10.5
+      vertex 103.092 -2.53757 0
+      vertex 103.092 -2.53757 10.5
+    endloop
+  endfacet
+  facet normal -0.74047 0.67209 0
+    outer loop
+      vertex 102.828 -2.82843 0
+      vertex 103.092 -2.53757 10.5
+      vertex 103.092 -2.53757 0
+    endloop
+  endfacet
+  facet normal -0.74047 0.67209 0
+    outer loop
+      vertex 103.092 -2.53757 10.5
+      vertex 102.828 -2.82843 0
+      vertex 102.828 -2.82843 10.5
+    endloop
+  endfacet
+  facet normal 0.427523 -0.904004 0
+    outer loop
+      vertex 98.1144 3.52768 0
+      vertex 98.4693 3.69552 10.5
+      vertex 98.1144 3.52768 10.5
+    endloop
+  endfacet
+  facet normal 0.427523 -0.904004 0
+    outer loop
+      vertex 98.4693 3.69552 10.5
+      vertex 98.1144 3.52768 0
+      vertex 98.4693 3.69552 0
+    endloop
+  endfacet
+  facet normal -0.0490735 -0.998795 0
+    outer loop
+      vertex 100 4 0
+      vertex 100.392 3.98074 10.5
+      vertex 100 4 10.5
+    endloop
+  endfacet
+  facet normal -0.0490735 -0.998795 -0
+    outer loop
+      vertex 100.392 3.98074 10.5
+      vertex 100 4 0
+      vertex 100.392 3.98074 0
+    endloop
+  endfacet
+  facet normal 0.427523 0.904004 -0
+    outer loop
+      vertex 98.4693 -3.69552 0
+      vertex 98.1144 -3.52768 10.5
+      vertex 98.4693 -3.69552 10.5
+    endloop
+  endfacet
+  facet normal 0.427523 0.904004 0
+    outer loop
+      vertex 98.1144 -3.52768 10.5
+      vertex 98.4693 -3.69552 0
+      vertex 98.1144 -3.52768 0
+    endloop
+  endfacet
+  facet normal 0.146733 -0.989176 0
+    outer loop
+      vertex 99.2196 3.92314 0
+      vertex 99.6079 3.98074 10.5
+      vertex 99.2196 3.92314 10.5
+    endloop
+  endfacet
+  facet normal 0.146733 -0.989176 0
+    outer loop
+      vertex 99.6079 3.98074 10.5
+      vertex 99.2196 3.92314 0
+      vertex 99.6079 3.98074 0
+    endloop
+  endfacet
+  facet normal 0.941497 -0.337022 0
+    outer loop
+      vertex 96.1722 1.16114 10.5
+      vertex 96.3045 1.53073 0
+      vertex 96.3045 1.53073 10.5
+    endloop
+  endfacet
+  facet normal 0.941497 -0.337022 0
+    outer loop
+      vertex 96.3045 1.53073 0
+      vertex 96.1722 1.16114 10.5
+      vertex 96.1722 1.16114 0
+    endloop
+  endfacet
+  facet normal 0.671621 0.740895 -0
+    outer loop
+      vertex 97.4624 -3.09204 0
+      vertex 97.1716 -2.82843 10.5
+      vertex 97.4624 -3.09204 10.5
+    endloop
+  endfacet
+  facet normal 0.671621 0.740895 0
+    outer loop
+      vertex 97.1716 -2.82843 10.5
+      vertex 97.4624 -3.09204 0
+      vertex 97.1716 -2.82843 0
+    endloop
+  endfacet
+  facet normal -0.0490735 0.998795 0
+    outer loop
+      vertex 100.392 -3.98074 0
+      vertex 100 -4 10.5
+      vertex 100.392 -3.98074 10.5
+    endloop
+  endfacet
+  facet normal -0.0490735 0.998795 0
+    outer loop
+      vertex 100 -4 10.5
+      vertex 100.392 -3.98074 0
+      vertex 100 -4 0
+    endloop
+  endfacet
+  facet normal -0.857509 -0.51447 0
+    outer loop
+      vertex 103.528 1.88559 0
+      vertex 103.326 2.22228 10.5
+      vertex 103.326 2.22228 0
+    endloop
+  endfacet
+  facet normal -0.857509 -0.51447 0
+    outer loop
+      vertex 103.326 2.22228 10.5
+      vertex 103.528 1.88559 0
+      vertex 103.528 1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0.970079 0.242788 0
+    outer loop
+      vertex 96.1722 -1.16114 10.5
+      vertex 96.0769 -0.780361 0
+      vertex 96.0769 -0.780361 10.5
+    endloop
+  endfacet
+  facet normal 0.970079 0.242788 0
+    outer loop
+      vertex 96.0769 -0.780361 0
+      vertex 96.1722 -1.16114 10.5
+      vertex 96.1722 -1.16114 0
+    endloop
+  endfacet
+  facet normal 0.998791 0.0491666 0
+    outer loop
+      vertex 96.0193 -0.392068 10.5
+      vertex 96 0 0
+      vertex 96 0 10.5
+    endloop
+  endfacet
+  facet normal 0.998791 0.0491666 0
+    outer loop
+      vertex 96 0 0
+      vertex 96.0193 -0.392068 10.5
+      vertex 96.0193 -0.392068 0
+    endloop
+  endfacet
+  facet normal 0.941497 0.337022 0
+    outer loop
+      vertex 96.3045 -1.53073 10.5
+      vertex 96.1722 -1.16114 0
+      vertex 96.1722 -1.16114 10.5
+    endloop
+  endfacet
+  facet normal 0.941497 0.337022 0
+    outer loop
+      vertex 96.1722 -1.16114 0
+      vertex 96.3045 -1.53073 10.5
+      vertex 96.3045 -1.53073 0
+    endloop
+  endfacet
+  facet normal -0.989027 -0.147733 0
+    outer loop
+      vertex 103.981 0.392068 0
+      vertex 103.923 0.780361 10.5
+      vertex 103.923 0.780361 0
+    endloop
+  endfacet
+  facet normal -0.989027 -0.147733 0
+    outer loop
+      vertex 103.923 0.780361 10.5
+      vertex 103.981 0.392068 0
+      vertex 103.981 0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0.336879 0.941548 -0
+    outer loop
+      vertex 98.8389 -3.82776 0
+      vertex 98.4693 -3.69552 10.5
+      vertex 98.8389 -3.82776 10.5
+    endloop
+  endfacet
+  facet normal 0.336879 0.941548 0
+    outer loop
+      vertex 98.4693 -3.69552 10.5
+      vertex 98.8389 -3.82776 0
+      vertex 98.4693 -3.69552 0
+    endloop
+  endfacet
+  facet normal -0.242847 0.970065 0
+    outer loop
+      vertex 101.161 -3.82776 0
+      vertex 100.78 -3.92314 10.5
+      vertex 101.161 -3.82776 10.5
+    endloop
+  endfacet
+  facet normal -0.242847 0.970065 0
+    outer loop
+      vertex 100.78 -3.92314 10.5
+      vertex 101.161 -3.82776 0
+      vertex 100.78 -3.92314 0
+    endloop
+  endfacet
+  facet normal -0.903828 -0.427896 0
+    outer loop
+      vertex 103.696 1.53073 0
+      vertex 103.528 1.88559 10.5
+      vertex 103.528 1.88559 0
+    endloop
+  endfacet
+  facet normal -0.903828 -0.427896 0
+    outer loop
+      vertex 103.528 1.88559 10.5
+      vertex 103.696 1.53073 0
+      vertex 103.696 1.53073 10.5
+    endloop
+  endfacet
+  facet normal -0.336556 -0.941664 0
+    outer loop
+      vertex 101.161 3.82776 0
+      vertex 101.531 3.69552 10.5
+      vertex 101.161 3.82776 10.5
+    endloop
+  endfacet
+  facet normal -0.336556 -0.941664 -0
+    outer loop
+      vertex 101.531 3.69552 10.5
+      vertex 101.161 3.82776 0
+      vertex 101.531 3.69552 0
+    endloop
+  endfacet
+  facet normal 0.989176 0.146736 0
+    outer loop
+      vertex 96.0769 -0.780361 10.5
+      vertex 96.0193 -0.392068 0
+      vertex 96.0193 -0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0.989176 0.146736 0
+    outer loop
+      vertex 96.0193 -0.392068 0
+      vertex 96.0769 -0.780361 10.5
+      vertex 96.0769 -0.780361 0
+    endloop
+  endfacet
+  facet normal -0.903828 0.427896 0
+    outer loop
+      vertex 103.528 -1.88559 0
+      vertex 103.696 -1.53073 10.5
+      vertex 103.696 -1.53073 0
+    endloop
+  endfacet
+  facet normal -0.903828 0.427896 0
+    outer loop
+      vertex 103.696 -1.53073 10.5
+      vertex 103.528 -1.88559 0
+      vertex 103.528 -1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0.049061 0.998796 -0
+    outer loop
+      vertex 100 -4 0
+      vertex 99.6079 -3.98074 10.5
+      vertex 100 -4 10.5
+    endloop
+  endfacet
+  facet normal 0.049061 0.998796 0
+    outer loop
+      vertex 99.6079 -3.98074 10.5
+      vertex 100 -4 0
+      vertex 99.6079 -3.98074 0
+    endloop
+  endfacet
+  facet normal -0.857509 0.51447 0
+    outer loop
+      vertex 103.326 -2.22228 0
+      vertex 103.528 -1.88559 10.5
+      vertex 103.528 -1.88559 0
+    endloop
+  endfacet
+  facet normal -0.857509 0.51447 0
+    outer loop
+      vertex 103.528 -1.88559 10.5
+      vertex 103.326 -2.22228 0
+      vertex 103.326 -2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0.243027 0.970019 -0
+    outer loop
+      vertex 99.2196 -3.92314 0
+      vertex 98.8389 -3.82776 10.5
+      vertex 99.2196 -3.92314 10.5
+    endloop
+  endfacet
+  facet normal 0.243027 0.970019 0
+    outer loop
+      vertex 98.8389 -3.82776 10.5
+      vertex 99.2196 -3.92314 0
+      vertex 98.8389 -3.82776 0
+    endloop
+  endfacet
+  facet normal 0.857733 -0.514095 0
+    outer loop
+      vertex 96.4723 1.88559 10.5
+      vertex 96.6741 2.22228 0
+      vertex 96.6741 2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0.857733 -0.514095 0
+    outer loop
+      vertex 96.6741 2.22228 0
+      vertex 96.4723 1.88559 10.5
+      vertex 96.4723 1.88559 0
+    endloop
+  endfacet
+  facet normal -0.242847 -0.970065 0
+    outer loop
+      vertex 100.78 3.92314 0
+      vertex 101.161 3.82776 10.5
+      vertex 100.78 3.92314 10.5
+    endloop
+  endfacet
+  facet normal -0.242847 -0.970065 -0
+    outer loop
+      vertex 101.161 3.82776 10.5
+      vertex 100.78 3.92314 0
+      vertex 101.161 3.82776 0
+    endloop
+  endfacet
+  facet normal 0.243027 -0.970019 0
+    outer loop
+      vertex 98.8389 3.82776 0
+      vertex 99.2196 3.92314 10.5
+      vertex 98.8389 3.82776 10.5
+    endloop
+  endfacet
+  facet normal 0.243027 -0.970019 0
+    outer loop
+      vertex 99.2196 3.92314 10.5
+      vertex 98.8389 3.82776 0
+      vertex 99.2196 3.92314 0
+    endloop
+  endfacet
+  facet normal 0.595695 -0.80321 0
+    outer loop
+      vertex 97.4624 3.09204 0
+      vertex 97.7777 3.32588 10.5
+      vertex 97.4624 3.09204 10.5
+    endloop
+  endfacet
+  facet normal 0.595695 -0.80321 0
+    outer loop
+      vertex 97.7777 3.32588 10.5
+      vertex 97.4624 3.09204 0
+      vertex 97.7777 3.32588 0
+    endloop
+  endfacet
+  facet normal -0.427425 0.904051 0
+    outer loop
+      vertex 101.886 -3.52768 0
+      vertex 101.531 -3.69552 10.5
+      vertex 101.886 -3.52768 10.5
+    endloop
+  endfacet
+  facet normal -0.427425 0.904051 0
+    outer loop
+      vertex 101.531 -3.69552 10.5
+      vertex 101.886 -3.52768 0
+      vertex 101.531 -3.69552 0
+    endloop
+  endfacet
+  facet normal 0.740977 -0.671531 0
+    outer loop
+      vertex 96.908 2.53757 10.5
+      vertex 97.1716 2.82843 0
+      vertex 97.1716 2.82843 10.5
+    endloop
+  endfacet
+  facet normal 0.740977 -0.671531 0
+    outer loop
+      vertex 97.1716 2.82843 0
+      vertex 96.908 2.53757 10.5
+      vertex 96.908 2.53757 0
+    endloop
+  endfacet
+  facet normal -0.941739 -0.336344 0
+    outer loop
+      vertex 103.828 1.16114 0
+      vertex 103.696 1.53073 10.5
+      vertex 103.696 1.53073 0
+    endloop
+  endfacet
+  facet normal -0.941739 -0.336344 0
+    outer loop
+      vertex 103.696 1.53073 10.5
+      vertex 103.828 1.16114 0
+      vertex 103.828 1.16114 10.5
+    endloop
+  endfacet
+  facet normal -0.672636 -0.739974 0
+    outer loop
+      vertex 102.538 3.09204 0
+      vertex 102.828 2.82843 10.5
+      vertex 102.538 3.09204 10.5
+    endloop
+  endfacet
+  facet normal -0.672636 -0.739974 -0
+    outer loop
+      vertex 102.828 2.82843 10.5
+      vertex 102.538 3.09204 0
+      vertex 102.828 2.82843 0
+    endloop
+  endfacet
+  facet normal 0.904025 -0.42748 0
+    outer loop
+      vertex 96.3045 1.53073 10.5
+      vertex 96.4723 1.88559 0
+      vertex 96.4723 1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0.904025 -0.42748 0
+    outer loop
+      vertex 96.4723 1.88559 0
+      vertex 96.3045 1.53073 10.5
+      vertex 96.3045 1.53073 0
+    endloop
+  endfacet
+  facet normal 0.970079 -0.242788 0
+    outer loop
+      vertex 96.0769 0.780361 10.5
+      vertex 96.1722 1.16114 0
+      vertex 96.1722 1.16114 10.5
+    endloop
+  endfacet
+  facet normal 0.970079 -0.242788 0
+    outer loop
+      vertex 96.1722 1.16114 0
+      vertex 96.0769 0.780361 10.5
+      vertex 96.0769 0.780361 0
+    endloop
+  endfacet
+  facet normal -0.427425 -0.904051 0
+    outer loop
+      vertex 101.531 3.69552 0
+      vertex 101.886 3.52768 10.5
+      vertex 101.531 3.69552 10.5
+    endloop
+  endfacet
+  facet normal -0.427425 -0.904051 -0
+    outer loop
+      vertex 101.886 3.52768 10.5
+      vertex 101.531 3.69552 0
+      vertex 101.886 3.52768 0
+    endloop
+  endfacet
+  facet normal -0.74047 -0.67209 0
+    outer loop
+      vertex 103.092 2.53757 0
+      vertex 102.828 2.82843 10.5
+      vertex 102.828 2.82843 0
+    endloop
+  endfacet
+  facet normal -0.74047 -0.67209 0
+    outer loop
+      vertex 102.828 2.82843 10.5
+      vertex 103.092 2.53757 0
+      vertex 103.092 2.53757 10.5
+    endloop
+  endfacet
+  facet normal -0.594843 -0.803842 0
+    outer loop
+      vertex 102.222 3.32588 0
+      vertex 102.538 3.09204 10.5
+      vertex 102.222 3.32588 10.5
+    endloop
+  endfacet
+  facet normal -0.594843 -0.803842 -0
+    outer loop
+      vertex 102.538 3.09204 10.5
+      vertex 102.222 3.32588 0
+      vertex 102.538 3.09204 0
+    endloop
+  endfacet
+  facet normal 0.671621 -0.740895 0
+    outer loop
+      vertex 97.1716 2.82843 0
+      vertex 97.4624 3.09204 10.5
+      vertex 97.1716 2.82843 10.5
+    endloop
+  endfacet
+  facet normal 0.671621 -0.740895 0
+    outer loop
+      vertex 97.4624 3.09204 10.5
+      vertex 97.1716 2.82843 0
+      vertex 97.4624 3.09204 0
+    endloop
+  endfacet
+  facet normal -0.514871 -0.857268 0
+    outer loop
+      vertex 101.886 3.52768 0
+      vertex 102.222 3.32588 10.5
+      vertex 101.886 3.52768 10.5
+    endloop
+  endfacet
+  facet normal -0.514871 -0.857268 -0
+    outer loop
+      vertex 102.222 3.32588 10.5
+      vertex 101.886 3.52768 0
+      vertex 102.222 3.32588 0
+    endloop
+  endfacet
+  facet normal -0.146844 0.98916 0
+    outer loop
+      vertex 100.78 -3.92314 0
+      vertex 100.392 -3.98074 10.5
+      vertex 100.78 -3.92314 10.5
+    endloop
+  endfacet
+  facet normal -0.146844 0.98916 0
+    outer loop
+      vertex 100.392 -3.98074 10.5
+      vertex 100.78 -3.92314 0
+      vertex 100.392 -3.98074 0
+    endloop
+  endfacet
+  facet normal 0.336879 -0.941548 0
+    outer loop
+      vertex 98.4693 3.69552 0
+      vertex 98.8389 3.82776 10.5
+      vertex 98.4693 3.69552 10.5
+    endloop
+  endfacet
+  facet normal 0.336879 -0.941548 0
+    outer loop
+      vertex 98.8389 3.82776 10.5
+      vertex 98.4693 3.69552 0
+      vertex 98.8389 3.82776 0
+    endloop
+  endfacet
+  facet normal -0.970259 0.242069 0
+    outer loop
+      vertex 103.828 -1.16114 0
+      vertex 103.923 -0.780361 10.5
+      vertex 103.923 -0.780361 0
+    endloop
+  endfacet
+  facet normal -0.970259 0.242069 0
+    outer loop
+      vertex 103.923 -0.780361 10.5
+      vertex 103.828 -1.16114 0
+      vertex 103.828 -1.16114 10.5
+    endloop
+  endfacet
+  facet normal 0.803128 -0.595806 0
+    outer loop
+      vertex 96.6741 2.22228 10.5
+      vertex 96.908 2.53757 0
+      vertex 96.908 2.53757 10.5
+    endloop
+  endfacet
+  facet normal 0.803128 -0.595806 0
+    outer loop
+      vertex 96.908 2.53757 0
+      vertex 96.6741 2.22228 10.5
+      vertex 96.6741 2.22228 0
+    endloop
+  endfacet
+  facet normal -0.989027 0.147733 0
+    outer loop
+      vertex 103.923 -0.780361 0
+      vertex 103.981 -0.392068 10.5
+      vertex 103.981 -0.392068 0
+    endloop
+  endfacet
+  facet normal -0.989027 0.147733 0
+    outer loop
+      vertex 103.981 -0.392068 10.5
+      vertex 103.923 -0.780361 0
+      vertex 103.923 -0.780361 10.5
+    endloop
+  endfacet
+  facet normal -0.594843 0.803842 0
+    outer loop
+      vertex 102.538 -3.09204 0
+      vertex 102.222 -3.32588 10.5
+      vertex 102.538 -3.09204 10.5
+    endloop
+  endfacet
+  facet normal -0.594843 0.803842 0
+    outer loop
+      vertex 102.222 -3.32588 10.5
+      vertex 102.538 -3.09204 0
+      vertex 102.222 -3.32588 0
+    endloop
+  endfacet
+  facet normal -0.146844 -0.98916 0
+    outer loop
+      vertex 100.392 3.98074 0
+      vertex 100.78 3.92314 10.5
+      vertex 100.392 3.98074 10.5
+    endloop
+  endfacet
+  facet normal -0.146844 -0.98916 -0
+    outer loop
+      vertex 100.78 3.92314 10.5
+      vertex 100.392 3.98074 0
+      vertex 100.78 3.92314 0
+    endloop
+  endfacet
+  facet normal -0.672636 0.739974 0
+    outer loop
+      vertex 102.828 -2.82843 0
+      vertex 102.538 -3.09204 10.5
+      vertex 102.828 -2.82843 10.5
+    endloop
+  endfacet
+  facet normal -0.672636 0.739974 0
+    outer loop
+      vertex 102.538 -3.09204 10.5
+      vertex 102.828 -2.82843 0
+      vertex 102.538 -3.09204 0
+    endloop
+  endfacet
+  facet normal 0.998791 -0.0491666 0
+    outer loop
+      vertex 96 0 10.5
+      vertex 96.0193 0.392068 0
+      vertex 96.0193 0.392068 10.5
+    endloop
+  endfacet
+  facet normal 0.998791 -0.0491666 0
+    outer loop
+      vertex 96.0193 0.392068 0
+      vertex 96 0 10.5
+      vertex 96 0 0
+    endloop
+  endfacet
+  facet normal 0.740977 0.671531 0
+    outer loop
+      vertex 97.1716 -2.82843 10.5
+      vertex 96.908 -2.53757 0
+      vertex 96.908 -2.53757 10.5
+    endloop
+  endfacet
+  facet normal 0.740977 0.671531 0
+    outer loop
+      vertex 96.908 -2.53757 0
+      vertex 97.1716 -2.82843 10.5
+      vertex 97.1716 -2.82843 0
+    endloop
+  endfacet
+  facet normal 0.803128 0.595806 0
+    outer loop
+      vertex 96.908 -2.53757 10.5
+      vertex 96.6741 -2.22228 0
+      vertex 96.6741 -2.22228 10.5
+    endloop
+  endfacet
+  facet normal 0.803128 0.595806 0
+    outer loop
+      vertex 96.6741 -2.22228 0
+      vertex 96.908 -2.53757 10.5
+      vertex 96.908 -2.53757 0
+    endloop
+  endfacet
+  facet normal -0.941739 0.336344 0
+    outer loop
+      vertex 103.696 -1.53073 0
+      vertex 103.828 -1.16114 10.5
+      vertex 103.828 -1.16114 0
+    endloop
+  endfacet
+  facet normal -0.941739 0.336344 0
+    outer loop
+      vertex 103.828 -1.16114 10.5
+      vertex 103.696 -1.53073 0
+      vertex 103.696 -1.53073 10.5
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146736 0
+    outer loop
+      vertex 96.0193 0.392068 10.5
+      vertex 96.0769 0.780361 0
+      vertex 96.0769 0.780361 10.5
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146736 0
+    outer loop
+      vertex 96.0769 0.780361 0
+      vertex 96.0193 0.392068 10.5
+      vertex 96.0193 0.392068 0
+    endloop
+  endfacet
+  facet normal 0.514084 0.85774 -0
+    outer loop
+      vertex 98.1144 -3.52768 0
+      vertex 97.7777 -3.32588 10.5
+      vertex 98.1144 -3.52768 10.5
+    endloop
+  endfacet
+  facet normal 0.514084 0.85774 0
+    outer loop
+      vertex 97.7777 -3.32588 10.5
+      vertex 98.1144 -3.52768 0
+      vertex 97.7777 -3.32588 0
+    endloop
+  endfacet
+  facet normal 0.146733 0.989176 -0
+    outer loop
+      vertex 99.6079 -3.98074 0
+      vertex 99.2196 -3.92314 10.5
+      vertex 99.6079 -3.98074 10.5
+    endloop
+  endfacet
+  facet normal 0.146733 0.989176 0
+    outer loop
+      vertex 99.2196 -3.92314 10.5
+      vertex 99.6079 -3.98074 0
+      vertex 99.2196 -3.92314 0
+    endloop
+  endfacet
+  facet normal 0.595695 0.80321 -0
+    outer loop
+      vertex 97.7777 -3.32588 0
+      vertex 97.4624 -3.09204 10.5
+      vertex 97.7777 -3.32588 10.5
+    endloop
+  endfacet
+  facet normal 0.595695 0.80321 0
+    outer loop
+      vertex 97.4624 -3.09204 10.5
+      vertex 97.7777 -3.32588 0
+      vertex 97.4624 -3.09204 0
+    endloop
+  endfacet
+  facet normal 0.857733 0.514095 0
+    outer loop
+      vertex 96.6741 -2.22228 10.5
+      vertex 96.4723 -1.88559 0
+      vertex 96.4723 -1.88559 10.5
+    endloop
+  endfacet
+  facet normal 0.857733 0.514095 0
+    outer loop
+      vertex 96.4723 -1.88559 0
+      vertex 96.6741 -2.22228 10.5
+      vertex 96.6741 -2.22228 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Just for fun, I created a cover version of the base plate in openscad. The cool thing is that it's completely parameterized: just enter any parameter (number of cameras from 4 to infinity, all physical dimensions like hole diameter or thickness) and it regenerates the base instantly. 

I find this a useful way to prototype with a printer. When I'm trying to tweak the properties of a part, I don't usually want to go back into a CAD program to redesign things, I want to adjust parameters like material thickness, hole diameter, etc.

I didn't bother getting the dimensions right; if this seems useful to you you can re-enter them easily enough! Just install [openscad](https://www.openscad.org/) and open the .scad file. From there you can tweak parameters, render, and export as .stl.

![5_cams](https://user-images.githubusercontent.com/5991943/94335048-963eaa80-0013-11eb-8eee-1a15f91dc30d.png)
![7_cams](https://user-images.githubusercontent.com/5991943/94335049-96d74100-0013-11eb-9952-0786d4c9068d.png)
![7_cams_big_holes](https://user-images.githubusercontent.com/5991943/94335050-976fd780-0013-11eb-8d71-416cb25ce8bb.png)
![13_cams](https://user-images.githubusercontent.com/5991943/94335051-98086e00-0013-11eb-9578-23208835c605.png)



