### PR TITLE
Added indent to mounting plate to align camera body

### DIFF
--- a/hardware/base/base.scad
+++ b/hardware/base/base.scad
@@ -1,4 +1,5 @@
-//define dimensions. All in mm
+// Define dimensions. All in mm
+
 num_cams = 7;
 plate_thickness = 3.5; // thickness of base plate
 mid_thickness = 3.5; // Thickness of inner raised area (first "step")
@@ -9,13 +10,21 @@ radius_to_hole = 65; // Distance from center to the center of the mounting holes
 mid_area_width = 5; // Width of the inner raised area
 radius_central_gap = 60 ; // Radius of the empty central area
 
+// Alignment indent in edge
+picam_base_width = 20; 
+picam_base_thickness = 10;
+indent_depth = 3;
+offset_of_hole = 0; // If the mounting bolt hole isn't centered you can adjust it
+
 // Don't touch
 rotate_angle = 360/num_cams;
 overhang = edge_width_from_hole + hole_diameter/2;
 plate_length = radius_to_hole + overhang;
-poly_side = tan(360/(num_cams * 2)) * 2 *
-            (plate_length);
+poly_side = tan(360/(num_cams * 2)) * 2 * (plate_length);
+radius_to_cam_base = radius_to_hole - picam_base_thickness / 2 - offset_of_hole;
 
+// Main loop            
+union(){
 for (cam = [1 : num_cams]){
     rotate([0, 0, cam * rotate_angle]){
         difference(){
@@ -33,6 +42,10 @@ for (cam = [1 : num_cams]){
             translate([radius_to_hole, 0, -1]){
                 cylinder(r = hole_diameter / 2, h = edge_thickness + 2, $fn = 64);
             }
+            translate([radius_to_cam_base, -picam_base_width/2, edge_thickness - indent_depth]){
+                cube([picam_base_thickness, picam_base_width, indent_depth + 1]);
+            }
         }
     }
+}
 }

--- a/hardware/base/base.stl
+++ b/hardware/base/base.stl
@@ -3359,6 +3359,412 @@ solid OpenSCAD_Model
       vertex -59.5934 -26.0626 0
     endloop
   endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.5698 50.8729 7
+      vertex -58.729 39.3815 7
+      vertex -49.7193 35.0427 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.393 61.9369 7
+      vertex -67.4067 21.3622 7
+      vertex -58.729 39.3815 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -79.2203 0 7
+      vertex -65.0688 0 7
+      vertex -79.2203 4.78721e-07 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -79.2203 4.78721e-07 7
+      vertex -67.4067 21.3622 7
+      vertex -49.393 61.9369 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.5698 -50.8729 7
+      vertex -58.729 -39.3815 7
+      vertex -49.393 -61.9369 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 7
+      vertex -49.393 -61.9369 7
+      vertex -58.729 -39.3815 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -79.2203 -4.78721e-07 7
+      vertex -65.0688 0 7
+      vertex -79.2203 0 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -65.0688 0 7
+      vertex -79.2203 -4.78721e-07 7
+      vertex -67.4067 -21.3622 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 7
+      vertex -79.2203 -4.78721e-07 7
+      vertex -49.393 -61.9369 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4792 -63.4374 7
+      vertex -23.1005 -56.2705 7
+      vertex -3.60198 -60.7209 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 -56.2705 7
+      vertex -40.5698 -50.8729 7
+      vertex -25.3257 -66.0197 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.5698 -50.8729 7
+      vertex -23.1005 -56.2705 7
+      vertex 14.4792 -63.4374 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 56.2705 7
+      vertex 14.4792 63.4374 7
+      vertex -3.60198 60.7209 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -23.1005 56.2705 7
+      vertex -40.5698 50.8729 7
+      vertex 14.4792 63.4374 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.5698 50.8729 7
+      vertex -23.1005 56.2705 7
+      vertex -25.3257 66.0197 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.625 -28.2323 7
+      vertex 45.2277 -40.675 7
+      vertex 51.4626 -48.4933 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.625 -28.2323 7
+      vertex 29.5911 -53.1448 7
+      vertex 45.2277 -40.675 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 -60.9631 7
+      vertex 14.4792 -63.4374 7
+      vertex 17.6282 -77.2341 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4792 -63.4374 7
+      vertex 29.5911 -53.1448 7
+      vertex 58.625 -28.2323 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 -70.4702 7
+      vertex 14.4792 -63.4374 7
+      vertex -3.60198 -60.7209 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4792 -63.4374 7
+      vertex -5.82719 -70.4702 7
+      vertex 17.6282 -77.2341 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 -66.0197 7
+      vertex 17.6282 -77.2341 7
+      vertex -5.82719 -70.4702 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 -66.0197 7
+      vertex -49.393 -61.9369 7
+      vertex 17.6282 -77.2341 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.5698 -50.8729 7
+      vertex -49.393 -61.9369 7
+      vertex -25.3257 -66.0197 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -58.729 -39.3815 7
+      vertex -40.5698 -50.8729 7
+      vertex -49.7193 -35.0427 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -40.5698 -50.8729 7
+      vertex -58.397 -17.0233 7
+      vertex -49.7193 -35.0427 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -65.0688 0 7
+      vertex -58.397 -17.0233 7
+      vertex -40.5698 -50.8729 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -65.0688 0 7
+      vertex -67.4067 -21.3622 7
+      vertex -58.397 -17.0233 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -79.2203 4.78721e-07 7
+      vertex -65.0688 0 7
+      vertex -67.4067 21.3622 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.375 34.3724 7
+      vertex 70 10 7
+      vertex 71.375 -34.3724 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.625 28.2323 7
+      vertex 70 10 7
+      vertex 71.375 34.3724 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 10 7
+      vertex 58.625 28.2323 7
+      vertex 60 -10 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 7
+      vertex 58.625 28.2323 7
+      vertex 60 10 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.375 34.3724 7
+      vertex 51.4626 48.4933 7
+      vertex 58.625 28.2323 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 71.375 34.3724 7
+      vertex 35.826 60.9631 7
+      vertex 51.4626 48.4933 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.4792 63.4374 7
+      vertex 35.826 60.9631 7
+      vertex 17.6282 77.2341 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6282 77.2341 7
+      vertex 35.826 60.9631 7
+      vertex 71.375 34.3724 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 70 -10 7
+      vertex 71.375 -34.3724 7
+      vertex 70 10 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.625 -28.2323 7
+      vertex 70 -10 7
+      vertex 60 -10 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.625 -28.2323 7
+      vertex 60 -10 7
+      vertex 58.625 28.2323 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 -10 7
+      vertex 58.625 -28.2323 7
+      vertex 71.375 -34.3724 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 7
+      vertex 71.375 -34.3724 7
+      vertex 58.625 -28.2323 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 -60.9631 7
+      vertex 71.375 -34.3724 7
+      vertex 51.4626 -48.4933 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.826 -60.9631 7
+      vertex 17.6282 -77.2341 7
+      vertex 71.375 -34.3724 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4792 -63.4374 7
+      vertex 35.826 -60.9631 7
+      vertex 29.5911 -53.1448 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 45.2277 40.675 7
+      vertex 58.625 28.2323 7
+      vertex 51.4626 48.4933 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 53.1448 7
+      vertex 58.625 28.2323 7
+      vertex 45.2277 40.675 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 53.1448 7
+      vertex 14.4792 63.4374 7
+      vertex 58.625 28.2323 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 60.9631 7
+      vertex 14.4792 63.4374 7
+      vertex 29.5911 53.1448 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.82719 70.4702 7
+      vertex 14.4792 63.4374 7
+      vertex 17.6282 77.2341 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4792 63.4374 7
+      vertex -5.82719 70.4702 7
+      vertex -3.60198 60.7209 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6282 77.2341 7
+      vertex -25.3257 66.0197 7
+      vertex -5.82719 70.4702 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.393 61.9369 7
+      vertex -25.3257 66.0197 7
+      vertex 17.6282 77.2341 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -49.393 61.9369 7
+      vertex -40.5698 50.8729 7
+      vertex -25.3257 66.0197 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 7
+      vertex -40.5698 50.8729 7
+      vertex -49.393 61.9369 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 17.0233 7
+      vertex -40.5698 50.8729 7
+      vertex -49.7193 35.0427 7
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -58.397 17.0233 7
+      vertex -65.0688 0 7
+      vertex -40.5698 50.8729 7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -65.0688 0 7
+      vertex -58.397 17.0233 7
+      vertex -67.4067 21.3622 7
+    endloop
+  endfacet
   facet normal -0.62349 -0.781831 0
     outer loop
       vertex 14.4792 63.4374 3.5
@@ -3371,3366 +3777,6 @@ solid OpenSCAD_Model
       vertex 58.625 28.2323 7
       vertex 14.4792 63.4374 3.5
       vertex 58.625 28.2323 3.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.2113 28.5344 7
-      vertex -56.1901 28.3023 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.2552 28.7634 7
-      vertex -56.2113 28.5344 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.3213 28.9869 7
-      vertex -56.2552 28.7634 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.4089 29.2028 7
-      vertex -56.3213 28.9869 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.5174 29.4091 7
-      vertex -56.4089 29.2028 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.6455 29.6038 7
-      vertex -56.5174 29.4091 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.7921 29.785 7
-      vertex -56.6455 29.6038 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -56.9557 29.951 7
-      vertex -56.7921 29.785 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -57.1348 30.1001 7
-      vertex -56.9557 29.951 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -57.3277 30.2309 7
-      vertex -57.1348 30.1001 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -57.5325 30.3422 7
-      vertex -57.3277 30.2309 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -57.7472 30.4329 7
-      vertex -57.5325 30.3422 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -57.9698 30.5022 7
-      vertex -57.7472 30.4329 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -58.198 30.5492 7
-      vertex -57.9698 30.5022 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -58.4298 30.5737 7
-      vertex -58.198 30.5492 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -58.6629 30.5753 7
-      vertex -58.4298 30.5737 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -58.895 30.5541 7
-      vertex -58.6629 30.5753 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -59.1239 30.5103 7
-      vertex -58.895 30.5541 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -59.3474 30.4442 7
-      vertex -59.1239 30.5103 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -59.5633 30.3565 7
-      vertex -59.3474 30.4442 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -59.7697 30.2481 7
-      vertex -59.5633 30.3565 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -59.9644 30.1199 7
-      vertex -59.7697 30.2481 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -60.1455 29.9733 7
-      vertex -59.9644 30.1199 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -60.3115 29.8097 7
-      vertex -60.1455 29.9733 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -60.4606 29.6306 7
-      vertex -60.3115 29.8097 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -60.5915 29.4377 7
-      vertex -60.4606 29.6306 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -60.7028 29.2329 7
-      vertex -60.5915 29.4377 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -79.2203 4.78721e-07 7
-      vertex -60.7028 29.2329 7
-      vertex -49.393 61.9369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -79.2203 4.78721e-07 7
-      vertex -60.9359 28.1025 7
-      vertex -60.9342 28.3356 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -79.2203 4.78721e-07 7
-      vertex -60.9342 28.3356 7
-      vertex -60.9098 28.5674 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.9359 28.1025 7
-      vertex -79.2203 4.78721e-07 7
-      vertex -65.0688 0 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.8627 28.7957 7
-      vertex -79.2203 4.78721e-07 7
-      vertex -60.9098 28.5674 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.7935 29.0182 7
-      vertex -79.2203 4.78721e-07 7
-      vertex -60.8627 28.7957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.7028 29.2329 7
-      vertex -79.2203 4.78721e-07 7
-      vertex -60.7935 29.0182 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.2552 -28.7634 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.2113 -28.5344 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.3213 -28.9869 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.2552 -28.7634 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.4089 -29.2028 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.3213 -28.9869 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.5174 -29.4091 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.4089 -29.2028 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.6455 -29.6038 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.5174 -29.4091 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.7921 -29.785 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.6455 -29.6038 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.9557 -29.951 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.7921 -29.785 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.1348 -30.1001 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.9557 -29.951 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.3277 -30.2309 7
-      vertex -40.5698 -50.8729 7
-      vertex -57.1348 -30.1001 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.5325 -30.3422 7
-      vertex -40.5698 -50.8729 7
-      vertex -57.3277 -30.2309 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.7472 -30.4329 7
-      vertex -40.5698 -50.8729 7
-      vertex -57.5325 -30.3422 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.9698 -30.5022 7
-      vertex -40.5698 -50.8729 7
-      vertex -57.7472 -30.4329 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -58.198 -30.5492 7
-      vertex -40.5698 -50.8729 7
-      vertex -57.9698 -30.5022 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -58.198 -30.5492 7
-      vertex -49.393 -61.9369 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -58.4298 -30.5737 7
-      vertex -49.393 -61.9369 7
-      vertex -58.198 -30.5492 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -58.6629 -30.5753 7
-      vertex -49.393 -61.9369 7
-      vertex -58.4298 -30.5737 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.895 -30.5541 7
-      vertex -49.393 -61.9369 7
-      vertex -58.6629 -30.5753 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.1239 -30.5103 7
-      vertex -49.393 -61.9369 7
-      vertex -58.895 -30.5541 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.3474 -30.4442 7
-      vertex -49.393 -61.9369 7
-      vertex -59.1239 -30.5103 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.5633 -30.3565 7
-      vertex -49.393 -61.9369 7
-      vertex -59.3474 -30.4442 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.7697 -30.2481 7
-      vertex -49.393 -61.9369 7
-      vertex -59.5633 -30.3565 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.9644 -30.1199 7
-      vertex -49.393 -61.9369 7
-      vertex -59.7697 -30.2481 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.1455 -29.9733 7
-      vertex -49.393 -61.9369 7
-      vertex -59.9644 -30.1199 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.3115 -29.8097 7
-      vertex -49.393 -61.9369 7
-      vertex -60.1455 -29.9733 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.4606 -29.6306 7
-      vertex -49.393 -61.9369 7
-      vertex -60.3115 -29.8097 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.5915 -29.4377 7
-      vertex -49.393 -61.9369 7
-      vertex -60.4606 -29.6306 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.7028 -29.2329 7
-      vertex -49.393 -61.9369 7
-      vertex -60.5915 -29.4377 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.7028 -29.2329 7
-      vertex -60.7935 -29.0182 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.9147 -27.8704 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.9359 -28.1025 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.9359 -28.1025 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.9342 -28.3356 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -79.2203 0 7
-      vertex -65.0688 0 7
-      vertex -79.2203 4.78721e-07 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -79.2203 -4.78721e-07 7
-      vertex -65.0688 0 7
-      vertex -79.2203 0 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.9342 -28.3356 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.9098 -28.5674 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.9098 -28.5674 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.8627 -28.7957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.8627 -28.7957 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.7935 -29.0182 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.7028 -29.2329 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -49.393 -61.9369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.0947 -63.2039 7
-      vertex -12.0898 -63.4369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.1224 -62.9725 7
-      vertex -12.0947 -63.2039 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.1727 -62.7449 7
-      vertex -12.1224 -62.9725 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.245 -62.5233 7
-      vertex -12.1727 -62.7449 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.3387 -62.3099 7
-      vertex -12.245 -62.5233 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.4529 -62.1067 7
-      vertex -12.3387 -62.3099 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.5864 -61.9157 7
-      vertex -12.4529 -62.1067 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.738 -61.7387 7
-      vertex -12.5864 -61.9157 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.9063 -61.5774 7
-      vertex -12.738 -61.7387 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -13.0895 -61.4334 7
-      vertex -12.9063 -61.5774 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -13.286 -61.308 7
-      vertex -13.0895 -61.4334 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -13.4938 -61.2025 7
-      vertex -13.286 -61.308 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -13.711 -61.1178 7
-      vertex -13.4938 -61.2025 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -13.9354 -61.0549 7
-      vertex -13.711 -61.1178 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -13.9354 -61.0549 7
-      vertex 14.4792 -63.4374 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.82 -63.0713 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.8379 -63.3037 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.7793 -62.8418 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.82 -63.0713 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.7164 -62.6174 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.7793 -62.8418 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6317 -62.4003 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.7164 -62.6174 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.5262 -62.1924 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.6317 -62.4003 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4008 -61.996 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.5262 -62.1924 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.2568 -61.8127 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.4008 -61.996 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0955 -61.6445 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.2568 -61.8127 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9185 -61.4929 7
-      vertex -40.5698 -50.8729 7
-      vertex -16.0955 -61.6445 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.7274 -61.3593 7
-      vertex -40.5698 -50.8729 7
-      vertex -15.9185 -61.4929 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.5242 -61.2452 7
-      vertex -40.5698 -50.8729 7
-      vertex -15.7274 -61.3593 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3108 -61.1515 7
-      vertex -40.5698 -50.8729 7
-      vertex -15.5242 -61.2452 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.0893 -61.0791 7
-      vertex -40.5698 -50.8729 7
-      vertex -15.3108 -61.1515 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8617 -61.0289 7
-      vertex -40.5698 -50.8729 7
-      vertex -15.0893 -61.0791 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6303 -61.0012 7
-      vertex -40.5698 -50.8729 7
-      vertex -14.8617 -61.0289 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3973 -60.9962 7
-      vertex -40.5698 -50.8729 7
-      vertex -14.6303 -61.0012 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.1649 -61.0142 7
-      vertex -40.5698 -50.8729 7
-      vertex -14.3973 -60.9962 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.9354 -61.0549 7
-      vertex -40.5698 -50.8729 7
-      vertex -14.1649 -61.0142 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0947 63.2039 7
-      vertex 14.4792 63.4374 7
-      vertex -12.0898 63.4369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.1224 62.9725 7
-      vertex 14.4792 63.4374 7
-      vertex -12.0947 63.2039 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.1727 62.7449 7
-      vertex 14.4792 63.4374 7
-      vertex -12.1224 62.9725 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.245 62.5233 7
-      vertex 14.4792 63.4374 7
-      vertex -12.1727 62.7449 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.3387 62.3099 7
-      vertex 14.4792 63.4374 7
-      vertex -12.245 62.5233 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.4529 62.1067 7
-      vertex 14.4792 63.4374 7
-      vertex -12.3387 62.3099 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5864 61.9157 7
-      vertex 14.4792 63.4374 7
-      vertex -12.4529 62.1067 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.738 61.7387 7
-      vertex 14.4792 63.4374 7
-      vertex -12.5864 61.9157 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.9063 61.5774 7
-      vertex 14.4792 63.4374 7
-      vertex -12.738 61.7387 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0895 61.4334 7
-      vertex 14.4792 63.4374 7
-      vertex -12.9063 61.5774 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.286 61.308 7
-      vertex 14.4792 63.4374 7
-      vertex -13.0895 61.4334 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.4938 61.2025 7
-      vertex 14.4792 63.4374 7
-      vertex -13.286 61.308 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.711 61.1178 7
-      vertex 14.4792 63.4374 7
-      vertex -13.4938 61.2025 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.9354 61.0549 7
-      vertex 14.4792 63.4374 7
-      vertex -13.711 61.1178 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -13.9354 61.0549 7
-      vertex -14.1649 61.0142 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.9354 61.0549 7
-      vertex -40.5698 50.8729 7
-      vertex 14.4792 63.4374 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.3973 60.9962 7
-      vertex -40.5698 50.8729 7
-      vertex -14.1649 61.0142 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6303 61.0012 7
-      vertex -40.5698 50.8729 7
-      vertex -14.3973 60.9962 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.8617 61.0289 7
-      vertex -40.5698 50.8729 7
-      vertex -14.6303 61.0012 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.0893 61.0791 7
-      vertex -40.5698 50.8729 7
-      vertex -14.8617 61.0289 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3108 61.1515 7
-      vertex -40.5698 50.8729 7
-      vertex -15.0893 61.0791 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.5242 61.2452 7
-      vertex -40.5698 50.8729 7
-      vertex -15.3108 61.1515 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.7274 61.3593 7
-      vertex -40.5698 50.8729 7
-      vertex -15.5242 61.2452 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9185 61.4929 7
-      vertex -40.5698 50.8729 7
-      vertex -15.7274 61.3593 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0955 61.6445 7
-      vertex -40.5698 50.8729 7
-      vertex -15.9185 61.4929 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.2568 61.8127 7
-      vertex -40.5698 50.8729 7
-      vertex -16.0955 61.6445 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4008 61.996 7
-      vertex -40.5698 50.8729 7
-      vertex -16.2568 61.8127 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.5262 62.1924 7
-      vertex -40.5698 50.8729 7
-      vertex -16.4008 61.996 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6317 62.4003 7
-      vertex -40.5698 50.8729 7
-      vertex -16.5262 62.1924 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.7164 62.6174 7
-      vertex -40.5698 50.8729 7
-      vertex -16.6317 62.4003 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.7793 62.8418 7
-      vertex -40.5698 50.8729 7
-      vertex -16.7164 62.6174 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.82 63.0713 7
-      vertex -40.5698 50.8729 7
-      vertex -16.7793 62.8418 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 50.8729 7
-      vertex -16.82 63.0713 7
-      vertex -16.8379 63.3037 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 -34.3724 7
-      vertex 42.8934 -50.6194 7
-      vertex 42.9016 -50.8524 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 -34.3724 7
-      vertex 42.8625 -50.3884 7
-      vertex 42.8934 -50.6194 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 -34.3724 7
-      vertex 42.809 -50.1616 7
-      vertex 42.8625 -50.3884 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 42.7336 -49.941 7
-      vertex 42.809 -50.1616 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 42.6369 -49.729 7
-      vertex 42.7336 -49.941 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 42.5199 -49.5274 7
-      vertex 42.6369 -49.729 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 42.3837 -49.3383 7
-      vertex 42.5199 -49.5274 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 42.2296 -49.1634 7
-      vertex 42.3837 -49.3383 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 42.0591 -49.0045 7
-      vertex 42.2296 -49.1634 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 41.8739 -48.863 7
-      vertex 42.0591 -49.0045 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 41.6757 -48.7404 7
-      vertex 41.8739 -48.863 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 41.4664 -48.6378 7
-      vertex 41.6757 -48.7404 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 41.2481 -48.5562 7
-      vertex 41.4664 -48.6378 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 41.0228 -48.4964 7
-      vertex 41.2481 -48.5562 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 40.7928 -48.459 7
-      vertex 41.0228 -48.4964 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 40.5601 -48.4443 7
-      vertex 40.7928 -48.459 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 40.3272 -48.4524 7
-      vertex 40.5601 -48.4443 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 40.0962 -48.4834 7
-      vertex 40.3272 -48.4524 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 39.8694 -48.5369 7
-      vertex 40.0962 -48.4834 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 39.6488 -48.6123 7
-      vertex 39.8694 -48.5369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 39.4368 -48.709 7
-      vertex 39.6488 -48.6123 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 39.2352 -48.826 7
-      vertex 39.4368 -48.709 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 39.046 -48.9622 7
-      vertex 39.2352 -48.826 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 39.046 -48.9622 7
-      vertex 58.625 -28.2323 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.1521 -50.7857 7
-      vertex 38.1668 -50.5531 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.1668 -50.5531 7
-      vertex 38.2042 -50.3231 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.2042 -50.3231 7
-      vertex 38.264 -50.0978 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.264 -50.0978 7
-      vertex 38.3456 -49.8795 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.3456 -49.8795 7
-      vertex 38.4482 -49.6702 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.4482 -49.6702 7
-      vertex 38.5708 -49.472 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1521 -50.7857 7
-      vertex 14.4792 -63.4374 7
-      vertex 17.6282 -77.2341 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.046 -48.9622 7
-      vertex 14.4792 -63.4374 7
-      vertex 38.8712 -49.1163 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.7122 -49.2868 7
-      vertex 38.8712 -49.1163 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex 38.5708 -49.472 7
-      vertex 38.7122 -49.2868 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.1078 -63.6693 7
-      vertex 14.4792 -63.4374 7
-      vertex -12.0898 -63.4369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.1484 -63.8988 7
-      vertex 14.4792 -63.4374 7
-      vertex -12.1078 -63.6693 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2114 -64.1232 7
-      vertex 14.4792 -63.4374 7
-      vertex -12.1484 -63.8988 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.296 -64.3404 7
-      vertex 14.4792 -63.4374 7
-      vertex -12.2114 -64.1232 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.4015 -64.5482 7
-      vertex 14.4792 -63.4374 7
-      vertex -12.296 -64.3404 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 -63.4374 7
-      vertex -12.4015 -64.5482 7
-      vertex 17.6282 -77.2341 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.5269 -64.7447 7
-      vertex 17.6282 -77.2341 7
-      vertex -12.4015 -64.5482 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.6709 -64.9279 7
-      vertex 17.6282 -77.2341 7
-      vertex -12.5269 -64.7447 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.8322 -65.0961 7
-      vertex 17.6282 -77.2341 7
-      vertex -12.6709 -64.9279 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.0093 -65.2477 7
-      vertex 17.6282 -77.2341 7
-      vertex -12.8322 -65.0961 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.2003 -65.3813 7
-      vertex 17.6282 -77.2341 7
-      vertex -13.0093 -65.2477 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.4035 -65.4955 7
-      vertex 17.6282 -77.2341 7
-      vertex -13.2003 -65.3813 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.6169 -65.5892 7
-      vertex 17.6282 -77.2341 7
-      vertex -13.4035 -65.4955 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8384 -65.6615 7
-      vertex 17.6282 -77.2341 7
-      vertex -13.6169 -65.5892 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.066 -65.7118 7
-      vertex 17.6282 -77.2341 7
-      vertex -13.8384 -65.6615 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.2975 -65.7395 7
-      vertex 17.6282 -77.2341 7
-      vertex -14.066 -65.7118 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.5305 -65.7444 7
-      vertex 17.6282 -77.2341 7
-      vertex -14.2975 -65.7395 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7628 -65.7264 7
-      vertex 17.6282 -77.2341 7
-      vertex -14.5305 -65.7444 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.9923 -65.6858 7
-      vertex 17.6282 -77.2341 7
-      vertex -14.7628 -65.7264 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 -61.9369 7
-      vertex -14.9923 -65.6858 7
-      vertex -15.2168 -65.6228 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -16.833 -63.5367 7
-      vertex -16.8379 -63.3037 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -16.8053 -63.7681 7
-      vertex -16.833 -63.5367 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -49.393 -61.9369 7
-      vertex -16.8053 -63.7681 7
-      vertex -40.5698 -50.8729 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.8053 -63.7681 7
-      vertex -49.393 -61.9369 7
-      vertex -16.755 -63.9957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.755 -63.9957 7
-      vertex -49.393 -61.9369 7
-      vertex -16.6827 -64.2173 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6827 -64.2173 7
-      vertex -49.393 -61.9369 7
-      vertex -16.589 -64.4307 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.589 -64.4307 7
-      vertex -49.393 -61.9369 7
-      vertex -16.4748 -64.6339 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.4748 -64.6339 7
-      vertex -49.393 -61.9369 7
-      vertex -16.3413 -64.8249 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.3413 -64.8249 7
-      vertex -49.393 -61.9369 7
-      vertex -16.1897 -65.0019 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1897 -65.0019 7
-      vertex -49.393 -61.9369 7
-      vertex -16.0214 -65.1632 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0214 -65.1632 7
-      vertex -49.393 -61.9369 7
-      vertex -15.8382 -65.3073 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.9923 -65.6858 7
-      vertex -49.393 -61.9369 7
-      vertex 17.6282 -77.2341 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.4339 -65.5382 7
-      vertex -49.393 -61.9369 7
-      vertex -15.2168 -65.6228 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6417 -65.4327 7
-      vertex -49.393 -61.9369 7
-      vertex -15.4339 -65.5382 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8382 -65.3073 7
-      vertex -49.393 -61.9369 7
-      vertex -15.6417 -65.4327 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.2113 -28.5344 7
-      vertex -40.5698 -50.8729 7
-      vertex -56.1901 -28.3023 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -56.1917 -28.0693 7
-      vertex -56.1901 -28.3023 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -56.2162 -27.8375 7
-      vertex -56.1917 -28.0693 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -56.2633 -27.6092 7
-      vertex -56.2162 -27.8375 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -56.3325 -27.3867 7
-      vertex -56.2633 -27.6092 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -40.5698 -50.8729 7
-      vertex -56.4232 -27.172 7
-      vertex -56.3325 -27.3867 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -65.0688 0 7
-      vertex -56.4232 -27.172 7
-      vertex -40.5698 -50.8729 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.8708 -27.6415 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.9147 -27.8704 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.8047 -27.418 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.8708 -27.6415 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.717 -27.2021 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.8047 -27.418 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.6086 -26.9958 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.717 -27.2021 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.4805 -26.8011 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.6086 -26.9958 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.3339 -26.6199 7
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.4805 -26.8011 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -79.2203 -4.78721e-07 7
-      vertex -60.3339 -26.6199 7
-      vertex -65.0688 0 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.1702 -26.4539 7
-      vertex -65.0688 0 7
-      vertex -60.3339 -26.6199 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.9911 -26.3048 7
-      vertex -65.0688 0 7
-      vertex -60.1702 -26.4539 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.7982 -26.174 7
-      vertex -65.0688 0 7
-      vertex -59.9911 -26.3048 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.5934 -26.0626 7
-      vertex -65.0688 0 7
-      vertex -59.7982 -26.174 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.3787 -25.9719 7
-      vertex -65.0688 0 7
-      vertex -59.5934 -26.0626 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.1562 -25.9027 7
-      vertex -65.0688 0 7
-      vertex -59.3787 -25.9719 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.9279 -25.8556 7
-      vertex -65.0688 0 7
-      vertex -59.1562 -25.9027 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.6961 -25.8312 7
-      vertex -65.0688 0 7
-      vertex -58.9279 -25.8556 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.4631 -25.8295 7
-      vertex -65.0688 0 7
-      vertex -58.6961 -25.8312 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.231 -25.8508 7
-      vertex -65.0688 0 7
-      vertex -58.4631 -25.8295 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.0021 -25.8946 7
-      vertex -65.0688 0 7
-      vertex -58.231 -25.8508 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -57.7786 -25.9607 7
-      vertex -65.0688 0 7
-      vertex -58.0021 -25.8946 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -57.5626 -26.0484 7
-      vertex -65.0688 0 7
-      vertex -57.7786 -25.9607 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -57.3563 -26.1568 7
-      vertex -65.0688 0 7
-      vertex -57.5626 -26.0484 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -57.1616 -26.285 7
-      vertex -65.0688 0 7
-      vertex -57.3563 -26.1568 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.9804 -26.4315 7
-      vertex -65.0688 0 7
-      vertex -57.1616 -26.285 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.8144 -26.5952 7
-      vertex -65.0688 0 7
-      vertex -56.9804 -26.4315 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.6653 -26.7743 7
-      vertex -65.0688 0 7
-      vertex -56.8144 -26.5952 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.5345 -26.9672 7
-      vertex -65.0688 0 7
-      vertex -56.6653 -26.7743 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.4232 -27.172 7
-      vertex -65.0688 0 7
-      vertex -56.5345 -26.9672 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 67.375 0 7
-      vertex 71.375 -34.3724 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 67.3636 0.23279 7
-      vertex 67.375 0 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 67.3294 0.463339 7
-      vertex 67.3636 0.23279 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 67.2727 0.689425 7
-      vertex 67.3294 0.463339 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 67.1942 0.908873 7
-      vertex 67.2727 0.689425 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 67.0946 1.11957 7
-      vertex 67.1942 0.908873 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 66.9747 1.31948 7
-      vertex 67.0946 1.11957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 66.8359 1.50668 7
-      vertex 66.9747 1.31948 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 66.6794 1.67938 7
-      vertex 66.8359 1.50668 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 66.5067 1.8359 7
-      vertex 66.6794 1.67938 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 66.3195 1.97474 7
-      vertex 66.5067 1.8359 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 66.1196 2.09456 7
-      vertex 66.3195 1.97474 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 65.9089 2.19421 7
-      vertex 66.1196 2.09456 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 65.6894 2.27273 7
-      vertex 65.9089 2.19421 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 58.625 28.2323 7
-      vertex 65.6894 2.27273 7
-      vertex 71.375 34.3724 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 65.6894 2.27273 7
-      vertex 58.625 28.2323 7
-      vertex 65.4633 2.32936 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 65.4633 2.32936 7
-      vertex 58.625 28.2323 7
-      vertex 65.2328 2.36356 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 65.2328 2.36356 7
-      vertex 58.625 28.2323 7
-      vertex 65 2.375 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 65 2.375 7
-      vertex 58.625 28.2323 7
-      vertex 64.7672 2.36356 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 64.7672 2.36356 7
-      vertex 58.625 28.2323 7
-      vertex 64.5367 2.32936 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 64.5367 2.32936 7
-      vertex 58.625 28.2323 7
-      vertex 64.3106 2.27273 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 64.3106 2.27273 7
-      vertex 58.625 28.2323 7
-      vertex 64.0911 2.19421 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 64.0911 2.19421 7
-      vertex 58.625 28.2323 7
-      vertex 63.8804 2.09456 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 63.8804 2.09456 7
-      vertex 58.625 28.2323 7
-      vertex 63.6805 1.97474 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 63.6805 1.97474 7
-      vertex 58.625 28.2323 7
-      vertex 63.4933 1.8359 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 63.4933 1.8359 7
-      vertex 58.625 28.2323 7
-      vertex 63.3206 1.67938 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 63.3206 1.67938 7
-      vertex 58.625 28.2323 7
-      vertex 63.1641 1.50668 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 63.1641 1.50668 7
-      vertex 58.625 28.2323 7
-      vertex 63.0253 1.31948 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 63.0253 1.31948 7
-      vertex 58.625 28.2323 7
-      vertex 62.9054 1.11957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 62.9054 1.11957 7
-      vertex 58.625 28.2323 7
-      vertex 62.8058 0.908873 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 62.6364 0.23279 7
-      vertex 58.625 28.2323 7
-      vertex 62.625 0 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 62.6706 0.463339 7
-      vertex 58.625 28.2323 7
-      vertex 62.6364 0.23279 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 62.7273 0.689425 7
-      vertex 58.625 28.2323 7
-      vertex 62.6706 0.463339 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 62.8058 0.908873 7
-      vertex 58.625 28.2323 7
-      vertex 62.7273 0.689425 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.8934 50.6194 7
-      vertex 71.375 34.3724 7
-      vertex 42.9016 50.8524 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.8869 51.085 7
-      vertex 42.9016 50.8524 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.8495 51.315 7
-      vertex 42.8869 51.085 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.7897 51.5403 7
-      vertex 42.8495 51.315 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.7081 51.7586 7
-      vertex 42.7897 51.5403 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.6055 51.9679 7
-      vertex 42.7081 51.7586 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.4829 52.1661 7
-      vertex 42.6055 51.9679 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.3414 52.3513 7
-      vertex 42.4829 52.1661 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.1825 52.5218 7
-      vertex 42.3414 52.3513 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.0076 52.6759 7
-      vertex 42.1825 52.5218 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex 42.0076 52.6759 7
-      vertex 71.375 34.3724 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1912 51.2497 7
-      vertex 14.4792 63.4374 7
-      vertex 38.1602 51.0187 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.2447 51.4765 7
-      vertex 14.4792 63.4374 7
-      vertex 38.1912 51.2497 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.3201 51.6971 7
-      vertex 14.4792 63.4374 7
-      vertex 38.2447 51.4765 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.4168 51.9091 7
-      vertex 14.4792 63.4374 7
-      vertex 38.3201 51.6971 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.5338 52.1107 7
-      vertex 14.4792 63.4374 7
-      vertex 38.4168 51.9091 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.67 52.2998 7
-      vertex 14.4792 63.4374 7
-      vertex 38.5338 52.1107 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.8241 52.4747 7
-      vertex 14.4792 63.4374 7
-      vertex 38.67 52.2998 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.9946 52.6336 7
-      vertex 14.4792 63.4374 7
-      vertex 38.8241 52.4747 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.1798 52.7751 7
-      vertex 14.4792 63.4374 7
-      vertex 38.9946 52.6336 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex 39.1798 52.7751 7
-      vertex 17.6282 77.2341 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.378 52.8977 7
-      vertex 17.6282 77.2341 7
-      vertex 39.1798 52.7751 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.5873 53.0003 7
-      vertex 17.6282 77.2341 7
-      vertex 39.378 52.8977 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.8056 53.0819 7
-      vertex 17.6282 77.2341 7
-      vertex 39.5873 53.0003 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.0309 53.1417 7
-      vertex 17.6282 77.2341 7
-      vertex 39.8056 53.0819 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.2609 53.1791 7
-      vertex 17.6282 77.2341 7
-      vertex 40.0309 53.1417 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.4935 53.1938 7
-      vertex 17.6282 77.2341 7
-      vertex 40.2609 53.1791 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.7265 53.1856 7
-      vertex 17.6282 77.2341 7
-      vertex 40.4935 53.1938 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.9575 53.1547 7
-      vertex 17.6282 77.2341 7
-      vertex 40.7265 53.1856 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 41.1843 53.1012 7
-      vertex 17.6282 77.2341 7
-      vertex 40.9575 53.1547 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 41.4049 53.0258 7
-      vertex 17.6282 77.2341 7
-      vertex 41.1843 53.1012 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 41.6169 52.9291 7
-      vertex 17.6282 77.2341 7
-      vertex 41.4049 53.0258 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 41.8185 52.8121 7
-      vertex 17.6282 77.2341 7
-      vertex 41.6169 52.9291 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.0076 52.6759 7
-      vertex 17.6282 77.2341 7
-      vertex 41.8185 52.8121 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 67.3636 -0.23279 7
-      vertex 71.375 -34.3724 7
-      vertex 67.375 0 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 67.3294 -0.463339 7
-      vertex 71.375 -34.3724 7
-      vertex 67.3636 -0.23279 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 67.2727 -0.689425 7
-      vertex 71.375 -34.3724 7
-      vertex 67.3294 -0.463339 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 67.1942 -0.908873 7
-      vertex 71.375 -34.3724 7
-      vertex 67.2727 -0.689425 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 67.0946 -1.11957 7
-      vertex 71.375 -34.3724 7
-      vertex 67.1942 -0.908873 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 66.9747 -1.31948 7
-      vertex 71.375 -34.3724 7
-      vertex 67.0946 -1.11957 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 66.8359 -1.50668 7
-      vertex 71.375 -34.3724 7
-      vertex 66.9747 -1.31948 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 66.6794 -1.67938 7
-      vertex 71.375 -34.3724 7
-      vertex 66.8359 -1.50668 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 66.5067 -1.8359 7
-      vertex 71.375 -34.3724 7
-      vertex 66.6794 -1.67938 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 66.3195 -1.97474 7
-      vertex 71.375 -34.3724 7
-      vertex 66.5067 -1.8359 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 66.1196 -2.09456 7
-      vertex 71.375 -34.3724 7
-      vertex 66.3195 -1.97474 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 65.9089 -2.19421 7
-      vertex 71.375 -34.3724 7
-      vertex 66.1196 -2.09456 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 65.6894 -2.27273 7
-      vertex 71.375 -34.3724 7
-      vertex 65.9089 -2.19421 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 65.6894 -2.27273 7
-      vertex 65.4633 -2.32936 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 65.4633 -2.32936 7
-      vertex 65.2328 -2.36356 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 65.2328 -2.36356 7
-      vertex 65 -2.375 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 65 -2.375 7
-      vertex 64.7672 -2.36356 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 64.7672 -2.36356 7
-      vertex 64.5367 -2.32936 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 64.5367 -2.32936 7
-      vertex 64.3106 -2.27273 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 64.3106 -2.27273 7
-      vertex 64.0911 -2.19421 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 64.0911 -2.19421 7
-      vertex 63.8804 -2.09456 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 63.8804 -2.09456 7
-      vertex 63.6805 -1.97474 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 63.6805 -1.97474 7
-      vertex 63.4933 -1.8359 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 63.4933 -1.8359 7
-      vertex 63.3206 -1.67938 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 63.3206 -1.67938 7
-      vertex 63.1641 -1.50668 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 63.1641 -1.50668 7
-      vertex 63.0253 -1.31948 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 63.0253 -1.31948 7
-      vertex 62.9054 -1.11957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 62.9054 -1.11957 7
-      vertex 62.8058 -0.908873 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 62.8058 -0.908873 7
-      vertex 62.7273 -0.689425 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 62.625 0 7
-      vertex 58.625 28.2323 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 62.625 0 7
-      vertex 58.625 -28.2323 7
-      vertex 62.6364 -0.23279 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 62.6706 -0.463339 7
-      vertex 62.6364 -0.23279 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -28.2323 7
-      vertex 62.7273 -0.689425 7
-      vertex 62.6706 -0.463339 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 65.6894 -2.27273 7
-      vertex 58.625 -28.2323 7
-      vertex 71.375 -34.3724 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.809 -50.1616 7
-      vertex 71.375 -34.3724 7
-      vertex 58.625 -28.2323 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.8869 -51.085 7
-      vertex 71.375 -34.3724 7
-      vertex 42.9016 -50.8524 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.8495 -51.315 7
-      vertex 71.375 -34.3724 7
-      vertex 42.8869 -51.085 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.7897 -51.5403 7
-      vertex 71.375 -34.3724 7
-      vertex 42.8495 -51.315 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.7081 -51.7586 7
-      vertex 71.375 -34.3724 7
-      vertex 42.7897 -51.5403 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.6055 -51.9679 7
-      vertex 71.375 -34.3724 7
-      vertex 42.7081 -51.7586 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.4829 -52.1661 7
-      vertex 71.375 -34.3724 7
-      vertex 42.6055 -51.9679 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.3414 -52.3513 7
-      vertex 71.375 -34.3724 7
-      vertex 42.4829 -52.1661 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.1825 -52.5218 7
-      vertex 71.375 -34.3724 7
-      vertex 42.3414 -52.3513 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 42.0076 -52.6759 7
-      vertex 71.375 -34.3724 7
-      vertex 42.1825 -52.5218 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 -77.2341 7
-      vertex 42.0076 -52.6759 7
-      vertex 41.8185 -52.8121 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.0076 -52.6759 7
-      vertex 17.6282 -77.2341 7
-      vertex 71.375 -34.3724 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.6169 -52.9291 7
-      vertex 17.6282 -77.2341 7
-      vertex 41.8185 -52.8121 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.4049 -53.0258 7
-      vertex 17.6282 -77.2341 7
-      vertex 41.6169 -52.9291 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.1843 -53.1012 7
-      vertex 17.6282 -77.2341 7
-      vertex 41.4049 -53.0258 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 40.9575 -53.1547 7
-      vertex 17.6282 -77.2341 7
-      vertex 41.1843 -53.1012 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 40.7265 -53.1856 7
-      vertex 17.6282 -77.2341 7
-      vertex 40.9575 -53.1547 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 40.4935 -53.1938 7
-      vertex 17.6282 -77.2341 7
-      vertex 40.7265 -53.1856 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.2609 -53.1791 7
-      vertex 17.6282 -77.2341 7
-      vertex 40.4935 -53.1938 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.0309 -53.1417 7
-      vertex 17.6282 -77.2341 7
-      vertex 40.2609 -53.1791 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.8056 -53.0819 7
-      vertex 17.6282 -77.2341 7
-      vertex 40.0309 -53.1417 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.5873 -53.0003 7
-      vertex 17.6282 -77.2341 7
-      vertex 39.8056 -53.0819 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.378 -52.8977 7
-      vertex 17.6282 -77.2341 7
-      vertex 39.5873 -53.0003 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.1798 -52.7751 7
-      vertex 17.6282 -77.2341 7
-      vertex 39.378 -52.8977 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.9946 -52.6336 7
-      vertex 17.6282 -77.2341 7
-      vertex 39.1798 -52.7751 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.8241 -52.4747 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.9946 -52.6336 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.67 -52.2998 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.8241 -52.4747 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.5338 -52.1107 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.67 -52.2998 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.4168 -51.9091 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.5338 -52.1107 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.3201 -51.6971 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.4168 -51.9091 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.2447 -51.4765 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.3201 -51.6971 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1912 -51.2497 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.2447 -51.4765 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1602 -51.0187 7
-      vertex 17.6282 -77.2341 7
-      vertex 38.1912 -51.2497 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 -77.2341 7
-      vertex 38.1602 -51.0187 7
-      vertex 38.1521 -50.7857 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.8625 50.3884 7
-      vertex 71.375 34.3724 7
-      vertex 42.8934 50.6194 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.809 50.1616 7
-      vertex 71.375 34.3724 7
-      vertex 42.8625 50.3884 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 71.375 34.3724 7
-      vertex 42.809 50.1616 7
-      vertex 58.625 28.2323 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.7336 49.941 7
-      vertex 58.625 28.2323 7
-      vertex 42.809 50.1616 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.6369 49.729 7
-      vertex 58.625 28.2323 7
-      vertex 42.7336 49.941 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.5199 49.5274 7
-      vertex 58.625 28.2323 7
-      vertex 42.6369 49.729 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.3837 49.3383 7
-      vertex 58.625 28.2323 7
-      vertex 42.5199 49.5274 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.2296 49.1634 7
-      vertex 58.625 28.2323 7
-      vertex 42.3837 49.3383 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 42.0591 49.0045 7
-      vertex 58.625 28.2323 7
-      vertex 42.2296 49.1634 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.8739 48.863 7
-      vertex 58.625 28.2323 7
-      vertex 42.0591 49.0045 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.6757 48.7404 7
-      vertex 58.625 28.2323 7
-      vertex 41.8739 48.863 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.4664 48.6378 7
-      vertex 58.625 28.2323 7
-      vertex 41.6757 48.7404 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.2481 48.5562 7
-      vertex 58.625 28.2323 7
-      vertex 41.4664 48.6378 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 41.0228 48.4964 7
-      vertex 58.625 28.2323 7
-      vertex 41.2481 48.5562 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 40.7928 48.459 7
-      vertex 58.625 28.2323 7
-      vertex 41.0228 48.4964 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 40.5601 48.4443 7
-      vertex 58.625 28.2323 7
-      vertex 40.7928 48.459 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.3272 48.4524 7
-      vertex 58.625 28.2323 7
-      vertex 40.5601 48.4443 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.0962 48.4834 7
-      vertex 58.625 28.2323 7
-      vertex 40.3272 48.4524 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.8694 48.5369 7
-      vertex 58.625 28.2323 7
-      vertex 40.0962 48.4834 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.6488 48.6123 7
-      vertex 58.625 28.2323 7
-      vertex 39.8694 48.5369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.4368 48.709 7
-      vertex 58.625 28.2323 7
-      vertex 39.6488 48.6123 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.2352 48.826 7
-      vertex 58.625 28.2323 7
-      vertex 39.4368 48.709 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.046 48.9622 7
-      vertex 58.625 28.2323 7
-      vertex 39.2352 48.826 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex 39.046 48.9622 7
-      vertex 38.8712 49.1163 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1602 51.0187 7
-      vertex 14.4792 63.4374 7
-      vertex 38.1521 50.7857 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1521 50.7857 7
-      vertex 14.4792 63.4374 7
-      vertex 38.1668 50.5531 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.1668 50.5531 7
-      vertex 14.4792 63.4374 7
-      vertex 38.2042 50.3231 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.2042 50.3231 7
-      vertex 14.4792 63.4374 7
-      vertex 38.264 50.0978 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.264 50.0978 7
-      vertex 14.4792 63.4374 7
-      vertex 38.3456 49.8795 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.3456 49.8795 7
-      vertex 14.4792 63.4374 7
-      vertex 38.4482 49.6702 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 39.046 48.9622 7
-      vertex 14.4792 63.4374 7
-      vertex 58.625 28.2323 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.7122 49.2868 7
-      vertex 14.4792 63.4374 7
-      vertex 38.8712 49.1163 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.5708 49.472 7
-      vertex 14.4792 63.4374 7
-      vertex 38.7122 49.2868 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.4482 49.6702 7
-      vertex 14.4792 63.4374 7
-      vertex 38.5708 49.472 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.4015 64.5482 7
-      vertex 14.4792 63.4374 7
-      vertex 17.6282 77.2341 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex -12.1078 63.6693 7
-      vertex -12.0898 63.4369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex -12.1484 63.8988 7
-      vertex -12.1078 63.6693 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex -12.2114 64.1232 7
-      vertex -12.1484 63.8988 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex -12.296 64.3404 7
-      vertex -12.2114 64.1232 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4792 63.4374 7
-      vertex -12.4015 64.5482 7
-      vertex -12.296 64.3404 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -12.5269 64.7447 7
-      vertex -12.4015 64.5482 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -12.6709 64.9279 7
-      vertex -12.5269 64.7447 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -12.8322 65.0961 7
-      vertex -12.6709 64.9279 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -13.0093 65.2477 7
-      vertex -12.8322 65.0961 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -13.2003 65.3813 7
-      vertex -13.0093 65.2477 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -13.4035 65.4955 7
-      vertex -13.2003 65.3813 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -13.6169 65.5892 7
-      vertex -13.4035 65.4955 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -13.8384 65.6615 7
-      vertex -13.6169 65.5892 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -14.066 65.7118 7
-      vertex -13.8384 65.6615 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -14.2975 65.7395 7
-      vertex -14.066 65.7118 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -14.5305 65.7444 7
-      vertex -14.2975 65.7395 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -14.7628 65.7264 7
-      vertex -14.5305 65.7444 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6282 77.2341 7
-      vertex -14.9923 65.6858 7
-      vertex -14.7628 65.7264 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -14.9923 65.6858 7
-      vertex 17.6282 77.2341 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.833 63.5367 7
-      vertex -40.5698 50.8729 7
-      vertex -16.8379 63.3037 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.8053 63.7681 7
-      vertex -40.5698 50.8729 7
-      vertex -16.833 63.5367 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.8053 63.7681 7
-      vertex -16.755 63.9957 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.755 63.9957 7
-      vertex -16.6827 64.2173 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.6827 64.2173 7
-      vertex -16.589 64.4307 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.589 64.4307 7
-      vertex -16.4748 64.6339 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.4748 64.6339 7
-      vertex -16.3413 64.8249 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.3413 64.8249 7
-      vertex -16.1897 65.0019 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.1897 65.0019 7
-      vertex -16.0214 65.1632 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -16.0214 65.1632 7
-      vertex -15.8382 65.3073 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -15.8382 65.3073 7
-      vertex -15.6417 65.4327 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.9923 65.6858 7
-      vertex -49.393 61.9369 7
-      vertex -15.2168 65.6228 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -15.4339 65.5382 7
-      vertex -15.2168 65.6228 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -49.393 61.9369 7
-      vertex -15.6417 65.4327 7
-      vertex -15.4339 65.5382 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.8053 63.7681 7
-      vertex -49.393 61.9369 7
-      vertex -40.5698 50.8729 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.198 30.5492 7
-      vertex -40.5698 50.8729 7
-      vertex -49.393 61.9369 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.1917 28.0693 7
-      vertex -40.5698 50.8729 7
-      vertex -56.1901 28.3023 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.2162 27.8375 7
-      vertex -40.5698 50.8729 7
-      vertex -56.1917 28.0693 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.2633 27.6092 7
-      vertex -40.5698 50.8729 7
-      vertex -56.2162 27.8375 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.3325 27.3867 7
-      vertex -40.5698 50.8729 7
-      vertex -56.2633 27.6092 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -56.4232 27.172 7
-      vertex -40.5698 50.8729 7
-      vertex -56.3325 27.3867 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -65.0688 0 7
-      vertex -56.4232 27.172 7
-      vertex -56.5345 26.9672 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.4232 27.172 7
-      vertex -65.0688 0 7
-      vertex -40.5698 50.8729 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.6653 26.7743 7
-      vertex -65.0688 0 7
-      vertex -56.5345 26.9672 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.8144 26.5952 7
-      vertex -65.0688 0 7
-      vertex -56.6653 26.7743 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -56.9804 26.4315 7
-      vertex -65.0688 0 7
-      vertex -56.8144 26.5952 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.1616 26.285 7
-      vertex -65.0688 0 7
-      vertex -56.9804 26.4315 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.3563 26.1568 7
-      vertex -65.0688 0 7
-      vertex -57.1616 26.285 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.5626 26.0484 7
-      vertex -65.0688 0 7
-      vertex -57.3563 26.1568 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -57.7786 25.9607 7
-      vertex -65.0688 0 7
-      vertex -57.5626 26.0484 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -58.0021 25.8946 7
-      vertex -65.0688 0 7
-      vertex -57.7786 25.9607 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -58.231 25.8508 7
-      vertex -65.0688 0 7
-      vertex -58.0021 25.8946 7
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -58.4631 25.8295 7
-      vertex -65.0688 0 7
-      vertex -58.231 25.8508 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.6961 25.8312 7
-      vertex -65.0688 0 7
-      vertex -58.4631 25.8295 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -58.9279 25.8556 7
-      vertex -65.0688 0 7
-      vertex -58.6961 25.8312 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.1562 25.9027 7
-      vertex -65.0688 0 7
-      vertex -58.9279 25.8556 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.3787 25.9719 7
-      vertex -65.0688 0 7
-      vertex -59.1562 25.9027 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.5934 26.0626 7
-      vertex -65.0688 0 7
-      vertex -59.3787 25.9719 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.7982 26.174 7
-      vertex -65.0688 0 7
-      vertex -59.5934 26.0626 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -59.9911 26.3048 7
-      vertex -65.0688 0 7
-      vertex -59.7982 26.174 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.1702 26.4539 7
-      vertex -65.0688 0 7
-      vertex -59.9911 26.3048 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.3339 26.6199 7
-      vertex -65.0688 0 7
-      vertex -60.1702 26.4539 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.4805 26.8011 7
-      vertex -65.0688 0 7
-      vertex -60.3339 26.6199 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.6086 26.9958 7
-      vertex -65.0688 0 7
-      vertex -60.4805 26.8011 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.717 27.2021 7
-      vertex -65.0688 0 7
-      vertex -60.6086 26.9958 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.8047 27.418 7
-      vertex -65.0688 0 7
-      vertex -60.717 27.2021 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.8708 27.6415 7
-      vertex -65.0688 0 7
-      vertex -60.8047 27.418 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -60.9147 27.8704 7
-      vertex -65.0688 0 7
-      vertex -60.8708 27.6415 7
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -65.0688 0 7
-      vertex -60.9147 27.8704 7
-      vertex -60.9359 28.1025 7
-    endloop
-  endfacet
-  facet normal -0.623491 -0.781831 0
-    outer loop
-      vertex 13.2443 58.027 0
-      vertex 53.625 25.8244 3.5
-      vertex 13.2443 58.027 3.5
-    endloop
-  endfacet
-  facet normal -0.623491 -0.781831 -0
-    outer loop
-      vertex 53.625 25.8244 3.5
-      vertex 13.2443 58.027 0
-      vertex 53.625 25.8244 0
     endloop
   endfacet
   facet normal 0 0 1
@@ -6831,900 +3877,1446 @@ solid OpenSCAD_Model
       vertex -65.0688 0 3.5
     endloop
   endfacet
-  facet normal -0.132585 -0.991172 0
+  facet normal -0.623491 -0.781831 0
     outer loop
-      vertex 40.7265 53.1856 0
-      vertex 40.9575 53.1547 7
-      vertex 40.7265 53.1856 7
+      vertex 13.2443 58.027 0
+      vertex 53.625 25.8244 3.5
+      vertex 13.2443 58.027 3.5
     endloop
   endfacet
-  facet normal -0.132585 -0.991172 -0
+  facet normal -0.623491 -0.781831 -0
     outer loop
-      vertex 40.9575 53.1547 7
-      vertex 40.7265 53.1856 0
-      vertex 40.9575 53.1547 0
-    endloop
-  endfacet
-  facet normal 0.526059 -0.850448 0
-    outer loop
-      vertex 39.1798 52.7751 0
-      vertex 39.378 52.8977 7
-      vertex 39.1798 52.7751 7
-    endloop
-  endfacet
-  facet normal 0.526059 -0.850448 0
-    outer loop
-      vertex 39.378 52.8977 7
-      vertex 39.1798 52.7751 0
-      vertex 39.378 52.8977 0
-    endloop
-  endfacet
-  facet normal 0.973288 -0.229589 0
-    outer loop
-      vertex 38.1912 51.2497 7
-      vertex 38.2447 51.4765 0
-      vertex 38.2447 51.4765 7
-    endloop
-  endfacet
-  facet normal 0.973288 -0.229589 0
-    outer loop
-      vertex 38.2447 51.4765 0
-      vertex 38.1912 51.2497 7
-      vertex 38.1912 51.2497 0
-    endloop
-  endfacet
-  facet normal 0.850448 0.526059 0
-    outer loop
-      vertex 38.5708 49.472 7
-      vertex 38.4482 49.6702 0
-      vertex 38.4482 49.6702 7
-    endloop
-  endfacet
-  facet normal 0.850448 0.526059 0
-    outer loop
-      vertex 38.4482 49.6702 0
-      vertex 38.5708 49.472 7
-      vertex 38.5708 49.472 0
-    endloop
-  endfacet
-  facet normal -0.661082 -0.750313 0
-    outer loop
-      vertex 42.0076 52.6759 0
-      vertex 42.1825 52.5218 7
-      vertex 42.0076 52.6759 7
-    endloop
-  endfacet
-  facet normal -0.661082 -0.750313 -0
-    outer loop
-      vertex 42.1825 52.5218 7
-      vertex 42.0076 52.6759 0
-      vertex 42.1825 52.5218 0
+      vertex 53.625 25.8244 3.5
+      vertex 13.2443 58.027 0
+      vertex 53.625 25.8244 0
     endloop
   endfacet
   facet normal 0.350136 -0.936699 0
     outer loop
       vertex 39.5873 53.0003 0
-      vertex 39.8056 53.0819 7
-      vertex 39.5873 53.0003 7
+      vertex 39.8056 53.0819 4
+      vertex 39.5873 53.0003 4
     endloop
   endfacet
   facet normal 0.350136 -0.936699 0
     outer loop
-      vertex 39.8056 53.0819 7
+      vertex 39.8056 53.0819 4
       vertex 39.5873 53.0003 0
       vertex 39.8056 53.0819 0
-    endloop
-  endfacet
-  facet normal 0.966533 0.256541 0
-    outer loop
-      vertex 38.264 50.0978 7
-      vertex 38.2042 50.3231 0
-      vertex 38.2042 50.3231 7
-    endloop
-  endfacet
-  facet normal 0.966533 0.256541 0
-    outer loop
-      vertex 38.2042 50.3231 0
-      vertex 38.264 50.0978 7
-      vertex 38.264 50.0978 0
-    endloop
-  endfacet
-  facet normal 0.909822 -0.414999 0
-    outer loop
-      vertex 38.3201 51.6971 7
-      vertex 38.4168 51.9091 0
-      vertex 38.4168 51.9091 7
-    endloop
-  endfacet
-  facet normal 0.909822 -0.414999 0
-    outer loop
-      vertex 38.4168 51.9091 0
-      vertex 38.3201 51.6971 7
-      vertex 38.3201 51.6971 0
     endloop
   endfacet
   facet normal -0.501949 -0.864897 0
     outer loop
       vertex 41.6169 52.9291 0
-      vertex 41.8185 52.8121 7
-      vertex 41.6169 52.9291 7
+      vertex 41.8185 52.8121 4
+      vertex 41.6169 52.9291 4
     endloop
   endfacet
   facet normal -0.501949 -0.864897 -0
     outer loop
-      vertex 41.8185 52.8121 7
+      vertex 41.8185 52.8121 4
       vertex 41.6169 52.9291 0
       vertex 41.8185 52.8121 0
-    endloop
-  endfacet
-  facet normal -0.0351714 -0.999381 0
-    outer loop
-      vertex 40.4935 53.1938 0
-      vertex 40.7265 53.1856 7
-      vertex 40.4935 53.1938 7
-    endloop
-  endfacet
-  facet normal -0.0351714 -0.999381 -0
-    outer loop
-      vertex 40.7265 53.1856 7
-      vertex 40.4935 53.1938 0
-      vertex 40.7265 53.1856 0
-    endloop
-  endfacet
-  facet normal 0.160501 -0.987036 0
-    outer loop
-      vertex 40.0309 53.1417 0
-      vertex 40.2609 53.1791 7
-      vertex 40.0309 53.1417 7
-    endloop
-  endfacet
-  facet normal 0.160501 -0.987036 0
-    outer loop
-      vertex 40.2609 53.1791 7
-      vertex 40.0309 53.1417 0
-      vertex 40.2609 53.1791 0
-    endloop
-  endfacet
-  facet normal 0.811437 -0.58444 0
-    outer loop
-      vertex 38.5338 52.1107 7
-      vertex 38.67 52.2998 0
-      vertex 38.67 52.2998 7
-    endloop
-  endfacet
-  facet normal 0.811437 -0.58444 0
-    outer loop
-      vertex 38.67 52.2998 0
-      vertex 38.5338 52.1107 7
-      vertex 38.5338 52.1107 0
-    endloop
-  endfacet
-  facet normal 0.607116 -0.794614 0
-    outer loop
-      vertex 38.9946 52.6336 0
-      vertex 39.1798 52.7751 7
-      vertex 38.9946 52.6336 7
-    endloop
-  endfacet
-  facet normal 0.607116 -0.794614 0
-    outer loop
-      vertex 39.1798 52.7751 7
-      vertex 38.9946 52.6336 0
-      vertex 39.1798 52.7751 0
-    endloop
-  endfacet
-  facet normal 0.681783 -0.731554 0
-    outer loop
-      vertex 38.8241 52.4747 0
-      vertex 38.9946 52.6336 7
-      vertex 38.8241 52.4747 7
-    endloop
-  endfacet
-  facet normal 0.681783 -0.731554 0
-    outer loop
-      vertex 38.9946 52.6336 7
-      vertex 38.8241 52.4747 0
-      vertex 38.9946 52.6336 0
-    endloop
-  endfacet
-  facet normal 0.440164 -0.897917 0
-    outer loop
-      vertex 39.378 52.8977 0
-      vertex 39.5873 53.0003 7
-      vertex 39.378 52.8977 7
-    endloop
-  endfacet
-  facet normal 0.440164 -0.897917 0
-    outer loop
-      vertex 39.5873 53.0003 7
-      vertex 39.378 52.8977 0
-      vertex 39.5873 53.0003 0
-    endloop
-  endfacet
-  facet normal 0.256541 -0.966533 0
-    outer loop
-      vertex 39.8056 53.0819 0
-      vertex 40.0309 53.1417 7
-      vertex 39.8056 53.0819 7
-    endloop
-  endfacet
-  facet normal 0.256541 -0.966533 0
-    outer loop
-      vertex 40.0309 53.1417 7
-      vertex 39.8056 53.0819 0
-      vertex 40.0309 53.1417 0
-    endloop
-  endfacet
-  facet normal 0.584237 0.811583 -0
-    outer loop
-      vertex 39.2352 48.826 0
-      vertex 39.046 48.9622 7
-      vertex 39.2352 48.826 7
-    endloop
-  endfacet
-  facet normal 0.584237 0.811583 0
-    outer loop
-      vertex 39.046 48.9622 7
-      vertex 39.2352 48.826 0
-      vertex 39.046 48.9622 0
-    endloop
-  endfacet
-  facet normal 0.794821 0.606845 0
-    outer loop
-      vertex 38.7122 49.2868 7
-      vertex 38.5708 49.472 0
-      vertex 38.5708 49.472 7
-    endloop
-  endfacet
-  facet normal 0.794821 0.606845 0
-    outer loop
-      vertex 38.5708 49.472 0
-      vertex 38.7122 49.2868 7
-      vertex 38.7122 49.2868 0
-    endloop
-  endfacet
-  facet normal 0.73134 0.682013 0
-    outer loop
-      vertex 38.8712 49.1163 7
-      vertex 38.7122 49.2868 0
-      vertex 38.7122 49.2868 7
-    endloop
-  endfacet
-  facet normal 0.73134 0.682013 0
-    outer loop
-      vertex 38.7122 49.2868 0
-      vertex 38.8712 49.1163 7
-      vertex 38.8712 49.1163 0
-    endloop
-  endfacet
-  facet normal 0.897917 0.440164 0
-    outer loop
-      vertex 38.4482 49.6702 7
-      vertex 38.3456 49.8795 0
-      vertex 38.3456 49.8795 7
-    endloop
-  endfacet
-  facet normal 0.897917 0.440164 0
-    outer loop
-      vertex 38.3456 49.8795 0
-      vertex 38.4482 49.6702 7
-      vertex 38.4482 49.6702 0
-    endloop
-  endfacet
-  facet normal 0.936699 0.350136 0
-    outer loop
-      vertex 38.3456 49.8795 7
-      vertex 38.264 50.0978 0
-      vertex 38.264 50.0978 7
-    endloop
-  endfacet
-  facet normal 0.936699 0.350136 0
-    outer loop
-      vertex 38.264 50.0978 0
-      vertex 38.3456 49.8795 7
-      vertex 38.3456 49.8795 0
-    endloop
-  endfacet
-  facet normal 0.946254 -0.323425 0
-    outer loop
-      vertex 38.2447 51.4765 7
-      vertex 38.3201 51.6971 0
-      vertex 38.3201 51.6971 7
-    endloop
-  endfacet
-  facet normal 0.946254 -0.323425 0
-    outer loop
-      vertex 38.3201 51.6971 0
-      vertex 38.2447 51.4765 7
-      vertex 38.2447 51.4765 0
-    endloop
-  endfacet
-  facet normal 0.864897 -0.501949 0
-    outer loop
-      vertex 38.4168 51.9091 7
-      vertex 38.5338 52.1107 0
-      vertex 38.5338 52.1107 7
-    endloop
-  endfacet
-  facet normal 0.864897 -0.501949 0
-    outer loop
-      vertex 38.5338 52.1107 0
-      vertex 38.4168 51.9091 7
-      vertex 38.4168 51.9091 0
-    endloop
-  endfacet
-  facet normal 0.999396 -0.034743 0
-    outer loop
-      vertex 38.1521 50.7857 7
-      vertex 38.1602 51.0187 0
-      vertex 38.1602 51.0187 7
-    endloop
-  endfacet
-  facet normal 0.999396 -0.034743 0
-    outer loop
-      vertex 38.1602 51.0187 0
-      vertex 38.1521 50.7857 7
-      vertex 38.1521 50.7857 0
-    endloop
-  endfacet
-  facet normal 0.998009 0.0630728 0
-    outer loop
-      vertex 38.1668 50.5531 7
-      vertex 38.1521 50.7857 0
-      vertex 38.1521 50.7857 7
-    endloop
-  endfacet
-  facet normal 0.998009 0.0630728 0
-    outer loop
-      vertex 38.1521 50.7857 0
-      vertex 38.1668 50.5531 7
-      vertex 38.1668 50.5531 0
-    endloop
-  endfacet
-  facet normal 0.991115 -0.133007 0
-    outer loop
-      vertex 38.1602 51.0187 7
-      vertex 38.1912 51.2497 0
-      vertex 38.1912 51.2497 7
-    endloop
-  endfacet
-  facet normal 0.991115 -0.133007 0
-    outer loop
-      vertex 38.1912 51.2497 0
-      vertex 38.1602 51.0187 7
-      vertex 38.1602 51.0187 0
-    endloop
-  endfacet
-  facet normal 0.987036 0.160501 0
-    outer loop
-      vertex 38.2042 50.3231 7
-      vertex 38.1668 50.5531 0
-      vertex 38.1668 50.5531 7
-    endloop
-  endfacet
-  facet normal 0.987036 0.160501 0
-    outer loop
-      vertex 38.1668 50.5531 0
-      vertex 38.2042 50.3231 7
-      vertex 38.2042 50.3231 0
     endloop
   endfacet
   facet normal -0.58444 -0.811437 0
     outer loop
       vertex 41.8185 52.8121 0
-      vertex 42.0076 52.6759 7
-      vertex 41.8185 52.8121 7
+      vertex 42.0076 52.6759 4
+      vertex 41.8185 52.8121 4
     endloop
   endfacet
   facet normal -0.58444 -0.811437 -0
     outer loop
-      vertex 42.0076 52.6759 7
+      vertex 42.0076 52.6759 4
       vertex 41.8185 52.8121 0
       vertex 42.0076 52.6759 0
-    endloop
-  endfacet
-  facet normal -0.794614 -0.607116 0
-    outer loop
-      vertex 42.4829 52.1661 0
-      vertex 42.3414 52.3513 7
-      vertex 42.3414 52.3513 0
-    endloop
-  endfacet
-  facet normal -0.794614 -0.607116 0
-    outer loop
-      vertex 42.3414 52.3513 7
-      vertex 42.4829 52.1661 0
-      vertex 42.4829 52.1661 7
-    endloop
-  endfacet
-  facet normal 0.501949 0.864897 -0
-    outer loop
-      vertex 39.4368 48.709 0
-      vertex 39.2352 48.826 7
-      vertex 39.4368 48.709 7
-    endloop
-  endfacet
-  facet normal 0.501949 0.864897 0
-    outer loop
-      vertex 39.2352 48.826 7
-      vertex 39.4368 48.709 0
-      vertex 39.2352 48.826 0
-    endloop
-  endfacet
-  facet normal -0.864897 0.501949 0
-    outer loop
-      vertex 42.5199 49.5274 0
-      vertex 42.6369 49.729 7
-      vertex 42.6369 49.729 0
-    endloop
-  endfacet
-  facet normal -0.864897 0.501949 0
-    outer loop
-      vertex 42.6369 49.729 7
-      vertex 42.5199 49.5274 0
-      vertex 42.5199 49.5274 7
-    endloop
-  endfacet
-  facet normal -0.973288 0.229589 0
-    outer loop
-      vertex 42.809 50.1616 0
-      vertex 42.8625 50.3884 7
-      vertex 42.8625 50.3884 0
-    endloop
-  endfacet
-  facet normal -0.973288 0.229589 0
-    outer loop
-      vertex 42.8625 50.3884 7
-      vertex 42.809 50.1616 0
-      vertex 42.809 50.1616 7
-    endloop
-  endfacet
-  facet normal -0.229589 -0.973288 0
-    outer loop
-      vertex 40.9575 53.1547 0
-      vertex 41.1843 53.1012 7
-      vertex 40.9575 53.1547 7
-    endloop
-  endfacet
-  facet normal -0.229589 -0.973288 -0
-    outer loop
-      vertex 41.1843 53.1012 7
-      vertex 40.9575 53.1547 0
-      vertex 41.1843 53.1012 0
-    endloop
-  endfacet
-  facet normal -0.323425 -0.946254 0
-    outer loop
-      vertex 41.1843 53.1012 0
-      vertex 41.4049 53.0258 7
-      vertex 41.1843 53.1012 7
-    endloop
-  endfacet
-  facet normal -0.323425 -0.946254 -0
-    outer loop
-      vertex 41.4049 53.0258 7
-      vertex 41.1843 53.1012 0
-      vertex 41.4049 53.0258 0
-    endloop
-  endfacet
-  facet normal 0.0630728 -0.998009 0
-    outer loop
-      vertex 40.2609 53.1791 0
-      vertex 40.4935 53.1938 7
-      vertex 40.2609 53.1791 7
-    endloop
-  endfacet
-  facet normal 0.0630728 -0.998009 0
-    outer loop
-      vertex 40.4935 53.1938 7
-      vertex 40.2609 53.1791 0
-      vertex 40.4935 53.1938 0
-    endloop
-  endfacet
-  facet normal 0.750313 -0.661082 0
-    outer loop
-      vertex 38.67 52.2998 7
-      vertex 38.8241 52.4747 0
-      vertex 38.8241 52.4747 7
-    endloop
-  endfacet
-  facet normal 0.750313 -0.661082 0
-    outer loop
-      vertex 38.8241 52.4747 0
-      vertex 38.67 52.2998 7
-      vertex 38.67 52.2998 0
-    endloop
-  endfacet
-  facet normal 0.661295 0.750126 -0
-    outer loop
-      vertex 39.046 48.9622 0
-      vertex 38.8712 49.1163 7
-      vertex 39.046 48.9622 7
-    endloop
-  endfacet
-  facet normal 0.661295 0.750126 0
-    outer loop
-      vertex 38.8712 49.1163 7
-      vertex 39.046 48.9622 0
-      vertex 38.8712 49.1163 0
-    endloop
-  endfacet
-  facet normal -0.987036 -0.160501 0
-    outer loop
-      vertex 42.8869 51.085 0
-      vertex 42.8495 51.315 7
-      vertex 42.8495 51.315 0
-    endloop
-  endfacet
-  facet normal -0.987036 -0.160501 0
-    outer loop
-      vertex 42.8495 51.315 7
-      vertex 42.8869 51.085 0
-      vertex 42.8869 51.085 7
-    endloop
-  endfacet
-  facet normal -0.936699 -0.350136 0
-    outer loop
-      vertex 42.7897 51.5403 0
-      vertex 42.7081 51.7586 7
-      vertex 42.7081 51.7586 0
-    endloop
-  endfacet
-  facet normal -0.936699 -0.350136 0
-    outer loop
-      vertex 42.7081 51.7586 7
-      vertex 42.7897 51.5403 0
-      vertex 42.7897 51.5403 7
-    endloop
-  endfacet
-  facet normal -0.897917 -0.440164 0
-    outer loop
-      vertex 42.7081 51.7586 0
-      vertex 42.6055 51.9679 7
-      vertex 42.6055 51.9679 0
-    endloop
-  endfacet
-  facet normal -0.897917 -0.440164 0
-    outer loop
-      vertex 42.6055 51.9679 7
-      vertex 42.7081 51.7586 0
-      vertex 42.7081 51.7586 7
-    endloop
-  endfacet
-  facet normal -0.750313 0.661082 0
-    outer loop
-      vertex 42.2296 49.1634 0
-      vertex 42.3837 49.3383 7
-      vertex 42.3837 49.3383 0
-    endloop
-  endfacet
-  facet normal -0.750313 0.661082 0
-    outer loop
-      vertex 42.3837 49.3383 7
-      vertex 42.2296 49.1634 0
-      vertex 42.2296 49.1634 7
-    endloop
-  endfacet
-  facet normal -0.909822 0.414999 0
-    outer loop
-      vertex 42.6369 49.729 0
-      vertex 42.7336 49.941 7
-      vertex 42.7336 49.941 0
-    endloop
-  endfacet
-  facet normal -0.909822 0.414999 0
-    outer loop
-      vertex 42.7336 49.941 7
-      vertex 42.6369 49.729 0
-      vertex 42.6369 49.729 7
-    endloop
-  endfacet
-  facet normal -0.946254 0.323425 0
-    outer loop
-      vertex 42.7336 49.941 0
-      vertex 42.809 50.1616 7
-      vertex 42.809 50.1616 0
-    endloop
-  endfacet
-  facet normal -0.946254 0.323425 0
-    outer loop
-      vertex 42.809 50.1616 7
-      vertex 42.7336 49.941 0
-      vertex 42.7336 49.941 7
     endloop
   endfacet
   facet normal -0.414999 -0.909822 0
     outer loop
       vertex 41.4049 53.0258 0
-      vertex 41.6169 52.9291 7
-      vertex 41.4049 53.0258 7
+      vertex 41.6169 52.9291 4
+      vertex 41.4049 53.0258 4
     endloop
   endfacet
   facet normal -0.414999 -0.909822 -0
     outer loop
-      vertex 41.6169 52.9291 7
+      vertex 41.6169 52.9291 4
       vertex 41.4049 53.0258 0
       vertex 41.6169 52.9291 0
     endloop
   endfacet
-  facet normal -0.731554 -0.681783 0
+  facet normal -0.946254 0.323425 0
     outer loop
-      vertex 42.3414 52.3513 0
-      vertex 42.1825 52.5218 7
+      vertex 42.7336 49.941 0
+      vertex 42.809 50.1616 4
+      vertex 42.809 50.1616 0
+    endloop
+  endfacet
+  facet normal -0.946254 0.323425 0
+    outer loop
+      vertex 42.809 50.1616 4
+      vertex 42.7336 49.941 0
+      vertex 42.7336 49.941 4
+    endloop
+  endfacet
+  facet normal -0.526059 0.850448 0
+    outer loop
+      vertex 41.8739 48.863 0
+      vertex 41.6757 48.7404 4
+      vertex 41.8739 48.863 4
+    endloop
+  endfacet
+  facet normal -0.526059 0.850448 0
+    outer loop
+      vertex 41.6757 48.7404 4
+      vertex 41.8739 48.863 0
+      vertex 41.6757 48.7404 0
+    endloop
+  endfacet
+  facet normal 0.73134 0.682013 0
+    outer loop
+      vertex 38.8712 49.1163 4
+      vertex 38.7122 49.2868 0
+      vertex 38.7122 49.2868 4
+    endloop
+  endfacet
+  facet normal 0.73134 0.682013 0
+    outer loop
+      vertex 38.7122 49.2868 0
+      vertex 38.8712 49.1163 4
+      vertex 38.8712 49.1163 0
+    endloop
+  endfacet
+  facet normal 0.811437 -0.58444 0
+    outer loop
+      vertex 38.5338 52.1107 4
+      vertex 38.67 52.2998 0
+      vertex 38.67 52.2998 4
+    endloop
+  endfacet
+  facet normal 0.811437 -0.58444 0
+    outer loop
+      vertex 38.67 52.2998 0
+      vertex 38.5338 52.1107 4
+      vertex 38.5338 52.1107 0
+    endloop
+  endfacet
+  facet normal -0.661082 -0.750313 0
+    outer loop
+      vertex 42.0076 52.6759 0
+      vertex 42.1825 52.5218 4
+      vertex 42.0076 52.6759 4
+    endloop
+  endfacet
+  facet normal -0.661082 -0.750313 -0
+    outer loop
+      vertex 42.1825 52.5218 4
+      vertex 42.0076 52.6759 0
       vertex 42.1825 52.5218 0
     endloop
   endfacet
-  facet normal -0.731554 -0.681783 0
+  facet normal 0.526059 -0.850448 0
     outer loop
-      vertex 42.1825 52.5218 7
-      vertex 42.3414 52.3513 0
-      vertex 42.3414 52.3513 7
+      vertex 39.1798 52.7751 0
+      vertex 39.378 52.8977 4
+      vertex 39.1798 52.7751 4
     endloop
   endfacet
-  facet normal -0.998009 -0.0630728 0
+  facet normal 0.526059 -0.850448 0
     outer loop
-      vertex 42.9016 50.8524 0
-      vertex 42.8869 51.085 7
-      vertex 42.8869 51.085 0
-    endloop
-  endfacet
-  facet normal -0.998009 -0.0630728 0
-    outer loop
-      vertex 42.8869 51.085 7
-      vertex 42.9016 50.8524 0
-      vertex 42.9016 50.8524 7
-    endloop
-  endfacet
-  facet normal -0.999381 0.0351714 0
-    outer loop
-      vertex 42.8934 50.6194 0
-      vertex 42.9016 50.8524 7
-      vertex 42.9016 50.8524 0
-    endloop
-  endfacet
-  facet normal -0.999381 0.0351714 0
-    outer loop
-      vertex 42.9016 50.8524 7
-      vertex 42.8934 50.6194 0
-      vertex 42.8934 50.6194 7
-    endloop
-  endfacet
-  facet normal -0.991172 0.132585 0
-    outer loop
-      vertex 42.8625 50.3884 0
-      vertex 42.8934 50.6194 7
-      vertex 42.8934 50.6194 0
-    endloop
-  endfacet
-  facet normal -0.991172 0.132585 0
-    outer loop
-      vertex 42.8934 50.6194 7
-      vertex 42.8625 50.3884 0
-      vertex 42.8625 50.3884 7
-    endloop
-  endfacet
-  facet normal -0.966533 -0.256541 0
-    outer loop
-      vertex 42.8495 51.315 0
-      vertex 42.7897 51.5403 7
-      vertex 42.7897 51.5403 0
-    endloop
-  endfacet
-  facet normal -0.966533 -0.256541 0
-    outer loop
-      vertex 42.7897 51.5403 7
-      vertex 42.8495 51.315 0
-      vertex 42.8495 51.315 7
-    endloop
-  endfacet
-  facet normal -0.850448 -0.526059 0
-    outer loop
-      vertex 42.6055 51.9679 0
-      vertex 42.4829 52.1661 7
-      vertex 42.4829 52.1661 0
-    endloop
-  endfacet
-  facet normal -0.850448 -0.526059 0
-    outer loop
-      vertex 42.4829 52.1661 7
-      vertex 42.6055 51.9679 0
-      vertex 42.6055 51.9679 7
-    endloop
-  endfacet
-  facet normal -0.607116 0.794614 0
-    outer loop
-      vertex 42.0591 49.0045 0
-      vertex 41.8739 48.863 7
-      vertex 42.0591 49.0045 7
-    endloop
-  endfacet
-  facet normal -0.607116 0.794614 0
-    outer loop
-      vertex 41.8739 48.863 7
-      vertex 42.0591 49.0045 0
-      vertex 41.8739 48.863 0
+      vertex 39.378 52.8977 4
+      vertex 39.1798 52.7751 0
+      vertex 39.378 52.8977 0
     endloop
   endfacet
   facet normal -0.811437 0.58444 0
     outer loop
       vertex 42.3837 49.3383 0
-      vertex 42.5199 49.5274 7
+      vertex 42.5199 49.5274 4
       vertex 42.5199 49.5274 0
     endloop
   endfacet
   facet normal -0.811437 0.58444 0
     outer loop
-      vertex 42.5199 49.5274 7
+      vertex 42.5199 49.5274 4
       vertex 42.3837 49.3383 0
-      vertex 42.3837 49.3383 7
+      vertex 42.3837 49.3383 4
     endloop
   endfacet
-  facet normal 0.323425 0.946254 -0
+  facet normal -0.991172 0.132585 0
     outer loop
-      vertex 39.8694 48.5369 0
-      vertex 39.6488 48.6123 7
-      vertex 39.8694 48.5369 7
+      vertex 42.8625 50.3884 0
+      vertex 42.8934 50.6194 4
+      vertex 42.8934 50.6194 0
     endloop
   endfacet
-  facet normal 0.323425 0.946254 0
+  facet normal -0.991172 0.132585 0
     outer loop
-      vertex 39.6488 48.6123 7
-      vertex 39.8694 48.5369 0
-      vertex 39.6488 48.6123 0
-    endloop
-  endfacet
-  facet normal 0.414999 0.909822 -0
-    outer loop
-      vertex 39.6488 48.6123 0
-      vertex 39.4368 48.709 7
-      vertex 39.6488 48.6123 7
-    endloop
-  endfacet
-  facet normal 0.414999 0.909822 0
-    outer loop
-      vertex 39.4368 48.709 7
-      vertex 39.6488 48.6123 0
-      vertex 39.4368 48.709 0
-    endloop
-  endfacet
-  facet normal 0.229589 0.973288 -0
-    outer loop
-      vertex 40.0962 48.4834 0
-      vertex 39.8694 48.5369 7
-      vertex 40.0962 48.4834 7
-    endloop
-  endfacet
-  facet normal 0.229589 0.973288 0
-    outer loop
-      vertex 39.8694 48.5369 7
-      vertex 40.0962 48.4834 0
-      vertex 39.8694 48.5369 0
-    endloop
-  endfacet
-  facet normal 0.133007 0.991115 -0
-    outer loop
-      vertex 40.3272 48.4524 0
-      vertex 40.0962 48.4834 7
-      vertex 40.3272 48.4524 7
-    endloop
-  endfacet
-  facet normal 0.133007 0.991115 0
-    outer loop
-      vertex 40.0962 48.4834 7
-      vertex 40.3272 48.4524 0
-      vertex 40.0962 48.4834 0
-    endloop
-  endfacet
-  facet normal -0.0630458 0.998011 0
-    outer loop
-      vertex 40.7928 48.459 0
-      vertex 40.5601 48.4443 7
-      vertex 40.7928 48.459 7
-    endloop
-  endfacet
-  facet normal -0.0630458 0.998011 0
-    outer loop
-      vertex 40.5601 48.4443 7
-      vertex 40.7928 48.459 0
-      vertex 40.5601 48.4443 0
+      vertex 42.8934 50.6194 4
+      vertex 42.8625 50.3884 0
+      vertex 42.8625 50.3884 4
     endloop
   endfacet
   facet normal 0.0347579 0.999396 -0
     outer loop
       vertex 40.5601 48.4443 0
-      vertex 40.3272 48.4524 7
-      vertex 40.5601 48.4443 7
+      vertex 40.3272 48.4524 4
+      vertex 40.5601 48.4443 4
     endloop
   endfacet
   facet normal 0.0347579 0.999396 0
     outer loop
-      vertex 40.3272 48.4524 7
+      vertex 40.3272 48.4524 4
       vertex 40.5601 48.4443 0
       vertex 40.3272 48.4524 0
     endloop
   endfacet
-  facet normal -0.160501 0.987036 0
+  facet normal 0.999396 -0.034743 0
     outer loop
-      vertex 41.0228 48.4964 0
-      vertex 40.7928 48.459 7
-      vertex 41.0228 48.4964 7
+      vertex 38.1521 50.7857 4
+      vertex 38.1602 51.0187 0
+      vertex 38.1602 51.0187 4
     endloop
   endfacet
-  facet normal -0.160501 0.987036 0
+  facet normal 0.999396 -0.034743 0
     outer loop
-      vertex 40.7928 48.459 7
-      vertex 41.0228 48.4964 0
+      vertex 38.1602 51.0187 0
+      vertex 38.1521 50.7857 4
+      vertex 38.1521 50.7857 0
+    endloop
+  endfacet
+  facet normal 0.864897 -0.501949 0
+    outer loop
+      vertex 38.4168 51.9091 4
+      vertex 38.5338 52.1107 0
+      vertex 38.5338 52.1107 4
+    endloop
+  endfacet
+  facet normal 0.864897 -0.501949 0
+    outer loop
+      vertex 38.5338 52.1107 0
+      vertex 38.4168 51.9091 4
+      vertex 38.4168 51.9091 0
+    endloop
+  endfacet
+  facet normal 0.909822 -0.414999 0
+    outer loop
+      vertex 38.3201 51.6971 4
+      vertex 38.4168 51.9091 0
+      vertex 38.4168 51.9091 4
+    endloop
+  endfacet
+  facet normal 0.909822 -0.414999 0
+    outer loop
+      vertex 38.4168 51.9091 0
+      vertex 38.3201 51.6971 4
+      vertex 38.3201 51.6971 0
+    endloop
+  endfacet
+  facet normal -0.973288 0.229589 0
+    outer loop
+      vertex 42.809 50.1616 0
+      vertex 42.8625 50.3884 4
+      vertex 42.8625 50.3884 0
+    endloop
+  endfacet
+  facet normal -0.973288 0.229589 0
+    outer loop
+      vertex 42.8625 50.3884 4
+      vertex 42.809 50.1616 0
+      vertex 42.809 50.1616 4
+    endloop
+  endfacet
+  facet normal 0.607116 -0.794614 0
+    outer loop
+      vertex 38.9946 52.6336 0
+      vertex 39.1798 52.7751 4
+      vertex 38.9946 52.6336 4
+    endloop
+  endfacet
+  facet normal 0.607116 -0.794614 0
+    outer loop
+      vertex 39.1798 52.7751 4
+      vertex 38.9946 52.6336 0
+      vertex 39.1798 52.7751 0
+    endloop
+  endfacet
+  facet normal -0.966533 -0.256541 0
+    outer loop
+      vertex 42.8495 51.315 0
+      vertex 42.7897 51.5403 4
+      vertex 42.7897 51.5403 0
+    endloop
+  endfacet
+  facet normal -0.966533 -0.256541 0
+    outer loop
+      vertex 42.7897 51.5403 4
+      vertex 42.8495 51.315 0
+      vertex 42.8495 51.315 4
+    endloop
+  endfacet
+  facet normal 0.501949 0.864897 -0
+    outer loop
+      vertex 39.4368 48.709 0
+      vertex 39.2352 48.826 4
+      vertex 39.4368 48.709 4
+    endloop
+  endfacet
+  facet normal 0.501949 0.864897 0
+    outer loop
+      vertex 39.2352 48.826 4
+      vertex 39.4368 48.709 0
+      vertex 39.2352 48.826 0
+    endloop
+  endfacet
+  facet normal 0.936699 0.350136 0
+    outer loop
+      vertex 38.3456 49.8795 4
+      vertex 38.264 50.0978 0
+      vertex 38.264 50.0978 4
+    endloop
+  endfacet
+  facet normal 0.936699 0.350136 0
+    outer loop
+      vertex 38.264 50.0978 0
+      vertex 38.3456 49.8795 4
+      vertex 38.3456 49.8795 0
+    endloop
+  endfacet
+  facet normal -0.794614 -0.607116 0
+    outer loop
+      vertex 42.4829 52.1661 0
+      vertex 42.3414 52.3513 4
+      vertex 42.3414 52.3513 0
+    endloop
+  endfacet
+  facet normal -0.794614 -0.607116 0
+    outer loop
+      vertex 42.3414 52.3513 4
+      vertex 42.4829 52.1661 0
+      vertex 42.4829 52.1661 4
+    endloop
+  endfacet
+  facet normal 0.966533 0.256541 0
+    outer loop
+      vertex 38.264 50.0978 4
+      vertex 38.2042 50.3231 0
+      vertex 38.2042 50.3231 4
+    endloop
+  endfacet
+  facet normal 0.966533 0.256541 0
+    outer loop
+      vertex 38.2042 50.3231 0
+      vertex 38.264 50.0978 4
+      vertex 38.264 50.0978 0
+    endloop
+  endfacet
+  facet normal -0.897917 -0.440164 0
+    outer loop
+      vertex 42.7081 51.7586 0
+      vertex 42.6055 51.9679 4
+      vertex 42.6055 51.9679 0
+    endloop
+  endfacet
+  facet normal -0.897917 -0.440164 0
+    outer loop
+      vertex 42.6055 51.9679 4
+      vertex 42.7081 51.7586 0
+      vertex 42.7081 51.7586 4
+    endloop
+  endfacet
+  facet normal 0.681783 -0.731554 0
+    outer loop
+      vertex 38.8241 52.4747 0
+      vertex 38.9946 52.6336 4
+      vertex 38.8241 52.4747 4
+    endloop
+  endfacet
+  facet normal 0.681783 -0.731554 0
+    outer loop
+      vertex 38.9946 52.6336 4
+      vertex 38.8241 52.4747 0
+      vertex 38.9946 52.6336 0
+    endloop
+  endfacet
+  facet normal -0.864897 0.501949 0
+    outer loop
+      vertex 42.5199 49.5274 0
+      vertex 42.6369 49.729 4
+      vertex 42.6369 49.729 0
+    endloop
+  endfacet
+  facet normal -0.864897 0.501949 0
+    outer loop
+      vertex 42.6369 49.729 4
+      vertex 42.5199 49.5274 0
+      vertex 42.5199 49.5274 4
+    endloop
+  endfacet
+  facet normal 0.256541 -0.966533 0
+    outer loop
+      vertex 39.8056 53.0819 0
+      vertex 40.0309 53.1417 4
+      vertex 39.8056 53.0819 4
+    endloop
+  endfacet
+  facet normal 0.256541 -0.966533 0
+    outer loop
+      vertex 40.0309 53.1417 4
+      vertex 39.8056 53.0819 0
+      vertex 40.0309 53.1417 0
+    endloop
+  endfacet
+  facet normal -0.0351714 -0.999381 0
+    outer loop
+      vertex 40.4935 53.1938 0
+      vertex 40.7265 53.1856 4
+      vertex 40.4935 53.1938 4
+    endloop
+  endfacet
+  facet normal -0.0351714 -0.999381 -0
+    outer loop
+      vertex 40.7265 53.1856 4
+      vertex 40.4935 53.1938 0
+      vertex 40.7265 53.1856 0
+    endloop
+  endfacet
+  facet normal 0.750313 -0.661082 0
+    outer loop
+      vertex 38.67 52.2998 4
+      vertex 38.8241 52.4747 0
+      vertex 38.8241 52.4747 4
+    endloop
+  endfacet
+  facet normal 0.750313 -0.661082 0
+    outer loop
+      vertex 38.8241 52.4747 0
+      vertex 38.67 52.2998 4
+      vertex 38.67 52.2998 0
+    endloop
+  endfacet
+  facet normal 0.850448 0.526059 0
+    outer loop
+      vertex 38.5708 49.472 4
+      vertex 38.4482 49.6702 0
+      vertex 38.4482 49.6702 4
+    endloop
+  endfacet
+  facet normal 0.850448 0.526059 0
+    outer loop
+      vertex 38.4482 49.6702 0
+      vertex 38.5708 49.472 4
+      vertex 38.5708 49.472 0
+    endloop
+  endfacet
+  facet normal 0.946254 -0.323425 0
+    outer loop
+      vertex 38.2447 51.4765 4
+      vertex 38.3201 51.6971 0
+      vertex 38.3201 51.6971 4
+    endloop
+  endfacet
+  facet normal 0.946254 -0.323425 0
+    outer loop
+      vertex 38.3201 51.6971 0
+      vertex 38.2447 51.4765 4
+      vertex 38.2447 51.4765 0
+    endloop
+  endfacet
+  facet normal -0.440164 0.897917 0
+    outer loop
+      vertex 41.6757 48.7404 0
+      vertex 41.4664 48.6378 4
+      vertex 41.6757 48.7404 4
+    endloop
+  endfacet
+  facet normal -0.440164 0.897917 0
+    outer loop
+      vertex 41.4664 48.6378 4
+      vertex 41.6757 48.7404 0
+      vertex 41.4664 48.6378 0
+    endloop
+  endfacet
+  facet normal 0.584237 0.811583 -0
+    outer loop
+      vertex 39.2352 48.826 0
+      vertex 39.046 48.9622 4
+      vertex 39.2352 48.826 4
+    endloop
+  endfacet
+  facet normal 0.584237 0.811583 0
+    outer loop
+      vertex 39.046 48.9622 4
+      vertex 39.2352 48.826 0
+      vertex 39.046 48.9622 0
+    endloop
+  endfacet
+  facet normal -0.936699 -0.350136 0
+    outer loop
+      vertex 42.7897 51.5403 0
+      vertex 42.7081 51.7586 4
+      vertex 42.7081 51.7586 0
+    endloop
+  endfacet
+  facet normal -0.936699 -0.350136 0
+    outer loop
+      vertex 42.7081 51.7586 4
+      vertex 42.7897 51.5403 0
+      vertex 42.7897 51.5403 4
+    endloop
+  endfacet
+  facet normal -0.998009 -0.0630728 0
+    outer loop
+      vertex 42.9016 50.8524 0
+      vertex 42.8869 51.085 4
+      vertex 42.8869 51.085 0
+    endloop
+  endfacet
+  facet normal -0.998009 -0.0630728 0
+    outer loop
+      vertex 42.8869 51.085 4
+      vertex 42.9016 50.8524 0
+      vertex 42.9016 50.8524 4
+    endloop
+  endfacet
+  facet normal 0.973288 -0.229589 0
+    outer loop
+      vertex 38.1912 51.2497 4
+      vertex 38.2447 51.4765 0
+      vertex 38.2447 51.4765 4
+    endloop
+  endfacet
+  facet normal 0.973288 -0.229589 0
+    outer loop
+      vertex 38.2447 51.4765 0
+      vertex 38.1912 51.2497 4
+      vertex 38.1912 51.2497 0
+    endloop
+  endfacet
+  facet normal -0.750313 0.661082 0
+    outer loop
+      vertex 42.2296 49.1634 0
+      vertex 42.3837 49.3383 4
+      vertex 42.3837 49.3383 0
+    endloop
+  endfacet
+  facet normal -0.750313 0.661082 0
+    outer loop
+      vertex 42.3837 49.3383 4
+      vertex 42.2296 49.1634 0
+      vertex 42.2296 49.1634 4
+    endloop
+  endfacet
+  facet normal 0.440164 -0.897917 0
+    outer loop
+      vertex 39.378 52.8977 0
+      vertex 39.5873 53.0003 4
+      vertex 39.378 52.8977 4
+    endloop
+  endfacet
+  facet normal 0.440164 -0.897917 0
+    outer loop
+      vertex 39.5873 53.0003 4
+      vertex 39.378 52.8977 0
+      vertex 39.5873 53.0003 0
+    endloop
+  endfacet
+  facet normal -0.850448 -0.526059 0
+    outer loop
+      vertex 42.6055 51.9679 0
+      vertex 42.4829 52.1661 4
+      vertex 42.4829 52.1661 0
+    endloop
+  endfacet
+  facet normal -0.850448 -0.526059 0
+    outer loop
+      vertex 42.4829 52.1661 4
+      vertex 42.6055 51.9679 0
+      vertex 42.6055 51.9679 4
+    endloop
+  endfacet
+  facet normal -0.350136 0.936699 0
+    outer loop
+      vertex 41.4664 48.6378 0
+      vertex 41.2481 48.5562 4
+      vertex 41.4664 48.6378 4
+    endloop
+  endfacet
+  facet normal -0.350136 0.936699 0
+    outer loop
+      vertex 41.2481 48.5562 4
+      vertex 41.4664 48.6378 0
+      vertex 41.2481 48.5562 0
+    endloop
+  endfacet
+  facet normal -0.323425 -0.946254 0
+    outer loop
+      vertex 41.1843 53.1012 0
+      vertex 41.4049 53.0258 4
+      vertex 41.1843 53.1012 4
+    endloop
+  endfacet
+  facet normal -0.323425 -0.946254 -0
+    outer loop
+      vertex 41.4049 53.0258 4
+      vertex 41.1843 53.1012 0
+      vertex 41.4049 53.0258 0
+    endloop
+  endfacet
+  facet normal 0.998009 0.0630728 0
+    outer loop
+      vertex 38.1668 50.5531 4
+      vertex 38.1521 50.7857 0
+      vertex 38.1521 50.7857 4
+    endloop
+  endfacet
+  facet normal 0.998009 0.0630728 0
+    outer loop
+      vertex 38.1521 50.7857 0
+      vertex 38.1668 50.5531 4
+      vertex 38.1668 50.5531 0
+    endloop
+  endfacet
+  facet normal -0.731554 -0.681783 0
+    outer loop
+      vertex 42.3414 52.3513 0
+      vertex 42.1825 52.5218 4
+      vertex 42.1825 52.5218 0
+    endloop
+  endfacet
+  facet normal -0.731554 -0.681783 0
+    outer loop
+      vertex 42.1825 52.5218 4
+      vertex 42.3414 52.3513 0
+      vertex 42.3414 52.3513 4
+    endloop
+  endfacet
+  facet normal -0.229589 -0.973288 0
+    outer loop
+      vertex 40.9575 53.1547 0
+      vertex 41.1843 53.1012 4
+      vertex 40.9575 53.1547 4
+    endloop
+  endfacet
+  facet normal -0.229589 -0.973288 -0
+    outer loop
+      vertex 41.1843 53.1012 4
+      vertex 40.9575 53.1547 0
+      vertex 41.1843 53.1012 0
+    endloop
+  endfacet
+  facet normal -0.0630458 0.998011 0
+    outer loop
       vertex 40.7928 48.459 0
+      vertex 40.5601 48.4443 4
+      vertex 40.7928 48.459 4
     endloop
   endfacet
-  facet normal -0.256541 0.966533 0
+  facet normal -0.0630458 0.998011 0
     outer loop
-      vertex 41.2481 48.5562 0
-      vertex 41.0228 48.4964 7
-      vertex 41.2481 48.5562 7
+      vertex 40.5601 48.4443 4
+      vertex 40.7928 48.459 0
+      vertex 40.5601 48.4443 0
     endloop
   endfacet
-  facet normal -0.256541 0.966533 0
+  facet normal -0.987036 -0.160501 0
     outer loop
-      vertex 41.0228 48.4964 7
-      vertex 41.2481 48.5562 0
-      vertex 41.0228 48.4964 0
+      vertex 42.8869 51.085 0
+      vertex 42.8495 51.315 4
+      vertex 42.8495 51.315 0
     endloop
   endfacet
-  facet normal -0.440164 0.897917 0
+  facet normal -0.987036 -0.160501 0
     outer loop
-      vertex 41.6757 48.7404 0
-      vertex 41.4664 48.6378 7
-      vertex 41.6757 48.7404 7
+      vertex 42.8495 51.315 4
+      vertex 42.8869 51.085 0
+      vertex 42.8869 51.085 4
     endloop
   endfacet
-  facet normal -0.440164 0.897917 0
+  facet normal -0.132585 -0.991172 0
     outer loop
-      vertex 41.4664 48.6378 7
-      vertex 41.6757 48.7404 0
-      vertex 41.4664 48.6378 0
+      vertex 40.7265 53.1856 0
+      vertex 40.9575 53.1547 4
+      vertex 40.7265 53.1856 4
     endloop
   endfacet
-  facet normal -0.350136 0.936699 0
+  facet normal -0.132585 -0.991172 -0
     outer loop
-      vertex 41.4664 48.6378 0
-      vertex 41.2481 48.5562 7
-      vertex 41.4664 48.6378 7
+      vertex 40.9575 53.1547 4
+      vertex 40.7265 53.1856 0
+      vertex 40.9575 53.1547 0
     endloop
   endfacet
-  facet normal -0.350136 0.936699 0
+  facet normal 0.323425 0.946254 -0
     outer loop
-      vertex 41.2481 48.5562 7
-      vertex 41.4664 48.6378 0
-      vertex 41.2481 48.5562 0
+      vertex 39.8694 48.5369 0
+      vertex 39.6488 48.6123 4
+      vertex 39.8694 48.5369 4
+    endloop
+  endfacet
+  facet normal 0.323425 0.946254 0
+    outer loop
+      vertex 39.6488 48.6123 4
+      vertex 39.8694 48.5369 0
+      vertex 39.6488 48.6123 0
     endloop
   endfacet
   facet normal -0.681783 0.731554 0
     outer loop
       vertex 42.2296 49.1634 0
-      vertex 42.0591 49.0045 7
-      vertex 42.2296 49.1634 7
+      vertex 42.0591 49.0045 4
+      vertex 42.2296 49.1634 4
     endloop
   endfacet
   facet normal -0.681783 0.731554 0
     outer loop
-      vertex 42.0591 49.0045 7
+      vertex 42.0591 49.0045 4
       vertex 42.2296 49.1634 0
       vertex 42.0591 49.0045 0
     endloop
   endfacet
-  facet normal -0.526059 0.850448 0
+  facet normal -0.160501 0.987036 0
     outer loop
-      vertex 41.8739 48.863 0
-      vertex 41.6757 48.7404 7
-      vertex 41.8739 48.863 7
+      vertex 41.0228 48.4964 0
+      vertex 40.7928 48.459 4
+      vertex 41.0228 48.4964 4
     endloop
   endfacet
-  facet normal -0.526059 0.850448 0
+  facet normal -0.160501 0.987036 0
     outer loop
-      vertex 41.6757 48.7404 7
+      vertex 40.7928 48.459 4
+      vertex 41.0228 48.4964 0
+      vertex 40.7928 48.459 0
+    endloop
+  endfacet
+  facet normal 0.0630728 -0.998009 0
+    outer loop
+      vertex 40.2609 53.1791 0
+      vertex 40.4935 53.1938 4
+      vertex 40.2609 53.1791 4
+    endloop
+  endfacet
+  facet normal 0.0630728 -0.998009 0
+    outer loop
+      vertex 40.4935 53.1938 4
+      vertex 40.2609 53.1791 0
+      vertex 40.4935 53.1938 0
+    endloop
+  endfacet
+  facet normal 0.987036 0.160501 0
+    outer loop
+      vertex 38.2042 50.3231 4
+      vertex 38.1668 50.5531 0
+      vertex 38.1668 50.5531 4
+    endloop
+  endfacet
+  facet normal 0.987036 0.160501 0
+    outer loop
+      vertex 38.1668 50.5531 0
+      vertex 38.2042 50.3231 4
+      vertex 38.2042 50.3231 0
+    endloop
+  endfacet
+  facet normal 0.414999 0.909822 -0
+    outer loop
+      vertex 39.6488 48.6123 0
+      vertex 39.4368 48.709 4
+      vertex 39.6488 48.6123 4
+    endloop
+  endfacet
+  facet normal 0.414999 0.909822 0
+    outer loop
+      vertex 39.4368 48.709 4
+      vertex 39.6488 48.6123 0
+      vertex 39.4368 48.709 0
+    endloop
+  endfacet
+  facet normal -0.999381 0.0351714 0
+    outer loop
+      vertex 42.8934 50.6194 0
+      vertex 42.9016 50.8524 4
+      vertex 42.9016 50.8524 0
+    endloop
+  endfacet
+  facet normal -0.999381 0.0351714 0
+    outer loop
+      vertex 42.9016 50.8524 4
+      vertex 42.8934 50.6194 0
+      vertex 42.8934 50.6194 4
+    endloop
+  endfacet
+  facet normal -0.607116 0.794614 0
+    outer loop
+      vertex 42.0591 49.0045 0
+      vertex 41.8739 48.863 4
+      vertex 42.0591 49.0045 4
+    endloop
+  endfacet
+  facet normal -0.607116 0.794614 0
+    outer loop
+      vertex 41.8739 48.863 4
+      vertex 42.0591 49.0045 0
       vertex 41.8739 48.863 0
-      vertex 41.6757 48.7404 0
+    endloop
+  endfacet
+  facet normal 0.160501 -0.987036 0
+    outer loop
+      vertex 40.0309 53.1417 0
+      vertex 40.2609 53.1791 4
+      vertex 40.0309 53.1417 4
+    endloop
+  endfacet
+  facet normal 0.160501 -0.987036 0
+    outer loop
+      vertex 40.2609 53.1791 4
+      vertex 40.0309 53.1417 0
+      vertex 40.2609 53.1791 0
+    endloop
+  endfacet
+  facet normal 0.133007 0.991115 -0
+    outer loop
+      vertex 40.3272 48.4524 0
+      vertex 40.0962 48.4834 4
+      vertex 40.3272 48.4524 4
+    endloop
+  endfacet
+  facet normal 0.133007 0.991115 0
+    outer loop
+      vertex 40.0962 48.4834 4
+      vertex 40.3272 48.4524 0
+      vertex 40.0962 48.4834 0
+    endloop
+  endfacet
+  facet normal 0.794821 0.606845 0
+    outer loop
+      vertex 38.7122 49.2868 4
+      vertex 38.5708 49.472 0
+      vertex 38.5708 49.472 4
+    endloop
+  endfacet
+  facet normal 0.794821 0.606845 0
+    outer loop
+      vertex 38.5708 49.472 0
+      vertex 38.7122 49.2868 4
+      vertex 38.7122 49.2868 0
+    endloop
+  endfacet
+  facet normal -0.256541 0.966533 0
+    outer loop
+      vertex 41.2481 48.5562 0
+      vertex 41.0228 48.4964 4
+      vertex 41.2481 48.5562 4
+    endloop
+  endfacet
+  facet normal -0.256541 0.966533 0
+    outer loop
+      vertex 41.0228 48.4964 4
+      vertex 41.2481 48.5562 0
+      vertex 41.0228 48.4964 0
+    endloop
+  endfacet
+  facet normal 0.991115 -0.133007 0
+    outer loop
+      vertex 38.1602 51.0187 4
+      vertex 38.1912 51.2497 0
+      vertex 38.1912 51.2497 4
+    endloop
+  endfacet
+  facet normal 0.991115 -0.133007 0
+    outer loop
+      vertex 38.1912 51.2497 0
+      vertex 38.1602 51.0187 4
+      vertex 38.1602 51.0187 0
+    endloop
+  endfacet
+  facet normal -0.909822 0.414999 0
+    outer loop
+      vertex 42.6369 49.729 0
+      vertex 42.7336 49.941 4
+      vertex 42.7336 49.941 0
+    endloop
+  endfacet
+  facet normal -0.909822 0.414999 0
+    outer loop
+      vertex 42.7336 49.941 4
+      vertex 42.6369 49.729 0
+      vertex 42.6369 49.729 4
+    endloop
+  endfacet
+  facet normal 0.661295 0.750126 -0
+    outer loop
+      vertex 39.046 48.9622 0
+      vertex 38.8712 49.1163 4
+      vertex 39.046 48.9622 4
+    endloop
+  endfacet
+  facet normal 0.661295 0.750126 0
+    outer loop
+      vertex 38.8712 49.1163 4
+      vertex 39.046 48.9622 0
+      vertex 38.8712 49.1163 0
+    endloop
+  endfacet
+  facet normal 0.229589 0.973288 -0
+    outer loop
+      vertex 40.0962 48.4834 0
+      vertex 39.8694 48.5369 4
+      vertex 40.0962 48.4834 4
+    endloop
+  endfacet
+  facet normal 0.229589 0.973288 0
+    outer loop
+      vertex 39.8694 48.5369 4
+      vertex 40.0962 48.4834 0
+      vertex 39.8694 48.5369 0
+    endloop
+  endfacet
+  facet normal 0.897917 0.440164 0
+    outer loop
+      vertex 38.4482 49.6702 4
+      vertex 38.3456 49.8795 0
+      vertex 38.3456 49.8795 4
+    endloop
+  endfacet
+  facet normal 0.897917 0.440164 0
+    outer loop
+      vertex 38.3456 49.8795 0
+      vertex 38.4482 49.6702 4
+      vertex 38.4482 49.6702 0
+    endloop
+  endfacet
+  facet normal -0.623491 -0.781831 0
+    outer loop
+      vertex 35.826 60.9631 4
+      vertex 51.4626 48.4933 7
+      vertex 35.826 60.9631 7
+    endloop
+  endfacet
+  facet normal -0.623491 -0.781831 -0
+    outer loop
+      vertex 51.4626 48.4933 7
+      vertex 35.826 60.9631 4
+      vertex 51.4626 48.4933 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.8934 50.6194 4
+      vertex 51.4626 48.4933 4
+      vertex 42.9016 50.8524 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.8869 51.085 4
+      vertex 42.9016 50.8524 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.8495 51.315 4
+      vertex 42.8869 51.085 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.7897 51.5403 4
+      vertex 42.8495 51.315 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.7081 51.7586 4
+      vertex 42.7897 51.5403 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.6055 51.9679 4
+      vertex 42.7081 51.7586 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.4829 52.1661 4
+      vertex 42.6055 51.9679 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.3414 52.3513 4
+      vertex 42.4829 52.1661 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.1825 52.5218 4
+      vertex 42.3414 52.3513 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.0076 52.6759 4
+      vertex 42.1825 52.5218 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 60.9631 4
+      vertex 42.0076 52.6759 4
+      vertex 51.4626 48.4933 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.0076 52.6759 4
+      vertex 35.826 60.9631 4
+      vertex 41.8185 52.8121 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.8185 52.8121 4
+      vertex 35.826 60.9631 4
+      vertex 41.6169 52.9291 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1912 51.2497 4
+      vertex 29.5911 53.1448 4
+      vertex 38.1602 51.0187 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.2447 51.4765 4
+      vertex 29.5911 53.1448 4
+      vertex 38.1912 51.2497 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.3201 51.6971 4
+      vertex 29.5911 53.1448 4
+      vertex 38.2447 51.4765 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.4168 51.9091 4
+      vertex 29.5911 53.1448 4
+      vertex 38.3201 51.6971 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.5338 52.1107 4
+      vertex 29.5911 53.1448 4
+      vertex 38.4168 51.9091 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.67 52.2998 4
+      vertex 29.5911 53.1448 4
+      vertex 38.5338 52.1107 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 29.5911 53.1448 4
+      vertex 38.67 52.2998 4
+      vertex 35.826 60.9631 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.8241 52.4747 4
+      vertex 35.826 60.9631 4
+      vertex 38.67 52.2998 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.9946 52.6336 4
+      vertex 35.826 60.9631 4
+      vertex 38.8241 52.4747 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.1798 52.7751 4
+      vertex 35.826 60.9631 4
+      vertex 38.9946 52.6336 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.378 52.8977 4
+      vertex 35.826 60.9631 4
+      vertex 39.1798 52.7751 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.5873 53.0003 4
+      vertex 35.826 60.9631 4
+      vertex 39.378 52.8977 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.8056 53.0819 4
+      vertex 35.826 60.9631 4
+      vertex 39.5873 53.0003 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.0309 53.1417 4
+      vertex 35.826 60.9631 4
+      vertex 39.8056 53.0819 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.2609 53.1791 4
+      vertex 35.826 60.9631 4
+      vertex 40.0309 53.1417 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.4935 53.1938 4
+      vertex 35.826 60.9631 4
+      vertex 40.2609 53.1791 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.7265 53.1856 4
+      vertex 35.826 60.9631 4
+      vertex 40.4935 53.1938 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.9575 53.1547 4
+      vertex 35.826 60.9631 4
+      vertex 40.7265 53.1856 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.1843 53.1012 4
+      vertex 35.826 60.9631 4
+      vertex 40.9575 53.1547 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.4049 53.0258 4
+      vertex 35.826 60.9631 4
+      vertex 41.1843 53.1012 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 41.6169 52.9291 4
+      vertex 35.826 60.9631 4
+      vertex 41.4049 53.0258 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.8625 50.3884 4
+      vertex 51.4626 48.4933 4
+      vertex 42.8934 50.6194 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.809 50.1616 4
+      vertex 51.4626 48.4933 4
+      vertex 42.8625 50.3884 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.7336 49.941 4
+      vertex 51.4626 48.4933 4
+      vertex 42.809 50.1616 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.6369 49.729 4
+      vertex 51.4626 48.4933 4
+      vertex 42.7336 49.941 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.5199 49.5274 4
+      vertex 51.4626 48.4933 4
+      vertex 42.6369 49.729 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.3837 49.3383 4
+      vertex 51.4626 48.4933 4
+      vertex 42.5199 49.5274 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 48.4933 4
+      vertex 42.3837 49.3383 4
+      vertex 45.2277 40.675 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.2296 49.1634 4
+      vertex 45.2277 40.675 4
+      vertex 42.3837 49.3383 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.0591 49.0045 4
+      vertex 45.2277 40.675 4
+      vertex 42.2296 49.1634 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.8739 48.863 4
+      vertex 45.2277 40.675 4
+      vertex 42.0591 49.0045 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.6757 48.7404 4
+      vertex 45.2277 40.675 4
+      vertex 41.8739 48.863 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.4664 48.6378 4
+      vertex 45.2277 40.675 4
+      vertex 41.6757 48.7404 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.2481 48.5562 4
+      vertex 45.2277 40.675 4
+      vertex 41.4664 48.6378 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.0228 48.4964 4
+      vertex 45.2277 40.675 4
+      vertex 41.2481 48.5562 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.7928 48.459 4
+      vertex 45.2277 40.675 4
+      vertex 41.0228 48.4964 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.5601 48.4443 4
+      vertex 45.2277 40.675 4
+      vertex 40.7928 48.459 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.3272 48.4524 4
+      vertex 45.2277 40.675 4
+      vertex 40.5601 48.4443 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.0962 48.4834 4
+      vertex 45.2277 40.675 4
+      vertex 40.3272 48.4524 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.8694 48.5369 4
+      vertex 45.2277 40.675 4
+      vertex 40.0962 48.4834 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.6488 48.6123 4
+      vertex 45.2277 40.675 4
+      vertex 39.8694 48.5369 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.4368 48.709 4
+      vertex 45.2277 40.675 4
+      vertex 39.6488 48.6123 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.2352 48.826 4
+      vertex 45.2277 40.675 4
+      vertex 39.4368 48.709 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.046 48.9622 4
+      vertex 45.2277 40.675 4
+      vertex 39.2352 48.826 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 53.1448 4
+      vertex 39.046 48.9622 4
+      vertex 38.8712 49.1163 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 53.1448 4
+      vertex 38.8712 49.1163 4
+      vertex 38.7122 49.2868 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 53.1448 4
+      vertex 38.7122 49.2868 4
+      vertex 38.5708 49.472 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1602 51.0187 4
+      vertex 29.5911 53.1448 4
+      vertex 38.1521 50.7857 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1521 50.7857 4
+      vertex 29.5911 53.1448 4
+      vertex 38.1668 50.5531 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.046 48.9622 4
+      vertex 29.5911 53.1448 4
+      vertex 45.2277 40.675 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.4482 49.6702 4
+      vertex 29.5911 53.1448 4
+      vertex 38.5708 49.472 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.3456 49.8795 4
+      vertex 29.5911 53.1448 4
+      vertex 38.4482 49.6702 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.264 50.0978 4
+      vertex 29.5911 53.1448 4
+      vertex 38.3456 49.8795 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.2042 50.3231 4
+      vertex 29.5911 53.1448 4
+      vertex 38.264 50.0978 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1668 50.5531 4
+      vertex 29.5911 53.1448 4
+      vertex 38.2042 50.3231 4
+    endloop
+  endfacet
+  facet normal 0.623491 0.781831 -0
+    outer loop
+      vertex 45.2277 40.675 4
+      vertex 29.5911 53.1448 7
+      vertex 45.2277 40.675 7
+    endloop
+  endfacet
+  facet normal 0.623491 0.781831 0
+    outer loop
+      vertex 29.5911 53.1448 7
+      vertex 45.2277 40.675 4
+      vertex 29.5911 53.1448 4
+    endloop
+  endfacet
+  facet normal 0.781831 -0.623491 0
+    outer loop
+      vertex 29.5911 53.1448 7
+      vertex 35.826 60.9631 4
+      vertex 35.826 60.9631 7
+    endloop
+  endfacet
+  facet normal 0.781831 -0.623491 0
+    outer loop
+      vertex 35.826 60.9631 4
+      vertex 29.5911 53.1448 7
+      vertex 29.5911 53.1448 4
+    endloop
+  endfacet
+  facet normal -0.781831 0.623491 0
+    outer loop
+      vertex 45.2277 40.675 4
+      vertex 51.4626 48.4933 7
+      vertex 51.4626 48.4933 4
+    endloop
+  endfacet
+  facet normal -0.781831 0.623491 0
+    outer loop
+      vertex 51.4626 48.4933 7
+      vertex 45.2277 40.675 4
+      vertex 45.2277 40.675 7
     endloop
   endfacet
   facet normal -0.222522 0.974928 0
@@ -7769,900 +5361,1432 @@ solid OpenSCAD_Model
       vertex 13.2443 58.027 0
     endloop
   endfacet
-  facet normal 0.691933 -0.721961 0
-    outer loop
-      vertex -16.1897 65.0019 0
-      vertex -16.0214 65.1632 7
-      vertex -16.1897 65.0019 7
-    endloop
-  endfacet
-  facet normal 0.691933 -0.721961 0
-    outer loop
-      vertex -16.0214 65.1632 7
-      vertex -16.1897 65.0019 0
-      vertex -16.0214 65.1632 0
-    endloop
-  endfacet
-  facet normal 0.992911 -0.118858 0
-    outer loop
-      vertex -16.833 63.5367 7
-      vertex -16.8053 63.7681 0
-      vertex -16.8053 63.7681 7
-    endloop
-  endfacet
-  facet normal 0.992911 -0.118858 0
-    outer loop
-      vertex -16.8053 63.7681 0
-      vertex -16.833 63.5367 7
-      vertex -16.833 63.5367 0
-    endloop
-  endfacet
-  facet normal 0.786363 0.617765 0
-    outer loop
-      vertex -16.2568 61.8127 7
-      vertex -16.4008 61.996 0
-      vertex -16.4008 61.996 7
-    endloop
-  endfacet
-  facet normal 0.786363 0.617765 0
-    outer loop
-      vertex -16.4008 61.996 0
-      vertex -16.2568 61.8127 7
-      vertex -16.2568 61.8127 0
-    endloop
-  endfacet
-  facet normal 0.118858 0.992911 -0
-    outer loop
-      vertex -14.6303 61.0012 0
-      vertex -14.8617 61.0289 7
-      vertex -14.6303 61.0012 7
-    endloop
-  endfacet
-  facet normal 0.118858 0.992911 0
-    outer loop
-      vertex -14.8617 61.0289 7
-      vertex -14.6303 61.0012 0
-      vertex -14.8617 61.0289 0
-    endloop
-  endfacet
-  facet normal 0.174201 -0.98471 0
-    outer loop
-      vertex -14.9923 65.6858 0
-      vertex -14.7628 65.7264 7
-      vertex -14.9923 65.6858 7
-    endloop
-  endfacet
-  facet normal 0.174201 -0.98471 0
-    outer loop
-      vertex -14.7628 65.7264 7
-      vertex -14.9923 65.6858 0
-      vertex -14.7628 65.7264 0
-    endloop
-  endfacet
   facet normal 0.95068 -0.310172 0
     outer loop
-      vertex -16.755 63.9957 7
+      vertex -16.755 63.9957 4
       vertex -16.6827 64.2173 0
-      vertex -16.6827 64.2173 7
+      vertex -16.6827 64.2173 4
     endloop
   endfacet
   facet normal 0.95068 -0.310172 0
     outer loop
       vertex -16.6827 64.2173 0
-      vertex -16.755 63.9957 7
+      vertex -16.755 63.9957 4
       vertex -16.755 63.9957 0
-    endloop
-  endfacet
-  facet normal 0.402034 0.915625 -0
-    outer loop
-      vertex -15.3108 61.1515 0
-      vertex -15.5242 61.2452 7
-      vertex -15.3108 61.1515 7
-    endloop
-  endfacet
-  facet normal 0.402034 0.915625 0
-    outer loop
-      vertex -15.5242 61.2452 7
-      vertex -15.3108 61.1515 0
-      vertex -15.5242 61.2452 0
-    endloop
-  endfacet
-  facet normal 0.891752 0.452524 0
-    outer loop
-      vertex -16.5262 62.1924 7
-      vertex -16.6317 62.4003 0
-      vertex -16.6317 62.4003 7
-    endloop
-  endfacet
-  facet normal 0.891752 0.452524 0
-    outer loop
-      vertex -16.6317 62.4003 0
-      vertex -16.5262 62.1924 7
-      vertex -16.5262 62.1924 0
     endloop
   endfacet
   facet normal 0.363088 -0.931755 0
     outer loop
       vertex -15.4339 65.5382 0
-      vertex -15.2168 65.6228 7
-      vertex -15.4339 65.5382 7
+      vertex -15.2168 65.6228 4
+      vertex -15.4339 65.5382 4
     endloop
   endfacet
   facet normal 0.363088 -0.931755 0
     outer loop
-      vertex -15.2168 65.6228 7
+      vertex -15.2168 65.6228 4
       vertex -15.4339 65.5382 0
       vertex -15.2168 65.6228 0
     endloop
   endfacet
-  facet normal 0.759499 -0.650509 0
+  facet normal 0.270187 -0.962808 0
     outer loop
-      vertex -16.3413 64.8249 7
-      vertex -16.1897 65.0019 0
-      vertex -16.1897 65.0019 7
+      vertex -15.2168 65.6228 0
+      vertex -14.9923 65.6858 4
+      vertex -15.2168 65.6228 4
     endloop
   endfacet
-  facet normal 0.759499 -0.650509 0
+  facet normal 0.270187 -0.962808 0
     outer loop
-      vertex -16.1897 65.0019 0
-      vertex -16.3413 64.8249 7
-      vertex -16.3413 64.8249 0
+      vertex -14.9923 65.6858 4
+      vertex -15.2168 65.6228 0
+      vertex -14.9923 65.6858 0
     endloop
   endfacet
-  facet normal 0.871759 -0.489935 0
+  facet normal 0.452698 -0.891664 0
     outer loop
-      vertex -16.589 64.4307 7
-      vertex -16.4748 64.6339 0
-      vertex -16.4748 64.6339 7
+      vertex -15.6417 65.4327 0
+      vertex -15.4339 65.5382 4
+      vertex -15.6417 65.4327 4
     endloop
   endfacet
-  facet normal 0.871759 -0.489935 0
+  facet normal 0.452698 -0.891664 0
     outer loop
-      vertex -16.4748 64.6339 0
-      vertex -16.589 64.4307 7
-      vertex -16.589 64.4307 0
+      vertex -15.4339 65.5382 4
+      vertex -15.6417 65.4327 0
+      vertex -15.4339 65.5382 0
+    endloop
+  endfacet
+  facet normal -0.842972 -0.537958 0
+    outer loop
+      vertex -12.4015 64.5482 0
+      vertex -12.5269 64.7447 4
+      vertex -12.5269 64.7447 0
+    endloop
+  endfacet
+  facet normal -0.842972 -0.537958 0
+    outer loop
+      vertex -12.5269 64.7447 4
+      vertex -12.4015 64.5482 0
+      vertex -12.4015 64.5482 4
+    endloop
+  endfacet
+  facet normal -0.992911 0.118858 0
+    outer loop
+      vertex -12.1224 62.9725 0
+      vertex -12.0947 63.2039 4
+      vertex -12.0947 63.2039 0
+    endloop
+  endfacet
+  facet normal -0.992911 0.118858 0
+    outer loop
+      vertex -12.0947 63.2039 4
+      vertex -12.1224 62.9725 0
+      vertex -12.1224 62.9725 4
+    endloop
+  endfacet
+  facet normal -0.0772214 0.997014 0
+    outer loop
+      vertex -14.1649 61.0142 0
+      vertex -14.3973 60.9962 4
+      vertex -14.1649 61.0142 4
+    endloop
+  endfacet
+  facet normal -0.0772214 0.997014 0
+    outer loop
+      vertex -14.3973 60.9962 4
+      vertex -14.1649 61.0142 0
+      vertex -14.3973 60.9962 0
     endloop
   endfacet
   facet normal 0.962888 0.2699 0
     outer loop
-      vertex -16.7164 62.6174 7
+      vertex -16.7164 62.6174 4
       vertex -16.7793 62.8418 0
-      vertex -16.7793 62.8418 7
+      vertex -16.7793 62.8418 4
     endloop
   endfacet
   facet normal 0.962888 0.2699 0
     outer loop
       vertex -16.7793 62.8418 0
-      vertex -16.7164 62.6174 7
+      vertex -16.7164 62.6174 4
       vertex -16.7164 62.6174 0
     endloop
   endfacet
-  facet normal 0.999779 -0.0210254 0
+  facet normal 0.174201 -0.98471 0
     outer loop
-      vertex -16.8379 63.3037 7
-      vertex -16.833 63.5367 0
-      vertex -16.833 63.5367 7
+      vertex -14.9923 65.6858 0
+      vertex -14.7628 65.7264 4
+      vertex -14.9923 65.6858 4
     endloop
   endfacet
-  facet normal 0.999779 -0.0210254 0
+  facet normal 0.174201 -0.98471 0
     outer loop
-      vertex -16.833 63.5367 0
-      vertex -16.8379 63.3037 7
-      vertex -16.8379 63.3037 0
+      vertex -14.7628 65.7264 4
+      vertex -14.9923 65.6858 0
+      vertex -14.7628 65.7264 0
     endloop
   endfacet
-  facet normal 0.997047 0.0767949 0
+  facet normal 0.992911 -0.118858 0
     outer loop
-      vertex -16.82 63.0713 7
-      vertex -16.8379 63.3037 0
-      vertex -16.8379 63.3037 7
-    endloop
-  endfacet
-  facet normal 0.997047 0.0767949 0
-    outer loop
-      vertex -16.8379 63.3037 0
-      vertex -16.82 63.0713 7
-      vertex -16.82 63.0713 0
-    endloop
-  endfacet
-  facet normal 0.976439 -0.215795 0
-    outer loop
-      vertex -16.8053 63.7681 7
-      vertex -16.755 63.9957 0
-      vertex -16.755 63.9957 7
-    endloop
-  endfacet
-  facet normal 0.976439 -0.215795 0
-    outer loop
-      vertex -16.755 63.9957 0
-      vertex -16.8053 63.7681 7
+      vertex -16.833 63.5367 4
       vertex -16.8053 63.7681 0
+      vertex -16.8053 63.7681 4
     endloop
   endfacet
-  facet normal 0.915625 -0.402034 0
+  facet normal 0.992911 -0.118858 0
     outer loop
-      vertex -16.6827 64.2173 7
-      vertex -16.589 64.4307 0
-      vertex -16.589 64.4307 7
+      vertex -16.8053 63.7681 0
+      vertex -16.833 63.5367 4
+      vertex -16.833 63.5367 0
     endloop
   endfacet
-  facet normal 0.915625 -0.402034 0
+  facet normal -0.962777 -0.270298 0
     outer loop
-      vertex -16.589 64.4307 0
-      vertex -16.6827 64.2173 7
-      vertex -16.6827 64.2173 0
+      vertex -12.1484 63.8988 0
+      vertex -12.2114 64.1232 4
+      vertex -12.2114 64.1232 0
     endloop
   endfacet
-  facet normal -0.2699 0.962888 0
+  facet normal -0.962777 -0.270298 0
     outer loop
-      vertex -13.711 61.1178 0
-      vertex -13.9354 61.0549 7
-      vertex -13.711 61.1178 7
+      vertex -12.2114 64.1232 4
+      vertex -12.1484 63.8988 0
+      vertex -12.1484 63.8988 4
     endloop
   endfacet
-  facet normal -0.2699 0.962888 0
+  facet normal -0.721756 -0.692148 0
     outer loop
-      vertex -13.9354 61.0549 7
-      vertex -13.711 61.1178 0
-      vertex -13.9354 61.0549 0
+      vertex -12.6709 64.9279 0
+      vertex -12.8322 65.0961 4
+      vertex -12.8322 65.0961 0
     endloop
   endfacet
-  facet normal 0.0214543 0.99977 -0
+  facet normal -0.721756 -0.692148 0
     outer loop
-      vertex -14.3973 60.9962 0
-      vertex -14.6303 61.0012 7
-      vertex -14.3973 60.9962 7
+      vertex -12.8322 65.0961 4
+      vertex -12.6709 64.9279 0
+      vertex -12.6709 64.9279 4
     endloop
   endfacet
-  facet normal 0.0214543 0.99977 0
+  facet normal -0.759499 0.650509 0
     outer loop
-      vertex -14.6303 61.0012 7
-      vertex -14.3973 60.9962 0
-      vertex -14.6303 61.0012 0
+      vertex -12.738 61.7387 0
+      vertex -12.5864 61.9157 4
+      vertex -12.5864 61.9157 0
     endloop
   endfacet
-  facet normal -0.0772214 0.997014 0
+  facet normal -0.759499 0.650509 0
     outer loop
-      vertex -14.1649 61.0142 0
-      vertex -14.3973 60.9962 7
-      vertex -14.1649 61.0142 7
-    endloop
-  endfacet
-  facet normal -0.0772214 0.997014 0
-    outer loop
-      vertex -14.3973 60.9962 7
-      vertex -14.1649 61.0142 0
-      vertex -14.3973 60.9962 0
-    endloop
-  endfacet
-  facet normal 0.215386 0.976529 -0
-    outer loop
-      vertex -14.8617 61.0289 0
-      vertex -15.0893 61.0791 7
-      vertex -14.8617 61.0289 7
-    endloop
-  endfacet
-  facet normal 0.215386 0.976529 0
-    outer loop
-      vertex -15.0893 61.0791 7
-      vertex -14.8617 61.0289 0
-      vertex -15.0893 61.0791 0
-    endloop
-  endfacet
-  facet normal 0.310687 0.950512 -0
-    outer loop
-      vertex -15.0893 61.0791 0
-      vertex -15.3108 61.1515 7
-      vertex -15.0893 61.0791 7
-    endloop
-  endfacet
-  facet normal 0.310687 0.950512 0
-    outer loop
-      vertex -15.3108 61.1515 7
-      vertex -15.0893 61.0791 0
-      vertex -15.3108 61.1515 0
-    endloop
-  endfacet
-  facet normal 0.842848 0.538152 0
-    outer loop
-      vertex -16.4008 61.996 7
-      vertex -16.5262 62.1924 0
-      vertex -16.5262 62.1924 7
-    endloop
-  endfacet
-  facet normal 0.842848 0.538152 0
-    outer loop
-      vertex -16.5262 62.1924 0
-      vertex -16.4008 61.996 7
-      vertex -16.4008 61.996 0
-    endloop
-  endfacet
-  facet normal 0.93161 0.363461 0
-    outer loop
-      vertex -16.6317 62.4003 7
-      vertex -16.7164 62.6174 0
-      vertex -16.7164 62.6174 7
-    endloop
-  endfacet
-  facet normal 0.93161 0.363461 0
-    outer loop
-      vertex -16.7164 62.6174 0
-      vertex -16.6317 62.4003 7
-      vertex -16.6317 62.4003 0
+      vertex -12.5864 61.9157 4
+      vertex -12.738 61.7387 0
+      vertex -12.738 61.7387 4
     endloop
   endfacet
   facet normal 0.650509 0.759499 -0
     outer loop
       vertex -15.9185 61.4929 0
-      vertex -16.0955 61.6445 7
-      vertex -15.9185 61.4929 7
+      vertex -16.0955 61.6445 4
+      vertex -15.9185 61.4929 4
     endloop
   endfacet
   facet normal 0.650509 0.759499 0
     outer loop
-      vertex -16.0955 61.6445 7
+      vertex -16.0955 61.6445 4
       vertex -15.9185 61.4929 0
       vertex -16.0955 61.6445 0
     endloop
   endfacet
-  facet normal 0.572973 0.819574 -0
+  facet normal 0.93161 0.363461 0
     outer loop
-      vertex -15.7274 61.3593 0
-      vertex -15.9185 61.4929 7
-      vertex -15.7274 61.3593 7
+      vertex -16.6317 62.4003 4
+      vertex -16.7164 62.6174 0
+      vertex -16.7164 62.6174 4
     endloop
   endfacet
-  facet normal 0.572973 0.819574 0
+  facet normal 0.93161 0.363461 0
     outer loop
-      vertex -15.9185 61.4929 7
-      vertex -15.7274 61.3593 0
-      vertex -15.9185 61.4929 0
+      vertex -16.7164 62.6174 0
+      vertex -16.6317 62.4003 4
+      vertex -16.6317 62.4003 0
     endloop
   endfacet
-  facet normal 0.721756 0.692148 0
+  facet normal 0.891752 0.452524 0
     outer loop
-      vertex -16.0955 61.6445 7
-      vertex -16.2568 61.8127 0
-      vertex -16.2568 61.8127 7
+      vertex -16.5262 62.1924 4
+      vertex -16.6317 62.4003 0
+      vertex -16.6317 62.4003 4
     endloop
   endfacet
-  facet normal 0.721756 0.692148 0
+  facet normal 0.891752 0.452524 0
     outer loop
-      vertex -16.2568 61.8127 0
-      vertex -16.0955 61.6445 7
-      vertex -16.0955 61.6445 0
-    endloop
-  endfacet
-  facet normal 0.489609 0.871942 -0
-    outer loop
-      vertex -15.5242 61.2452 0
-      vertex -15.7274 61.3593 7
-      vertex -15.5242 61.2452 7
-    endloop
-  endfacet
-  facet normal 0.489609 0.871942 0
-    outer loop
-      vertex -15.7274 61.3593 7
-      vertex -15.5242 61.2452 0
-      vertex -15.7274 61.3593 0
-    endloop
-  endfacet
-  facet normal 0.270187 -0.962808 0
-    outer loop
-      vertex -15.2168 65.6228 0
-      vertex -14.9923 65.6858 7
-      vertex -15.2168 65.6228 7
-    endloop
-  endfacet
-  facet normal 0.270187 -0.962808 0
-    outer loop
-      vertex -14.9923 65.6858 7
-      vertex -15.2168 65.6228 0
-      vertex -14.9923 65.6858 0
-    endloop
-  endfacet
-  facet normal -0.0210254 -0.999779 0
-    outer loop
-      vertex -14.5305 65.7444 0
-      vertex -14.2975 65.7395 7
-      vertex -14.5305 65.7444 7
-    endloop
-  endfacet
-  facet normal -0.0210254 -0.999779 -0
-    outer loop
-      vertex -14.2975 65.7395 7
-      vertex -14.5305 65.7444 0
-      vertex -14.2975 65.7395 0
-    endloop
-  endfacet
-  facet normal -0.363315 0.931666 0
-    outer loop
-      vertex -13.4938 61.2025 0
-      vertex -13.711 61.1178 7
-      vertex -13.4938 61.2025 7
-    endloop
-  endfacet
-  facet normal -0.363315 0.931666 0
-    outer loop
-      vertex -13.711 61.1178 7
-      vertex -13.4938 61.2025 0
-      vertex -13.711 61.1178 0
-    endloop
-  endfacet
-  facet normal -0.931811 -0.362943 0
-    outer loop
-      vertex -12.2114 64.1232 0
-      vertex -12.296 64.3404 7
-      vertex -12.296 64.3404 0
-    endloop
-  endfacet
-  facet normal -0.931811 -0.362943 0
-    outer loop
-      vertex -12.296 64.3404 7
-      vertex -12.2114 64.1232 0
-      vertex -12.2114 64.1232 7
+      vertex -16.6317 62.4003 0
+      vertex -16.5262 62.1924 4
+      vertex -16.5262 62.1924 0
     endloop
   endfacet
   facet normal -0.786199 -0.617973 0
     outer loop
       vertex -12.5269 64.7447 0
-      vertex -12.6709 64.9279 7
+      vertex -12.6709 64.9279 4
       vertex -12.6709 64.9279 0
     endloop
   endfacet
   facet normal -0.786199 -0.617973 0
     outer loop
-      vertex -12.6709 64.9279 7
+      vertex -12.6709 64.9279 4
       vertex -12.5269 64.7447 0
-      vertex -12.5269 64.7447 7
+      vertex -12.5269 64.7447 4
     endloop
   endfacet
-  facet normal 0.618238 -0.785991 0
+  facet normal 0.999779 -0.0210254 0
     outer loop
-      vertex -16.0214 65.1632 0
-      vertex -15.8382 65.3073 7
-      vertex -16.0214 65.1632 7
+      vertex -16.8379 63.3037 4
+      vertex -16.833 63.5367 0
+      vertex -16.833 63.5367 4
     endloop
   endfacet
-  facet normal 0.618238 -0.785991 0
+  facet normal 0.999779 -0.0210254 0
     outer loop
-      vertex -15.8382 65.3073 7
-      vertex -16.0214 65.1632 0
-      vertex -15.8382 65.3073 0
-    endloop
-  endfacet
-  facet normal 0.537958 -0.842972 0
-    outer loop
-      vertex -15.8382 65.3073 0
-      vertex -15.6417 65.4327 7
-      vertex -15.8382 65.3073 7
-    endloop
-  endfacet
-  facet normal 0.537958 -0.842972 0
-    outer loop
-      vertex -15.6417 65.4327 7
-      vertex -15.8382 65.3073 0
-      vertex -15.6417 65.4327 0
-    endloop
-  endfacet
-  facet normal 0.819635 -0.572886 0
-    outer loop
-      vertex -16.4748 64.6339 7
-      vertex -16.3413 64.8249 0
-      vertex -16.3413 64.8249 7
-    endloop
-  endfacet
-  facet normal 0.819635 -0.572886 0
-    outer loop
-      vertex -16.3413 64.8249 0
-      vertex -16.4748 64.6339 7
-      vertex -16.4748 64.6339 0
-    endloop
-  endfacet
-  facet normal 0.984636 0.174617 0
-    outer loop
-      vertex -16.7793 62.8418 7
-      vertex -16.82 63.0713 0
-      vertex -16.82 63.0713 7
-    endloop
-  endfacet
-  facet normal 0.984636 0.174617 0
-    outer loop
-      vertex -16.82 63.0713 0
-      vertex -16.7793 62.8418 7
-      vertex -16.7793 62.8418 0
-    endloop
-  endfacet
-  facet normal -0.174617 0.984636 0
-    outer loop
-      vertex -13.9354 61.0549 0
-      vertex -14.1649 61.0142 7
-      vertex -13.9354 61.0549 7
-    endloop
-  endfacet
-  facet normal -0.174617 0.984636 0
-    outer loop
-      vertex -14.1649 61.0142 7
-      vertex -13.9354 61.0549 0
-      vertex -14.1649 61.0142 0
-    endloop
-  endfacet
-  facet normal -0.489935 -0.871759 0
-    outer loop
-      vertex -13.4035 65.4955 0
-      vertex -13.2003 65.3813 7
-      vertex -13.4035 65.4955 7
-    endloop
-  endfacet
-  facet normal -0.489935 -0.871759 -0
-    outer loop
-      vertex -13.2003 65.3813 7
-      vertex -13.4035 65.4955 0
-      vertex -13.2003 65.3813 0
-    endloop
-  endfacet
-  facet normal -0.310299 -0.950639 0
-    outer loop
-      vertex -13.8384 65.6615 0
-      vertex -13.6169 65.5892 7
-      vertex -13.8384 65.6615 7
-    endloop
-  endfacet
-  facet normal -0.310299 -0.950639 -0
-    outer loop
-      vertex -13.6169 65.5892 7
-      vertex -13.8384 65.6615 0
-      vertex -13.6169 65.5892 0
-    endloop
-  endfacet
-  facet normal -0.215795 -0.976439 0
-    outer loop
-      vertex -14.066 65.7118 0
-      vertex -13.8384 65.6615 7
-      vertex -14.066 65.7118 7
-    endloop
-  endfacet
-  facet normal -0.215795 -0.976439 -0
-    outer loop
-      vertex -13.8384 65.6615 7
-      vertex -14.066 65.7118 0
-      vertex -13.8384 65.6615 0
-    endloop
-  endfacet
-  facet normal -0.98471 -0.174201 0
-    outer loop
-      vertex -12.1078 63.6693 0
-      vertex -12.1484 63.8988 7
-      vertex -12.1484 63.8988 0
-    endloop
-  endfacet
-  facet normal -0.98471 -0.174201 0
-    outer loop
-      vertex -12.1484 63.8988 7
-      vertex -12.1078 63.6693 0
-      vertex -12.1078 63.6693 7
-    endloop
-  endfacet
-  facet normal -0.891664 -0.452698 0
-    outer loop
-      vertex -12.296 64.3404 0
-      vertex -12.4015 64.5482 7
-      vertex -12.4015 64.5482 0
-    endloop
-  endfacet
-  facet normal -0.891664 -0.452698 0
-    outer loop
-      vertex -12.4015 64.5482 7
-      vertex -12.296 64.3404 0
-      vertex -12.296 64.3404 7
-    endloop
-  endfacet
-  facet normal -0.842972 -0.537958 0
-    outer loop
-      vertex -12.4015 64.5482 0
-      vertex -12.5269 64.7447 7
-      vertex -12.5269 64.7447 0
-    endloop
-  endfacet
-  facet normal -0.842972 -0.537958 0
-    outer loop
-      vertex -12.5269 64.7447 7
-      vertex -12.4015 64.5482 0
-      vertex -12.4015 64.5482 7
-    endloop
-  endfacet
-  facet normal 0.452698 -0.891664 0
-    outer loop
-      vertex -15.6417 65.4327 0
-      vertex -15.4339 65.5382 7
-      vertex -15.6417 65.4327 7
-    endloop
-  endfacet
-  facet normal 0.452698 -0.891664 0
-    outer loop
-      vertex -15.4339 65.5382 7
-      vertex -15.6417 65.4327 0
-      vertex -15.4339 65.5382 0
-    endloop
-  endfacet
-  facet normal 0.0772544 -0.997011 0
-    outer loop
-      vertex -14.7628 65.7264 0
-      vertex -14.5305 65.7444 7
-      vertex -14.7628 65.7264 7
-    endloop
-  endfacet
-  facet normal 0.0772544 -0.997011 0
-    outer loop
-      vertex -14.5305 65.7444 7
-      vertex -14.7628 65.7264 0
-      vertex -14.5305 65.7444 0
-    endloop
-  endfacet
-  facet normal -0.573174 -0.819433 0
-    outer loop
-      vertex -13.2003 65.3813 0
-      vertex -13.0093 65.2477 7
-      vertex -13.2003 65.3813 7
-    endloop
-  endfacet
-  facet normal -0.573174 -0.819433 -0
-    outer loop
-      vertex -13.0093 65.2477 7
-      vertex -13.2003 65.3813 0
-      vertex -13.0093 65.2477 0
-    endloop
-  endfacet
-  facet normal -0.650297 -0.75968 0
-    outer loop
-      vertex -13.0093 65.2477 0
-      vertex -12.8322 65.0961 7
-      vertex -13.0093 65.2477 7
-    endloop
-  endfacet
-  facet normal -0.650297 -0.75968 -0
-    outer loop
-      vertex -12.8322 65.0961 7
-      vertex -13.0093 65.2477 0
-      vertex -12.8322 65.0961 0
-    endloop
-  endfacet
-  facet normal -0.721756 -0.692148 0
-    outer loop
-      vertex -12.6709 64.9279 0
-      vertex -12.8322 65.0961 7
-      vertex -12.8322 65.0961 0
-    endloop
-  endfacet
-  facet normal -0.721756 -0.692148 0
-    outer loop
-      vertex -12.8322 65.0961 7
-      vertex -12.6709 64.9279 0
-      vertex -12.6709 64.9279 7
+      vertex -16.833 63.5367 0
+      vertex -16.8379 63.3037 4
+      vertex -16.8379 63.3037 0
     endloop
   endfacet
   facet normal -0.402034 -0.915625 0
     outer loop
       vertex -13.6169 65.5892 0
-      vertex -13.4035 65.4955 7
-      vertex -13.6169 65.5892 7
+      vertex -13.4035 65.4955 4
+      vertex -13.6169 65.5892 4
     endloop
   endfacet
   facet normal -0.402034 -0.915625 -0
     outer loop
-      vertex -13.4035 65.4955 7
+      vertex -13.4035 65.4955 4
       vertex -13.6169 65.5892 0
       vertex -13.4035 65.4955 0
+    endloop
+  endfacet
+  facet normal -0.363315 0.931666 0
+    outer loop
+      vertex -13.4938 61.2025 0
+      vertex -13.711 61.1178 4
+      vertex -13.4938 61.2025 4
+    endloop
+  endfacet
+  facet normal -0.363315 0.931666 0
+    outer loop
+      vertex -13.711 61.1178 4
+      vertex -13.4938 61.2025 0
+      vertex -13.711 61.1178 0
+    endloop
+  endfacet
+  facet normal 0.310687 0.950512 -0
+    outer loop
+      vertex -15.0893 61.0791 0
+      vertex -15.3108 61.1515 4
+      vertex -15.0893 61.0791 4
+    endloop
+  endfacet
+  facet normal 0.310687 0.950512 0
+    outer loop
+      vertex -15.3108 61.1515 4
+      vertex -15.0893 61.0791 0
+      vertex -15.3108 61.1515 0
+    endloop
+  endfacet
+  facet normal -0.0210254 -0.999779 0
+    outer loop
+      vertex -14.5305 65.7444 0
+      vertex -14.2975 65.7395 4
+      vertex -14.5305 65.7444 4
+    endloop
+  endfacet
+  facet normal -0.0210254 -0.999779 -0
+    outer loop
+      vertex -14.2975 65.7395 4
+      vertex -14.5305 65.7444 0
+      vertex -14.2975 65.7395 0
+    endloop
+  endfacet
+  facet normal 0.402034 0.915625 -0
+    outer loop
+      vertex -15.3108 61.1515 0
+      vertex -15.5242 61.2452 4
+      vertex -15.3108 61.1515 4
+    endloop
+  endfacet
+  facet normal 0.402034 0.915625 0
+    outer loop
+      vertex -15.5242 61.2452 4
+      vertex -15.3108 61.1515 0
+      vertex -15.5242 61.2452 0
+    endloop
+  endfacet
+  facet normal -0.215795 -0.976439 0
+    outer loop
+      vertex -14.066 65.7118 0
+      vertex -13.8384 65.6615 4
+      vertex -14.066 65.7118 4
+    endloop
+  endfacet
+  facet normal -0.215795 -0.976439 -0
+    outer loop
+      vertex -13.8384 65.6615 4
+      vertex -14.066 65.7118 0
+      vertex -13.8384 65.6615 0
+    endloop
+  endfacet
+  facet normal 0.997047 0.0767949 0
+    outer loop
+      vertex -16.82 63.0713 4
+      vertex -16.8379 63.3037 0
+      vertex -16.8379 63.3037 4
+    endloop
+  endfacet
+  facet normal 0.997047 0.0767949 0
+    outer loop
+      vertex -16.8379 63.3037 0
+      vertex -16.82 63.0713 4
+      vertex -16.82 63.0713 0
+    endloop
+  endfacet
+  facet normal -0.931811 -0.362943 0
+    outer loop
+      vertex -12.2114 64.1232 0
+      vertex -12.296 64.3404 4
+      vertex -12.296 64.3404 0
+    endloop
+  endfacet
+  facet normal -0.931811 -0.362943 0
+    outer loop
+      vertex -12.296 64.3404 4
+      vertex -12.2114 64.1232 0
+      vertex -12.2114 64.1232 4
+    endloop
+  endfacet
+  facet normal 0.915625 -0.402034 0
+    outer loop
+      vertex -16.6827 64.2173 4
+      vertex -16.589 64.4307 0
+      vertex -16.589 64.4307 4
+    endloop
+  endfacet
+  facet normal 0.915625 -0.402034 0
+    outer loop
+      vertex -16.589 64.4307 0
+      vertex -16.6827 64.2173 4
+      vertex -16.6827 64.2173 0
+    endloop
+  endfacet
+  facet normal 0.759499 -0.650509 0
+    outer loop
+      vertex -16.3413 64.8249 4
+      vertex -16.1897 65.0019 0
+      vertex -16.1897 65.0019 4
+    endloop
+  endfacet
+  facet normal 0.759499 -0.650509 0
+    outer loop
+      vertex -16.1897 65.0019 0
+      vertex -16.3413 64.8249 4
+      vertex -16.3413 64.8249 0
+    endloop
+  endfacet
+  facet normal 0.984636 0.174617 0
+    outer loop
+      vertex -16.7793 62.8418 4
+      vertex -16.82 63.0713 0
+      vertex -16.82 63.0713 4
+    endloop
+  endfacet
+  facet normal 0.984636 0.174617 0
+    outer loop
+      vertex -16.82 63.0713 0
+      vertex -16.7793 62.8418 4
+      vertex -16.7793 62.8418 0
+    endloop
+  endfacet
+  facet normal 0.118858 0.992911 -0
+    outer loop
+      vertex -14.6303 61.0012 0
+      vertex -14.8617 61.0289 4
+      vertex -14.6303 61.0012 4
+    endloop
+  endfacet
+  facet normal 0.118858 0.992911 0
+    outer loop
+      vertex -14.8617 61.0289 4
+      vertex -14.6303 61.0012 0
+      vertex -14.8617 61.0289 0
+    endloop
+  endfacet
+  facet normal 0.842848 0.538152 0
+    outer loop
+      vertex -16.4008 61.996 4
+      vertex -16.5262 62.1924 0
+      vertex -16.5262 62.1924 4
+    endloop
+  endfacet
+  facet normal 0.842848 0.538152 0
+    outer loop
+      vertex -16.5262 62.1924 0
+      vertex -16.4008 61.996 4
+      vertex -16.4008 61.996 0
+    endloop
+  endfacet
+  facet normal -0.976439 0.215795 0
+    outer loop
+      vertex -12.1727 62.7449 0
+      vertex -12.1224 62.9725 4
+      vertex -12.1224 62.9725 0
+    endloop
+  endfacet
+  facet normal -0.976439 0.215795 0
+    outer loop
+      vertex -12.1224 62.9725 4
+      vertex -12.1727 62.7449 0
+      vertex -12.1727 62.7449 4
+    endloop
+  endfacet
+  facet normal -0.2699 0.962888 0
+    outer loop
+      vertex -13.711 61.1178 0
+      vertex -13.9354 61.0549 4
+      vertex -13.711 61.1178 4
+    endloop
+  endfacet
+  facet normal -0.2699 0.962888 0
+    outer loop
+      vertex -13.9354 61.0549 4
+      vertex -13.711 61.1178 0
+      vertex -13.9354 61.0549 0
+    endloop
+  endfacet
+  facet normal -0.310299 -0.950639 0
+    outer loop
+      vertex -13.8384 65.6615 0
+      vertex -13.6169 65.5892 4
+      vertex -13.8384 65.6615 4
+    endloop
+  endfacet
+  facet normal -0.310299 -0.950639 -0
+    outer loop
+      vertex -13.6169 65.5892 4
+      vertex -13.8384 65.6615 0
+      vertex -13.6169 65.5892 0
+    endloop
+  endfacet
+  facet normal -0.573174 -0.819433 0
+    outer loop
+      vertex -13.2003 65.3813 0
+      vertex -13.0093 65.2477 4
+      vertex -13.2003 65.3813 4
+    endloop
+  endfacet
+  facet normal -0.573174 -0.819433 -0
+    outer loop
+      vertex -13.0093 65.2477 4
+      vertex -13.2003 65.3813 0
+      vertex -13.0093 65.2477 0
+    endloop
+  endfacet
+  facet normal 0.786363 0.617765 0
+    outer loop
+      vertex -16.2568 61.8127 4
+      vertex -16.4008 61.996 0
+      vertex -16.4008 61.996 4
+    endloop
+  endfacet
+  facet normal 0.786363 0.617765 0
+    outer loop
+      vertex -16.4008 61.996 0
+      vertex -16.2568 61.8127 4
+      vertex -16.2568 61.8127 0
+    endloop
+  endfacet
+  facet normal -0.98471 -0.174201 0
+    outer loop
+      vertex -12.1078 63.6693 0
+      vertex -12.1484 63.8988 4
+      vertex -12.1484 63.8988 0
+    endloop
+  endfacet
+  facet normal -0.98471 -0.174201 0
+    outer loop
+      vertex -12.1484 63.8988 4
+      vertex -12.1078 63.6693 0
+      vertex -12.1078 63.6693 4
+    endloop
+  endfacet
+  facet normal 0.976439 -0.215795 0
+    outer loop
+      vertex -16.8053 63.7681 4
+      vertex -16.755 63.9957 0
+      vertex -16.755 63.9957 4
+    endloop
+  endfacet
+  facet normal 0.976439 -0.215795 0
+    outer loop
+      vertex -16.755 63.9957 0
+      vertex -16.8053 63.7681 4
+      vertex -16.8053 63.7681 0
     endloop
   endfacet
   facet normal -0.118807 -0.992917 0
     outer loop
       vertex -14.2975 65.7395 0
-      vertex -14.066 65.7118 7
-      vertex -14.2975 65.7395 7
+      vertex -14.066 65.7118 4
+      vertex -14.2975 65.7395 4
     endloop
   endfacet
   facet normal -0.118807 -0.992917 -0
     outer loop
-      vertex -14.066 65.7118 7
+      vertex -14.066 65.7118 4
       vertex -14.2975 65.7395 0
       vertex -14.066 65.7118 0
     endloop
   endfacet
-  facet normal -0.999779 0.0210254 0
-    outer loop
-      vertex -12.0947 63.2039 0
-      vertex -12.0898 63.4369 7
-      vertex -12.0898 63.4369 0
-    endloop
-  endfacet
-  facet normal -0.999779 0.0210254 0
-    outer loop
-      vertex -12.0898 63.4369 7
-      vertex -12.0947 63.2039 0
-      vertex -12.0947 63.2039 7
-    endloop
-  endfacet
-  facet normal -0.962777 -0.270298 0
-    outer loop
-      vertex -12.1484 63.8988 0
-      vertex -12.2114 64.1232 7
-      vertex -12.2114 64.1232 0
-    endloop
-  endfacet
-  facet normal -0.962777 -0.270298 0
-    outer loop
-      vertex -12.2114 64.1232 7
-      vertex -12.1484 63.8988 0
-      vertex -12.1484 63.8988 7
-    endloop
-  endfacet
-  facet normal -0.537958 0.842972 0
-    outer loop
-      vertex -13.0895 61.4334 0
-      vertex -13.286 61.308 7
-      vertex -13.0895 61.4334 7
-    endloop
-  endfacet
-  facet normal -0.537958 0.842972 0
-    outer loop
-      vertex -13.286 61.308 7
-      vertex -13.0895 61.4334 0
-      vertex -13.286 61.308 0
-    endloop
-  endfacet
-  facet normal -0.452698 0.891664 0
-    outer loop
-      vertex -13.286 61.308 0
-      vertex -13.4938 61.2025 7
-      vertex -13.286 61.308 7
-    endloop
-  endfacet
-  facet normal -0.452698 0.891664 0
-    outer loop
-      vertex -13.4938 61.2025 7
-      vertex -13.286 61.308 0
-      vertex -13.4938 61.2025 0
-    endloop
-  endfacet
-  facet normal -0.617973 0.786199 0
-    outer loop
-      vertex -12.9063 61.5774 0
-      vertex -13.0895 61.4334 7
-      vertex -12.9063 61.5774 7
-    endloop
-  endfacet
-  facet normal -0.617973 0.786199 0
-    outer loop
-      vertex -13.0895 61.4334 7
-      vertex -12.9063 61.5774 0
-      vertex -13.0895 61.4334 0
-    endloop
-  endfacet
-  facet normal -0.691933 0.721961 0
-    outer loop
-      vertex -12.738 61.7387 0
-      vertex -12.9063 61.5774 7
-      vertex -12.738 61.7387 7
-    endloop
-  endfacet
-  facet normal -0.691933 0.721961 0
-    outer loop
-      vertex -12.9063 61.5774 7
-      vertex -12.738 61.7387 0
-      vertex -12.9063 61.5774 0
-    endloop
-  endfacet
-  facet normal -0.819635 0.572886 0
-    outer loop
-      vertex -12.5864 61.9157 0
-      vertex -12.4529 62.1067 7
-      vertex -12.4529 62.1067 0
-    endloop
-  endfacet
-  facet normal -0.819635 0.572886 0
-    outer loop
-      vertex -12.4529 62.1067 7
-      vertex -12.5864 61.9157 0
-      vertex -12.5864 61.9157 7
-    endloop
-  endfacet
-  facet normal -0.759499 0.650509 0
-    outer loop
-      vertex -12.738 61.7387 0
-      vertex -12.5864 61.9157 7
-      vertex -12.5864 61.9157 0
-    endloop
-  endfacet
-  facet normal -0.759499 0.650509 0
-    outer loop
-      vertex -12.5864 61.9157 7
-      vertex -12.738 61.7387 0
-      vertex -12.738 61.7387 7
-    endloop
-  endfacet
-  facet normal -0.871759 0.489935 0
-    outer loop
-      vertex -12.4529 62.1067 0
-      vertex -12.3387 62.3099 7
-      vertex -12.3387 62.3099 0
-    endloop
-  endfacet
-  facet normal -0.871759 0.489935 0
-    outer loop
-      vertex -12.3387 62.3099 7
-      vertex -12.4529 62.1067 0
-      vertex -12.4529 62.1067 7
-    endloop
-  endfacet
-  facet normal -0.915625 0.402034 0
-    outer loop
-      vertex -12.3387 62.3099 0
-      vertex -12.245 62.5233 7
-      vertex -12.245 62.5233 0
-    endloop
-  endfacet
-  facet normal -0.915625 0.402034 0
-    outer loop
-      vertex -12.245 62.5233 7
-      vertex -12.3387 62.3099 0
-      vertex -12.3387 62.3099 7
-    endloop
-  endfacet
-  facet normal -0.976439 0.215795 0
-    outer loop
-      vertex -12.1727 62.7449 0
-      vertex -12.1224 62.9725 7
-      vertex -12.1224 62.9725 0
-    endloop
-  endfacet
-  facet normal -0.976439 0.215795 0
-    outer loop
-      vertex -12.1224 62.9725 7
-      vertex -12.1727 62.7449 0
-      vertex -12.1727 62.7449 7
-    endloop
-  endfacet
   facet normal -0.95068 0.310172 0
     outer loop
       vertex -12.245 62.5233 0
-      vertex -12.1727 62.7449 7
+      vertex -12.1727 62.7449 4
       vertex -12.1727 62.7449 0
     endloop
   endfacet
   facet normal -0.95068 0.310172 0
     outer loop
-      vertex -12.1727 62.7449 7
+      vertex -12.1727 62.7449 4
       vertex -12.245 62.5233 0
-      vertex -12.245 62.5233 7
+      vertex -12.245 62.5233 4
+    endloop
+  endfacet
+  facet normal 0.537958 -0.842972 0
+    outer loop
+      vertex -15.8382 65.3073 0
+      vertex -15.6417 65.4327 4
+      vertex -15.8382 65.3073 4
+    endloop
+  endfacet
+  facet normal 0.537958 -0.842972 0
+    outer loop
+      vertex -15.6417 65.4327 4
+      vertex -15.8382 65.3073 0
+      vertex -15.6417 65.4327 0
+    endloop
+  endfacet
+  facet normal 0.572973 0.819574 -0
+    outer loop
+      vertex -15.7274 61.3593 0
+      vertex -15.9185 61.4929 4
+      vertex -15.7274 61.3593 4
+    endloop
+  endfacet
+  facet normal 0.572973 0.819574 0
+    outer loop
+      vertex -15.9185 61.4929 4
+      vertex -15.7274 61.3593 0
+      vertex -15.9185 61.4929 0
+    endloop
+  endfacet
+  facet normal 0.0772544 -0.997011 0
+    outer loop
+      vertex -14.7628 65.7264 0
+      vertex -14.5305 65.7444 4
+      vertex -14.7628 65.7264 4
+    endloop
+  endfacet
+  facet normal 0.0772544 -0.997011 0
+    outer loop
+      vertex -14.5305 65.7444 4
+      vertex -14.7628 65.7264 0
+      vertex -14.5305 65.7444 0
+    endloop
+  endfacet
+  facet normal 0.618238 -0.785991 0
+    outer loop
+      vertex -16.0214 65.1632 0
+      vertex -15.8382 65.3073 4
+      vertex -16.0214 65.1632 4
+    endloop
+  endfacet
+  facet normal 0.618238 -0.785991 0
+    outer loop
+      vertex -15.8382 65.3073 4
+      vertex -16.0214 65.1632 0
+      vertex -15.8382 65.3073 0
+    endloop
+  endfacet
+  facet normal -0.819635 0.572886 0
+    outer loop
+      vertex -12.5864 61.9157 0
+      vertex -12.4529 62.1067 4
+      vertex -12.4529 62.1067 0
+    endloop
+  endfacet
+  facet normal -0.819635 0.572886 0
+    outer loop
+      vertex -12.4529 62.1067 4
+      vertex -12.5864 61.9157 0
+      vertex -12.5864 61.9157 4
+    endloop
+  endfacet
+  facet normal -0.489935 -0.871759 0
+    outer loop
+      vertex -13.4035 65.4955 0
+      vertex -13.2003 65.3813 4
+      vertex -13.4035 65.4955 4
+    endloop
+  endfacet
+  facet normal -0.489935 -0.871759 -0
+    outer loop
+      vertex -13.2003 65.3813 4
+      vertex -13.4035 65.4955 0
+      vertex -13.2003 65.3813 0
+    endloop
+  endfacet
+  facet normal 0.691933 -0.721961 0
+    outer loop
+      vertex -16.1897 65.0019 0
+      vertex -16.0214 65.1632 4
+      vertex -16.1897 65.0019 4
+    endloop
+  endfacet
+  facet normal 0.691933 -0.721961 0
+    outer loop
+      vertex -16.0214 65.1632 4
+      vertex -16.1897 65.0019 0
+      vertex -16.0214 65.1632 0
+    endloop
+  endfacet
+  facet normal -0.537958 0.842972 0
+    outer loop
+      vertex -13.0895 61.4334 0
+      vertex -13.286 61.308 4
+      vertex -13.0895 61.4334 4
+    endloop
+  endfacet
+  facet normal -0.537958 0.842972 0
+    outer loop
+      vertex -13.286 61.308 4
+      vertex -13.0895 61.4334 0
+      vertex -13.286 61.308 0
     endloop
   endfacet
   facet normal -0.997014 -0.0772214 0
     outer loop
       vertex -12.0898 63.4369 0
-      vertex -12.1078 63.6693 7
+      vertex -12.1078 63.6693 4
       vertex -12.1078 63.6693 0
     endloop
   endfacet
   facet normal -0.997014 -0.0772214 0
     outer loop
-      vertex -12.1078 63.6693 7
+      vertex -12.1078 63.6693 4
       vertex -12.0898 63.4369 0
-      vertex -12.0898 63.4369 7
+      vertex -12.0898 63.4369 4
     endloop
   endfacet
-  facet normal -0.992911 0.118858 0
+  facet normal -0.871759 0.489935 0
     outer loop
-      vertex -12.1224 62.9725 0
-      vertex -12.0947 63.2039 7
+      vertex -12.4529 62.1067 0
+      vertex -12.3387 62.3099 4
+      vertex -12.3387 62.3099 0
+    endloop
+  endfacet
+  facet normal -0.871759 0.489935 0
+    outer loop
+      vertex -12.3387 62.3099 4
+      vertex -12.4529 62.1067 0
+      vertex -12.4529 62.1067 4
+    endloop
+  endfacet
+  facet normal 0.819635 -0.572886 0
+    outer loop
+      vertex -16.4748 64.6339 4
+      vertex -16.3413 64.8249 0
+      vertex -16.3413 64.8249 4
+    endloop
+  endfacet
+  facet normal 0.819635 -0.572886 0
+    outer loop
+      vertex -16.3413 64.8249 0
+      vertex -16.4748 64.6339 4
+      vertex -16.4748 64.6339 0
+    endloop
+  endfacet
+  facet normal 0.489609 0.871942 -0
+    outer loop
+      vertex -15.5242 61.2452 0
+      vertex -15.7274 61.3593 4
+      vertex -15.5242 61.2452 4
+    endloop
+  endfacet
+  facet normal 0.489609 0.871942 0
+    outer loop
+      vertex -15.7274 61.3593 4
+      vertex -15.5242 61.2452 0
+      vertex -15.7274 61.3593 0
+    endloop
+  endfacet
+  facet normal -0.452698 0.891664 0
+    outer loop
+      vertex -13.286 61.308 0
+      vertex -13.4938 61.2025 4
+      vertex -13.286 61.308 4
+    endloop
+  endfacet
+  facet normal -0.452698 0.891664 0
+    outer loop
+      vertex -13.4938 61.2025 4
+      vertex -13.286 61.308 0
+      vertex -13.4938 61.2025 0
+    endloop
+  endfacet
+  facet normal -0.650297 -0.75968 0
+    outer loop
+      vertex -13.0093 65.2477 0
+      vertex -12.8322 65.0961 4
+      vertex -13.0093 65.2477 4
+    endloop
+  endfacet
+  facet normal -0.650297 -0.75968 -0
+    outer loop
+      vertex -12.8322 65.0961 4
+      vertex -13.0093 65.2477 0
+      vertex -12.8322 65.0961 0
+    endloop
+  endfacet
+  facet normal -0.999779 0.0210254 0
+    outer loop
       vertex -12.0947 63.2039 0
+      vertex -12.0898 63.4369 4
+      vertex -12.0898 63.4369 0
     endloop
   endfacet
-  facet normal -0.992911 0.118858 0
+  facet normal -0.999779 0.0210254 0
     outer loop
-      vertex -12.0947 63.2039 7
-      vertex -12.1224 62.9725 0
-      vertex -12.1224 62.9725 7
+      vertex -12.0898 63.4369 4
+      vertex -12.0947 63.2039 0
+      vertex -12.0947 63.2039 4
+    endloop
+  endfacet
+  facet normal 0.871759 -0.489935 0
+    outer loop
+      vertex -16.589 64.4307 4
+      vertex -16.4748 64.6339 0
+      vertex -16.4748 64.6339 4
+    endloop
+  endfacet
+  facet normal 0.871759 -0.489935 0
+    outer loop
+      vertex -16.4748 64.6339 0
+      vertex -16.589 64.4307 4
+      vertex -16.589 64.4307 0
+    endloop
+  endfacet
+  facet normal -0.691933 0.721961 0
+    outer loop
+      vertex -12.738 61.7387 0
+      vertex -12.9063 61.5774 4
+      vertex -12.738 61.7387 4
+    endloop
+  endfacet
+  facet normal -0.691933 0.721961 0
+    outer loop
+      vertex -12.9063 61.5774 4
+      vertex -12.738 61.7387 0
+      vertex -12.9063 61.5774 0
+    endloop
+  endfacet
+  facet normal 0.0214543 0.99977 -0
+    outer loop
+      vertex -14.3973 60.9962 0
+      vertex -14.6303 61.0012 4
+      vertex -14.3973 60.9962 4
+    endloop
+  endfacet
+  facet normal 0.0214543 0.99977 0
+    outer loop
+      vertex -14.6303 61.0012 4
+      vertex -14.3973 60.9962 0
+      vertex -14.6303 61.0012 0
+    endloop
+  endfacet
+  facet normal -0.915625 0.402034 0
+    outer loop
+      vertex -12.3387 62.3099 0
+      vertex -12.245 62.5233 4
+      vertex -12.245 62.5233 0
+    endloop
+  endfacet
+  facet normal -0.915625 0.402034 0
+    outer loop
+      vertex -12.245 62.5233 4
+      vertex -12.3387 62.3099 0
+      vertex -12.3387 62.3099 4
+    endloop
+  endfacet
+  facet normal 0.721756 0.692148 0
+    outer loop
+      vertex -16.0955 61.6445 4
+      vertex -16.2568 61.8127 0
+      vertex -16.2568 61.8127 4
+    endloop
+  endfacet
+  facet normal 0.721756 0.692148 0
+    outer loop
+      vertex -16.2568 61.8127 0
+      vertex -16.0955 61.6445 4
+      vertex -16.0955 61.6445 0
+    endloop
+  endfacet
+  facet normal -0.891664 -0.452698 0
+    outer loop
+      vertex -12.296 64.3404 0
+      vertex -12.4015 64.5482 4
+      vertex -12.4015 64.5482 0
+    endloop
+  endfacet
+  facet normal -0.891664 -0.452698 0
+    outer loop
+      vertex -12.4015 64.5482 4
+      vertex -12.296 64.3404 0
+      vertex -12.296 64.3404 4
+    endloop
+  endfacet
+  facet normal -0.174617 0.984636 0
+    outer loop
+      vertex -13.9354 61.0549 0
+      vertex -14.1649 61.0142 4
+      vertex -13.9354 61.0549 4
+    endloop
+  endfacet
+  facet normal -0.174617 0.984636 0
+    outer loop
+      vertex -14.1649 61.0142 4
+      vertex -13.9354 61.0549 0
+      vertex -14.1649 61.0142 0
+    endloop
+  endfacet
+  facet normal -0.617973 0.786199 0
+    outer loop
+      vertex -12.9063 61.5774 0
+      vertex -13.0895 61.4334 4
+      vertex -12.9063 61.5774 4
+    endloop
+  endfacet
+  facet normal -0.617973 0.786199 0
+    outer loop
+      vertex -13.0895 61.4334 4
+      vertex -12.9063 61.5774 0
+      vertex -13.0895 61.4334 0
+    endloop
+  endfacet
+  facet normal 0.215386 0.976529 -0
+    outer loop
+      vertex -14.8617 61.0289 0
+      vertex -15.0893 61.0791 4
+      vertex -14.8617 61.0289 4
+    endloop
+  endfacet
+  facet normal 0.215386 0.976529 0
+    outer loop
+      vertex -15.0893 61.0791 4
+      vertex -14.8617 61.0289 0
+      vertex -15.0893 61.0791 0
+    endloop
+  endfacet
+  facet normal 0.222525 -0.974927 0
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -5.82719 70.4702 7
+      vertex -25.3257 66.0197 7
+    endloop
+  endfacet
+  facet normal 0.222525 -0.974927 0
+    outer loop
+      vertex -5.82719 70.4702 7
+      vertex -25.3257 66.0197 4
+      vertex -5.82719 70.4702 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.60198 60.7209 4
+      vertex -12.1078 63.6693 4
+      vertex -12.0898 63.4369 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.60198 60.7209 4
+      vertex -12.1484 63.8988 4
+      vertex -12.1078 63.6693 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -12.2114 64.1232 4
+      vertex -12.1484 63.8988 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -12.296 64.3404 4
+      vertex -12.2114 64.1232 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -12.4015 64.5482 4
+      vertex -12.296 64.3404 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -12.5269 64.7447 4
+      vertex -12.4015 64.5482 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -12.6709 64.9279 4
+      vertex -12.5269 64.7447 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -12.8322 65.0961 4
+      vertex -12.6709 64.9279 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -13.0093 65.2477 4
+      vertex -12.8322 65.0961 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -13.2003 65.3813 4
+      vertex -13.0093 65.2477 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -13.4035 65.4955 4
+      vertex -13.2003 65.3813 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -13.6169 65.5892 4
+      vertex -13.4035 65.4955 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -13.8384 65.6615 4
+      vertex -13.6169 65.5892 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -14.066 65.7118 4
+      vertex -13.8384 65.6615 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -14.2975 65.7395 4
+      vertex -14.066 65.7118 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -14.5305 65.7444 4
+      vertex -14.2975 65.7395 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -14.7628 65.7264 4
+      vertex -14.5305 65.7444 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.82719 70.4702 4
+      vertex -14.9923 65.6858 4
+      vertex -14.7628 65.7264 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -14.9923 65.6858 4
+      vertex -5.82719 70.4702 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.9923 65.6858 4
+      vertex -25.3257 66.0197 4
+      vertex -15.2168 65.6228 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.2168 65.6228 4
+      vertex -25.3257 66.0197 4
+      vertex -15.4339 65.5382 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.8379 63.3037 4
+      vertex -16.833 63.5367 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.833 63.5367 4
+      vertex -16.8053 63.7681 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.8053 63.7681 4
+      vertex -16.755 63.9957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.755 63.9957 4
+      vertex -16.6827 64.2173 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.6827 64.2173 4
+      vertex -16.589 64.4307 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.589 64.4307 4
+      vertex -16.4748 64.6339 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -16.4748 64.6339 4
+      vertex -16.3413 64.8249 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.8379 63.3037 4
+      vertex -25.3257 66.0197 4
+      vertex -23.1005 56.2705 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1897 65.0019 4
+      vertex -25.3257 66.0197 4
+      vertex -16.3413 64.8249 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0214 65.1632 4
+      vertex -25.3257 66.0197 4
+      vertex -16.1897 65.0019 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8382 65.3073 4
+      vertex -25.3257 66.0197 4
+      vertex -16.0214 65.1632 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6417 65.4327 4
+      vertex -25.3257 66.0197 4
+      vertex -15.8382 65.3073 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4339 65.5382 4
+      vertex -25.3257 66.0197 4
+      vertex -15.6417 65.4327 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.1484 63.8988 4
+      vertex -3.60198 60.7209 4
+      vertex -5.82719 70.4702 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.0947 63.2039 4
+      vertex -3.60198 60.7209 4
+      vertex -12.0898 63.4369 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.1224 62.9725 4
+      vertex -3.60198 60.7209 4
+      vertex -12.0947 63.2039 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.1727 62.7449 4
+      vertex -3.60198 60.7209 4
+      vertex -12.1224 62.9725 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.245 62.5233 4
+      vertex -3.60198 60.7209 4
+      vertex -12.1727 62.7449 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.3387 62.3099 4
+      vertex -3.60198 60.7209 4
+      vertex -12.245 62.5233 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.4529 62.1067 4
+      vertex -3.60198 60.7209 4
+      vertex -12.3387 62.3099 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.5864 61.9157 4
+      vertex -3.60198 60.7209 4
+      vertex -12.4529 62.1067 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.738 61.7387 4
+      vertex -3.60198 60.7209 4
+      vertex -12.5864 61.9157 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.9063 61.5774 4
+      vertex -3.60198 60.7209 4
+      vertex -12.738 61.7387 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.0895 61.4334 4
+      vertex -3.60198 60.7209 4
+      vertex -12.9063 61.5774 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.286 61.308 4
+      vertex -3.60198 60.7209 4
+      vertex -13.0895 61.4334 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.4938 61.2025 4
+      vertex -3.60198 60.7209 4
+      vertex -13.286 61.308 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.711 61.1178 4
+      vertex -3.60198 60.7209 4
+      vertex -13.4938 61.2025 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.9354 61.0549 4
+      vertex -3.60198 60.7209 4
+      vertex -13.711 61.1178 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 56.2705 4
+      vertex -13.9354 61.0549 4
+      vertex -14.1649 61.0142 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 56.2705 4
+      vertex -14.1649 61.0142 4
+      vertex -14.3973 60.9962 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 56.2705 4
+      vertex -14.3973 60.9962 4
+      vertex -14.6303 61.0012 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.9354 61.0549 4
+      vertex -23.1005 56.2705 4
+      vertex -3.60198 60.7209 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8617 61.0289 4
+      vertex -23.1005 56.2705 4
+      vertex -14.6303 61.0012 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0893 61.0791 4
+      vertex -23.1005 56.2705 4
+      vertex -14.8617 61.0289 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3108 61.1515 4
+      vertex -23.1005 56.2705 4
+      vertex -15.0893 61.0791 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5242 61.2452 4
+      vertex -23.1005 56.2705 4
+      vertex -15.3108 61.1515 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.7274 61.3593 4
+      vertex -23.1005 56.2705 4
+      vertex -15.5242 61.2452 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9185 61.4929 4
+      vertex -23.1005 56.2705 4
+      vertex -15.7274 61.3593 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0955 61.6445 4
+      vertex -23.1005 56.2705 4
+      vertex -15.9185 61.4929 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.2568 61.8127 4
+      vertex -23.1005 56.2705 4
+      vertex -16.0955 61.6445 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4008 61.996 4
+      vertex -23.1005 56.2705 4
+      vertex -16.2568 61.8127 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.5262 62.1924 4
+      vertex -23.1005 56.2705 4
+      vertex -16.4008 61.996 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6317 62.4003 4
+      vertex -23.1005 56.2705 4
+      vertex -16.5262 62.1924 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7164 62.6174 4
+      vertex -23.1005 56.2705 4
+      vertex -16.6317 62.4003 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7793 62.8418 4
+      vertex -23.1005 56.2705 4
+      vertex -16.7164 62.6174 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.82 63.0713 4
+      vertex -23.1005 56.2705 4
+      vertex -16.7793 62.8418 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 56.2705 4
+      vertex -16.82 63.0713 4
+      vertex -16.8379 63.3037 4
+    endloop
+  endfacet
+  facet normal -0.22252 0.974928 0
+    outer loop
+      vertex -3.60198 60.7209 4
+      vertex -23.1005 56.2705 7
+      vertex -3.60198 60.7209 7
+    endloop
+  endfacet
+  facet normal -0.22252 0.974928 0
+    outer loop
+      vertex -23.1005 56.2705 7
+      vertex -3.60198 60.7209 4
+      vertex -23.1005 56.2705 4
+    endloop
+  endfacet
+  facet normal 0.974928 0.222522 0
+    outer loop
+      vertex -23.1005 56.2705 7
+      vertex -25.3257 66.0197 4
+      vertex -25.3257 66.0197 7
+    endloop
+  endfacet
+  facet normal 0.974928 0.222522 0
+    outer loop
+      vertex -25.3257 66.0197 4
+      vertex -23.1005 56.2705 7
+      vertex -23.1005 56.2705 4
+    endloop
+  endfacet
+  facet normal -0.974928 -0.222521 0
+    outer loop
+      vertex -3.60198 60.7209 4
+      vertex -5.82719 70.4702 7
+      vertex -5.82719 70.4702 4
+    endloop
+  endfacet
+  facet normal -0.974928 -0.222521 0
+    outer loop
+      vertex -5.82719 70.4702 7
+      vertex -3.60198 60.7209 4
+      vertex -3.60198 60.7209 7
     endloop
   endfacet
   facet normal -0.900969 0.433884 0
@@ -8721,900 +6845,1432 @@ solid OpenSCAD_Model
       vertex -59.5193 0 0
     endloop
   endfacet
-  facet normal 0.995854 0.0909613 0
-    outer loop
-      vertex -60.9147 27.8704 7
-      vertex -60.9359 28.1025 0
-      vertex -60.9359 28.1025 7
-    endloop
-  endfacet
-  facet normal 0.995854 0.0909613 0
-    outer loop
-      vertex -60.9359 28.1025 0
-      vertex -60.9147 27.8704 7
-      vertex -60.9147 27.8704 0
-    endloop
-  endfacet
-  facet normal 0.712022 0.702157 0
-    outer loop
-      vertex -60.1702 26.4539 7
-      vertex -60.3339 26.6199 0
-      vertex -60.3339 26.6199 7
-    endloop
-  endfacet
-  facet normal 0.712022 0.702157 0
-    outer loop
-      vertex -60.3339 26.6199 0
-      vertex -60.1702 26.4539 7
-      vertex -60.1702 26.4539 0
-    endloop
-  endfacet
-  facet normal 0.00729594 0.999973 -0
-    outer loop
-      vertex -58.4631 25.8295 0
-      vertex -58.6961 25.8312 7
-      vertex -58.4631 25.8295 7
-    endloop
-  endfacet
-  facet normal 0.00729594 0.999973 0
-    outer loop
-      vertex -58.6961 25.8312 7
-      vertex -58.4631 25.8295 0
-      vertex -58.6961 25.8312 0
-    endloop
-  endfacet
-  facet normal -0.702157 0.712022 0
-    outer loop
-      vertex -56.8144 26.5952 0
-      vertex -56.9804 26.4315 7
-      vertex -56.8144 26.5952 7
-    endloop
-  endfacet
-  facet normal -0.702157 0.712022 0
-    outer loop
-      vertex -56.9804 26.4315 7
-      vertex -56.8144 26.5952 0
-      vertex -56.9804 26.4315 0
-    endloop
-  endfacet
-  facet normal 0.878632 -0.477499 0
-    outer loop
-      vertex -60.7028 29.2329 7
-      vertex -60.5915 29.4377 0
-      vertex -60.5915 29.4377 7
-    endloop
-  endfacet
-  facet normal 0.878632 -0.477499 0
-    outer loop
-      vertex -60.5915 29.4377 0
-      vertex -60.7028 29.2329 7
-      vertex -60.7028 29.2329 0
-    endloop
-  endfacet
   facet normal 0.835402 0.54964 0
     outer loop
-      vertex -60.4805 26.8011 7
+      vertex -60.4805 26.8011 4
       vertex -60.6086 26.9958 0
-      vertex -60.6086 26.9958 7
+      vertex -60.6086 26.9958 4
     endloop
   endfacet
   facet normal 0.835402 0.54964 0
     outer loop
       vertex -60.6086 26.9958 0
-      vertex -60.4805 26.8011 7
+      vertex -60.4805 26.8011 4
       vertex -60.4805 26.8011 0
     endloop
   endfacet
-  facet normal -0.465145 0.885234 0
-    outer loop
-      vertex -57.3563 26.1568 0
-      vertex -57.5626 26.0484 7
-      vertex -57.3563 26.1568 7
-    endloop
-  endfacet
-  facet normal -0.465145 0.885234 0
-    outer loop
-      vertex -57.5626 26.0484 7
-      vertex -57.3563 26.1568 0
-      vertex -57.5626 26.0484 0
-    endloop
-  endfacet
-  facet normal 0.202052 0.979375 -0
-    outer loop
-      vertex -58.9279 25.8556 0
-      vertex -59.1562 25.9027 7
-      vertex -58.9279 25.8556 7
-    endloop
-  endfacet
-  facet normal 0.202052 0.979375 0
-    outer loop
-      vertex -59.1562 25.9027 7
-      vertex -58.9279 25.8556 0
-      vertex -59.1562 25.9027 0
-    endloop
-  endfacet
   facet normal 0.954884 -0.29698 0
     outer loop
-      vertex -60.8627 28.7957 7
+      vertex -60.8627 28.7957 4
       vertex -60.7935 29.0182 0
-      vertex -60.7935 29.0182 7
+      vertex -60.7935 29.0182 4
     endloop
   endfacet
   facet normal 0.954884 -0.29698 0
     outer loop
       vertex -60.7935 29.0182 0
-      vertex -60.8627 28.7957 7
+      vertex -60.8627 28.7957 4
       vertex -60.8627 28.7957 0
     endloop
   endfacet
-  facet normal 0.982101 0.188354 0
-    outer loop
-      vertex -60.8708 27.6415 7
-      vertex -60.9147 27.8704 0
-      vertex -60.9147 27.8704 7
-    endloop
-  endfacet
-  facet normal 0.982101 0.188354 0
-    outer loop
-      vertex -60.9147 27.8704 0
-      vertex -60.8708 27.6415 7
-      vertex -60.8708 27.6415 0
-    endloop
-  endfacet
-  facet normal 0.926481 0.376343 0
-    outer loop
-      vertex -60.717 27.2021 7
-      vertex -60.8047 27.418 0
-      vertex -60.8047 27.418 7
-    endloop
-  endfacet
-  facet normal 0.926481 0.376343 0
-    outer loop
-      vertex -60.8047 27.418 0
-      vertex -60.717 27.2021 7
-      vertex -60.717 27.2021 0
-    endloop
-  endfacet
-  facet normal 0.38915 0.921174 -0
-    outer loop
-      vertex -59.3787 25.9719 0
-      vertex -59.5934 26.0626 7
-      vertex -59.3787 25.9719 7
-    endloop
-  endfacet
-  facet normal 0.38915 0.921174 0
-    outer loop
-      vertex -59.5934 26.0626 7
-      vertex -59.3787 25.9719 0
-      vertex -59.5934 26.0626 0
-    endloop
-  endfacet
-  facet normal 0.639804 0.768538 -0
-    outer loop
-      vertex -59.9911 26.3048 0
-      vertex -60.1702 26.4539 7
-      vertex -59.9911 26.3048 7
-    endloop
-  endfacet
-  facet normal 0.639804 0.768538 0
-    outer loop
-      vertex -60.1702 26.4539 7
-      vertex -59.9911 26.3048 0
-      vertex -60.1702 26.4539 0
-    endloop
-  endfacet
-  facet normal 0.561218 0.827668 -0
-    outer loop
-      vertex -59.7982 26.174 0
-      vertex -59.9911 26.3048 7
-      vertex -59.7982 26.174 7
-    endloop
-  endfacet
-  facet normal 0.561218 0.827668 0
-    outer loop
-      vertex -59.9911 26.3048 7
-      vertex -59.7982 26.174 0
-      vertex -59.9911 26.3048 0
-    endloop
-  endfacet
-  facet normal 0.777425 0.628976 0
-    outer loop
-      vertex -60.3339 26.6199 7
-      vertex -60.4805 26.8011 0
-      vertex -60.4805 26.8011 7
-    endloop
-  endfacet
-  facet normal 0.777425 0.628976 0
-    outer loop
-      vertex -60.4805 26.8011 0
-      vertex -60.3339 26.6199 7
-      vertex -60.3339 26.6199 0
-    endloop
-  endfacet
-  facet normal 0.885234 0.465145 0
-    outer loop
-      vertex -60.6086 26.9958 7
-      vertex -60.717 27.2021 0
-      vertex -60.717 27.2021 7
-    endloop
-  endfacet
-  facet normal 0.885234 0.465145 0
-    outer loop
-      vertex -60.717 27.2021 0
-      vertex -60.6086 26.9958 7
-      vertex -60.6086 26.9958 0
-    endloop
-  endfacet
-  facet normal -0.921174 0.38915 0
-    outer loop
-      vertex -56.4232 27.172 0
-      vertex -56.3325 27.3867 7
-      vertex -56.3325 27.3867 0
-    endloop
-  endfacet
-  facet normal -0.921174 0.38915 0
-    outer loop
-      vertex -56.3325 27.3867 7
-      vertex -56.4232 27.172 0
-      vertex -56.4232 27.172 7
-    endloop
-  endfacet
-  facet normal -0.768538 0.639804 0
-    outer loop
-      vertex -56.8144 26.5952 0
-      vertex -56.6653 26.7743 7
-      vertex -56.6653 26.7743 0
-    endloop
-  endfacet
-  facet normal -0.768538 0.639804 0
-    outer loop
-      vertex -56.6653 26.7743 7
-      vertex -56.8144 26.5952 0
-      vertex -56.8144 26.5952 7
-    endloop
-  endfacet
-  facet normal -0.827668 0.561218 0
-    outer loop
-      vertex -56.6653 26.7743 0
-      vertex -56.5345 26.9672 7
-      vertex -56.5345 26.9672 0
-    endloop
-  endfacet
-  facet normal -0.827668 0.561218 0
-    outer loop
-      vertex -56.5345 26.9672 7
-      vertex -56.6653 26.7743 0
-      vertex -56.6653 26.7743 7
-    endloop
-  endfacet
-  facet normal -0.628717 0.777634 0
-    outer loop
-      vertex -56.9804 26.4315 0
-      vertex -57.1616 26.285 7
-      vertex -56.9804 26.4315 7
-    endloop
-  endfacet
-  facet normal -0.628717 0.777634 0
-    outer loop
-      vertex -57.1616 26.285 7
-      vertex -56.9804 26.4315 0
-      vertex -57.1616 26.285 0
-    endloop
-  endfacet
-  facet normal -0.549939 0.835205 0
-    outer loop
-      vertex -57.1616 26.285 0
-      vertex -57.3563 26.1568 7
-      vertex -57.1616 26.285 7
-    endloop
-  endfacet
-  facet normal -0.549939 0.835205 0
-    outer loop
-      vertex -57.3563 26.1568 7
-      vertex -57.1616 26.285 0
-      vertex -57.3563 26.1568 0
-    endloop
-  endfacet
-  facet normal 0.104685 0.994505 -0
-    outer loop
-      vertex -58.6961 25.8312 0
-      vertex -58.9279 25.8556 7
-      vertex -58.6961 25.8312 7
-    endloop
-  endfacet
-  facet normal 0.104685 0.994505 0
-    outer loop
-      vertex -58.9279 25.8556 7
-      vertex -58.6961 25.8312 0
-      vertex -58.9279 25.8556 0
-    endloop
-  endfacet
-  facet normal 0.29698 0.954884 -0
-    outer loop
-      vertex -59.1562 25.9027 0
-      vertex -59.3787 25.9719 7
-      vertex -59.1562 25.9027 7
-    endloop
-  endfacet
-  facet normal 0.29698 0.954884 0
-    outer loop
-      vertex -59.3787 25.9719 7
-      vertex -59.1562 25.9027 0
-      vertex -59.3787 25.9719 0
-    endloop
-  endfacet
-  facet normal -0.18794 0.98218 0
-    outer loop
-      vertex -58.0021 25.8946 0
-      vertex -58.231 25.8508 7
-      vertex -58.0021 25.8946 7
-    endloop
-  endfacet
-  facet normal -0.18794 0.98218 0
-    outer loop
-      vertex -58.231 25.8508 7
-      vertex -58.0021 25.8946 0
-      vertex -58.231 25.8508 0
-    endloop
-  endfacet
-  facet normal -0.283606 0.958941 0
-    outer loop
-      vertex -57.7786 25.9607 0
-      vertex -58.0021 25.8946 7
-      vertex -57.7786 25.9607 7
-    endloop
-  endfacet
-  facet normal -0.283606 0.958941 0
-    outer loop
-      vertex -58.0021 25.8946 7
-      vertex -57.7786 25.9607 0
-      vertex -58.0021 25.8946 0
-    endloop
-  endfacet
-  facet normal -0.0913868 0.995815 0
-    outer loop
-      vertex -58.231 25.8508 0
-      vertex -58.4631 25.8295 7
-      vertex -58.231 25.8508 7
-    endloop
-  endfacet
-  facet normal -0.0913868 0.995815 0
-    outer loop
-      vertex -58.4631 25.8295 7
-      vertex -58.231 25.8508 0
-      vertex -58.4631 25.8295 0
-    endloop
-  endfacet
-  facet normal -0.376193 0.926541 0
-    outer loop
-      vertex -57.5626 26.0484 0
-      vertex -57.7786 25.9607 7
-      vertex -57.5626 26.0484 7
-    endloop
-  endfacet
-  facet normal -0.376193 0.926541 0
-    outer loop
-      vertex -57.7786 25.9607 7
-      vertex -57.5626 26.0484 0
-      vertex -57.7786 25.9607 0
-    endloop
-  endfacet
   facet normal 0.921174 -0.38915 0
     outer loop
-      vertex -60.7935 29.0182 7
+      vertex -60.7935 29.0182 4
       vertex -60.7028 29.2329 0
-      vertex -60.7028 29.2329 7
+      vertex -60.7028 29.2329 4
     endloop
   endfacet
   facet normal 0.921174 -0.38915 0
     outer loop
       vertex -60.7028 29.2329 0
-      vertex -60.7935 29.0182 7
+      vertex -60.7935 29.0182 4
       vertex -60.7935 29.0182 0
     endloop
   endfacet
-  facet normal 0.768538 -0.639804 0
+  facet normal 0.979375 -0.202052 0
     outer loop
-      vertex -60.4606 29.6306 7
-      vertex -60.3115 29.8097 0
-      vertex -60.3115 29.8097 7
+      vertex -60.9098 28.5674 4
+      vertex -60.8627 28.7957 0
+      vertex -60.8627 28.7957 4
     endloop
   endfacet
-  facet normal 0.768538 -0.639804 0
+  facet normal 0.979375 -0.202052 0
     outer loop
-      vertex -60.3115 29.8097 0
-      vertex -60.4606 29.6306 7
-      vertex -60.4606 29.6306 0
-    endloop
-  endfacet
-  facet normal -0.954884 0.29698 0
-    outer loop
-      vertex -56.3325 27.3867 0
-      vertex -56.2633 27.6092 7
-      vertex -56.2633 27.6092 0
-    endloop
-  endfacet
-  facet normal -0.954884 0.29698 0
-    outer loop
-      vertex -56.2633 27.6092 7
-      vertex -56.3325 27.3867 0
-      vertex -56.3325 27.3867 7
-    endloop
-  endfacet
-  facet normal -0.297249 -0.9548 0
-    outer loop
-      vertex -57.9698 30.5022 0
-      vertex -57.7472 30.4329 7
-      vertex -57.9698 30.5022 7
-    endloop
-  endfacet
-  facet normal -0.297249 -0.9548 -0
-    outer loop
-      vertex -57.7472 30.4329 7
-      vertex -57.9698 30.5022 0
-      vertex -57.7472 30.4329 0
-    endloop
-  endfacet
-  facet normal -0.00686385 -0.999976 0
-    outer loop
-      vertex -58.6629 30.5753 0
-      vertex -58.4298 30.5737 7
-      vertex -58.6629 30.5753 7
-    endloop
-  endfacet
-  facet normal -0.00686385 -0.999976 -0
-    outer loop
-      vertex -58.4298 30.5737 7
-      vertex -58.6629 30.5753 0
-      vertex -58.4298 30.5737 0
-    endloop
-  endfacet
-  facet normal 0.999973 -0.00729281 0
-    outer loop
-      vertex -60.9359 28.1025 7
-      vertex -60.9342 28.3356 0
-      vertex -60.9342 28.3356 7
-    endloop
-  endfacet
-  facet normal 0.999973 -0.00729281 0
-    outer loop
-      vertex -60.9342 28.3356 0
-      vertex -60.9359 28.1025 7
-      vertex -60.9359 28.1025 0
-    endloop
-  endfacet
-  facet normal 0.994505 -0.104685 0
-    outer loop
-      vertex -60.9342 28.3356 7
+      vertex -60.8627 28.7957 0
+      vertex -60.9098 28.5674 4
       vertex -60.9098 28.5674 0
-      vertex -60.9098 28.5674 7
-    endloop
-  endfacet
-  facet normal 0.994505 -0.104685 0
-    outer loop
-      vertex -60.9098 28.5674 0
-      vertex -60.9342 28.3356 7
-      vertex -60.9342 28.3356 0
-    endloop
-  endfacet
-  facet normal 0.958941 0.283606 0
-    outer loop
-      vertex -60.8047 27.418 7
-      vertex -60.8708 27.6415 0
-      vertex -60.8708 27.6415 7
-    endloop
-  endfacet
-  facet normal 0.958941 0.283606 0
-    outer loop
-      vertex -60.8708 27.6415 0
-      vertex -60.8047 27.418 7
-      vertex -60.8047 27.418 0
-    endloop
-  endfacet
-  facet normal 0.47783 0.878452 -0
-    outer loop
-      vertex -59.5934 26.0626 0
-      vertex -59.7982 26.174 7
-      vertex -59.5934 26.0626 7
-    endloop
-  endfacet
-  facet normal 0.47783 0.878452 0
-    outer loop
-      vertex -59.7982 26.174 7
-      vertex -59.5934 26.0626 0
-      vertex -59.7982 26.174 0
-    endloop
-  endfacet
-  facet normal -0.878632 0.477499 0
-    outer loop
-      vertex -56.5345 26.9672 0
-      vertex -56.4232 27.172 7
-      vertex -56.4232 27.172 0
-    endloop
-  endfacet
-  facet normal -0.878632 0.477499 0
-    outer loop
-      vertex -56.4232 27.172 7
-      vertex -56.5345 26.9672 0
-      vertex -56.5345 26.9672 7
-    endloop
-  endfacet
-  facet normal 0.376343 -0.926481 0
-    outer loop
-      vertex -59.5633 30.3565 0
-      vertex -59.3474 30.4442 7
-      vertex -59.5633 30.3565 7
-    endloop
-  endfacet
-  facet normal 0.376343 -0.926481 0
-    outer loop
-      vertex -59.3474 30.4442 7
-      vertex -59.5633 30.3565 0
-      vertex -59.3474 30.4442 0
-    endloop
-  endfacet
-  facet normal 0.549939 -0.835205 0
-    outer loop
-      vertex -59.9644 30.1199 0
-      vertex -59.7697 30.2481 7
-      vertex -59.9644 30.1199 7
-    endloop
-  endfacet
-  facet normal 0.549939 -0.835205 0
-    outer loop
-      vertex -59.7697 30.2481 7
-      vertex -59.9644 30.1199 0
-      vertex -59.7697 30.2481 0
-    endloop
-  endfacet
-  facet normal 0.629186 -0.777255 0
-    outer loop
-      vertex -60.1455 29.9733 0
-      vertex -59.9644 30.1199 7
-      vertex -60.1455 29.9733 7
-    endloop
-  endfacet
-  facet normal 0.629186 -0.777255 0
-    outer loop
-      vertex -59.9644 30.1199 7
-      vertex -60.1455 29.9733 0
-      vertex -59.9644 30.1199 0
-    endloop
-  endfacet
-  facet normal -0.477499 -0.878632 0
-    outer loop
-      vertex -57.5325 30.3422 0
-      vertex -57.3277 30.2309 7
-      vertex -57.5325 30.3422 7
-    endloop
-  endfacet
-  facet normal -0.477499 -0.878632 -0
-    outer loop
-      vertex -57.3277 30.2309 7
-      vertex -57.5325 30.3422 0
-      vertex -57.3277 30.2309 0
-    endloop
-  endfacet
-  facet normal -0.201726 -0.979442 0
-    outer loop
-      vertex -58.198 30.5492 0
-      vertex -57.9698 30.5022 7
-      vertex -58.198 30.5492 7
-    endloop
-  endfacet
-  facet normal -0.201726 -0.979442 -0
-    outer loop
-      vertex -57.9698 30.5022 7
-      vertex -58.198 30.5492 0
-      vertex -57.9698 30.5022 0
     endloop
   endfacet
   facet normal -0.105109 -0.994461 0
     outer loop
       vertex -58.4298 30.5737 0
-      vertex -58.198 30.5492 7
-      vertex -58.4298 30.5737 7
+      vertex -58.198 30.5492 4
+      vertex -58.4298 30.5737 4
     endloop
   endfacet
   facet normal -0.105109 -0.994461 -0
     outer loop
-      vertex -58.198 30.5492 7
+      vertex -58.198 30.5492 4
       vertex -58.4298 30.5737 0
       vertex -58.198 30.5492 0
     endloop
   endfacet
-  facet normal 0.979375 -0.202052 0
+  facet normal -0.712237 -0.701939 0
     outer loop
-      vertex -60.9098 28.5674 7
-      vertex -60.8627 28.7957 0
-      vertex -60.8627 28.7957 7
-    endloop
-  endfacet
-  facet normal 0.979375 -0.202052 0
-    outer loop
-      vertex -60.8627 28.7957 0
-      vertex -60.9098 28.5674 7
-      vertex -60.9098 28.5674 0
-    endloop
-  endfacet
-  facet normal 0.827469 -0.561512 0
-    outer loop
-      vertex -60.5915 29.4377 7
-      vertex -60.4606 29.6306 0
-      vertex -60.4606 29.6306 7
-    endloop
-  endfacet
-  facet normal 0.827469 -0.561512 0
-    outer loop
-      vertex -60.4606 29.6306 0
-      vertex -60.5915 29.4377 7
-      vertex -60.5915 29.4377 0
-    endloop
-  endfacet
-  facet normal 0.283606 -0.958941 0
-    outer loop
-      vertex -59.3474 30.4442 0
-      vertex -59.1239 30.5103 7
-      vertex -59.3474 30.4442 7
-    endloop
-  endfacet
-  facet normal 0.283606 -0.958941 0
-    outer loop
-      vertex -59.1239 30.5103 7
-      vertex -59.3474 30.4442 0
-      vertex -59.1239 30.5103 0
-    endloop
-  endfacet
-  facet normal 0.18794 -0.98218 0
-    outer loop
-      vertex -59.1239 30.5103 0
-      vertex -58.895 30.5541 7
-      vertex -59.1239 30.5103 7
-    endloop
-  endfacet
-  facet normal 0.18794 -0.98218 0
-    outer loop
-      vertex -58.895 30.5541 7
-      vertex -59.1239 30.5103 0
-      vertex -58.895 30.5541 0
-    endloop
-  endfacet
-  facet normal 0.0909613 -0.995854 0
-    outer loop
-      vertex -58.895 30.5541 0
-      vertex -58.6629 30.5753 7
-      vertex -58.895 30.5541 7
-    endloop
-  endfacet
-  facet normal 0.0909613 -0.995854 0
-    outer loop
-      vertex -58.6629 30.5753 7
-      vertex -58.895 30.5541 0
-      vertex -58.6629 30.5753 0
-    endloop
-  endfacet
-  facet normal 0.464968 -0.885327 0
-    outer loop
-      vertex -59.7697 30.2481 0
-      vertex -59.5633 30.3565 7
-      vertex -59.7697 30.2481 7
-    endloop
-  endfacet
-  facet normal 0.464968 -0.885327 0
-    outer loop
-      vertex -59.5633 30.3565 7
-      vertex -59.7697 30.2481 0
-      vertex -59.5633 30.3565 0
-    endloop
-  endfacet
-  facet normal 0.701939 -0.712237 0
-    outer loop
-      vertex -60.3115 29.8097 0
-      vertex -60.1455 29.9733 7
-      vertex -60.3115 29.8097 7
-    endloop
-  endfacet
-  facet normal 0.701939 -0.712237 0
-    outer loop
-      vertex -60.1455 29.9733 7
-      vertex -60.3115 29.8097 0
-      vertex -60.1455 29.9733 0
-    endloop
-  endfacet
-  facet normal -0.639804 -0.768538 0
-    outer loop
-      vertex -57.1348 30.1001 0
-      vertex -56.9557 29.951 7
-      vertex -57.1348 30.1001 7
-    endloop
-  endfacet
-  facet normal -0.639804 -0.768538 -0
-    outer loop
-      vertex -56.9557 29.951 7
-      vertex -57.1348 30.1001 0
+      vertex -56.7921 29.785 0
+      vertex -56.9557 29.951 4
       vertex -56.9557 29.951 0
+    endloop
+  endfacet
+  facet normal -0.712237 -0.701939 0
+    outer loop
+      vertex -56.9557 29.951 4
+      vertex -56.7921 29.785 0
+      vertex -56.7921 29.785 4
+    endloop
+  endfacet
+  facet normal -0.827668 0.561218 0
+    outer loop
+      vertex -56.6653 26.7743 0
+      vertex -56.5345 26.9672 4
+      vertex -56.5345 26.9672 0
+    endloop
+  endfacet
+  facet normal -0.827668 0.561218 0
+    outer loop
+      vertex -56.5345 26.9672 4
+      vertex -56.6653 26.7743 0
+      vertex -56.6653 26.7743 4
+    endloop
+  endfacet
+  facet normal 0.38915 0.921174 -0
+    outer loop
+      vertex -59.3787 25.9719 0
+      vertex -59.5934 26.0626 4
+      vertex -59.3787 25.9719 4
+    endloop
+  endfacet
+  facet normal 0.38915 0.921174 0
+    outer loop
+      vertex -59.5934 26.0626 4
+      vertex -59.3787 25.9719 0
+      vertex -59.5934 26.0626 0
+    endloop
+  endfacet
+  facet normal 0.878632 -0.477499 0
+    outer loop
+      vertex -60.7028 29.2329 4
+      vertex -60.5915 29.4377 0
+      vertex -60.5915 29.4377 4
+    endloop
+  endfacet
+  facet normal 0.878632 -0.477499 0
+    outer loop
+      vertex -60.5915 29.4377 0
+      vertex -60.7028 29.2329 4
+      vertex -60.7028 29.2329 0
+    endloop
+  endfacet
+  facet normal 0.712022 0.702157 0
+    outer loop
+      vertex -60.1702 26.4539 4
+      vertex -60.3339 26.6199 0
+      vertex -60.3339 26.6199 4
+    endloop
+  endfacet
+  facet normal 0.712022 0.702157 0
+    outer loop
+      vertex -60.3339 26.6199 0
+      vertex -60.1702 26.4539 4
+      vertex -60.1702 26.4539 0
     endloop
   endfacet
   facet normal -0.38915 -0.921174 0
     outer loop
       vertex -57.7472 30.4329 0
-      vertex -57.5325 30.3422 7
-      vertex -57.7472 30.4329 7
+      vertex -57.5325 30.3422 4
+      vertex -57.7472 30.4329 4
     endloop
   endfacet
   facet normal -0.38915 -0.921174 -0
     outer loop
-      vertex -57.5325 30.3422 7
+      vertex -57.5325 30.3422 4
       vertex -57.7472 30.4329 0
       vertex -57.5325 30.3422 0
     endloop
   endfacet
-  facet normal -0.994461 0.105109 0
+  facet normal 0.0909613 -0.995854 0
     outer loop
-      vertex -56.2162 27.8375 0
-      vertex -56.1917 28.0693 7
-      vertex -56.1917 28.0693 0
+      vertex -58.895 30.5541 0
+      vertex -58.6629 30.5753 4
+      vertex -58.895 30.5541 4
     endloop
   endfacet
-  facet normal -0.994461 0.105109 0
+  facet normal 0.0909613 -0.995854 0
     outer loop
-      vertex -56.1917 28.0693 7
-      vertex -56.2162 27.8375 0
-      vertex -56.2162 27.8375 7
-    endloop
-  endfacet
-  facet normal -0.979375 0.202052 0
-    outer loop
-      vertex -56.2633 27.6092 0
-      vertex -56.2162 27.8375 7
-      vertex -56.2162 27.8375 0
-    endloop
-  endfacet
-  facet normal -0.979375 0.202052 0
-    outer loop
-      vertex -56.2162 27.8375 7
-      vertex -56.2633 27.6092 0
-      vertex -56.2633 27.6092 7
-    endloop
-  endfacet
-  facet normal -0.999976 0.00686679 0
-    outer loop
-      vertex -56.1917 28.0693 0
-      vertex -56.1901 28.3023 7
-      vertex -56.1901 28.3023 0
-    endloop
-  endfacet
-  facet normal -0.999976 0.00686679 0
-    outer loop
-      vertex -56.1901 28.3023 7
-      vertex -56.1917 28.0693 0
-      vertex -56.1917 28.0693 7
-    endloop
-  endfacet
-  facet normal -0.995854 -0.0909613 0
-    outer loop
-      vertex -56.1901 28.3023 0
-      vertex -56.2113 28.5344 7
-      vertex -56.2113 28.5344 0
-    endloop
-  endfacet
-  facet normal -0.995854 -0.0909613 0
-    outer loop
-      vertex -56.2113 28.5344 7
-      vertex -56.1901 28.3023 0
-      vertex -56.1901 28.3023 7
-    endloop
-  endfacet
-  facet normal -0.958941 -0.283606 0
-    outer loop
-      vertex -56.2552 28.7634 0
-      vertex -56.3213 28.9869 7
-      vertex -56.3213 28.9869 0
-    endloop
-  endfacet
-  facet normal -0.958941 -0.283606 0
-    outer loop
-      vertex -56.3213 28.9869 7
-      vertex -56.2552 28.7634 0
-      vertex -56.2552 28.7634 7
+      vertex -58.6629 30.5753 4
+      vertex -58.895 30.5541 0
+      vertex -58.6629 30.5753 0
     endloop
   endfacet
   facet normal -0.982116 -0.188275 0
     outer loop
       vertex -56.2113 28.5344 0
-      vertex -56.2552 28.7634 7
+      vertex -56.2552 28.7634 4
       vertex -56.2552 28.7634 0
     endloop
   endfacet
   facet normal -0.982116 -0.188275 0
     outer loop
-      vertex -56.2552 28.7634 7
+      vertex -56.2552 28.7634 4
       vertex -56.2113 28.5344 0
-      vertex -56.2113 28.5344 7
+      vertex -56.2113 28.5344 4
     endloop
   endfacet
-  facet normal -0.92663 -0.375974 0
+  facet normal -0.18794 0.98218 0
     outer loop
-      vertex -56.3213 28.9869 0
-      vertex -56.4089 29.2028 7
-      vertex -56.4089 29.2028 0
+      vertex -58.0021 25.8946 0
+      vertex -58.231 25.8508 4
+      vertex -58.0021 25.8946 4
     endloop
   endfacet
-  facet normal -0.92663 -0.375974 0
+  facet normal -0.18794 0.98218 0
     outer loop
-      vertex -56.4089 29.2028 7
-      vertex -56.3213 28.9869 0
-      vertex -56.3213 28.9869 7
+      vertex -58.231 25.8508 4
+      vertex -58.0021 25.8946 0
+      vertex -58.231 25.8508 0
     endloop
   endfacet
-  facet normal -0.885058 -0.465481 0
+  facet normal 0.29698 0.954884 -0
     outer loop
-      vertex -56.4089 29.2028 0
-      vertex -56.5174 29.4091 7
-      vertex -56.5174 29.4091 0
+      vertex -59.1562 25.9027 0
+      vertex -59.3787 25.9719 4
+      vertex -59.1562 25.9027 4
     endloop
   endfacet
-  facet normal -0.885058 -0.465481 0
+  facet normal 0.29698 0.954884 0
     outer loop
-      vertex -56.5174 29.4091 7
-      vertex -56.4089 29.2028 0
-      vertex -56.4089 29.2028 7
+      vertex -59.3787 25.9719 4
+      vertex -59.1562 25.9027 0
+      vertex -59.3787 25.9719 0
+    endloop
+  endfacet
+  facet normal 0.202052 0.979375 -0
+    outer loop
+      vertex -58.9279 25.8556 0
+      vertex -59.1562 25.9027 4
+      vertex -58.9279 25.8556 4
+    endloop
+  endfacet
+  facet normal 0.202052 0.979375 0
+    outer loop
+      vertex -59.1562 25.9027 4
+      vertex -58.9279 25.8556 0
+      vertex -59.1562 25.9027 0
+    endloop
+  endfacet
+  facet normal -0.00686385 -0.999976 0
+    outer loop
+      vertex -58.6629 30.5753 0
+      vertex -58.4298 30.5737 4
+      vertex -58.6629 30.5753 4
+    endloop
+  endfacet
+  facet normal -0.00686385 -0.999976 -0
+    outer loop
+      vertex -58.4298 30.5737 4
+      vertex -58.6629 30.5753 0
+      vertex -58.4298 30.5737 0
+    endloop
+  endfacet
+  facet normal 0.639804 0.768538 -0
+    outer loop
+      vertex -59.9911 26.3048 0
+      vertex -60.1702 26.4539 4
+      vertex -59.9911 26.3048 4
+    endloop
+  endfacet
+  facet normal 0.639804 0.768538 0
+    outer loop
+      vertex -60.1702 26.4539 4
+      vertex -59.9911 26.3048 0
+      vertex -60.1702 26.4539 0
+    endloop
+  endfacet
+  facet normal 0.464968 -0.885327 0
+    outer loop
+      vertex -59.7697 30.2481 0
+      vertex -59.5633 30.3565 4
+      vertex -59.7697 30.2481 4
+    endloop
+  endfacet
+  facet normal 0.464968 -0.885327 0
+    outer loop
+      vertex -59.5633 30.3565 4
+      vertex -59.7697 30.2481 0
+      vertex -59.5633 30.3565 0
+    endloop
+  endfacet
+  facet normal -0.954884 0.29698 0
+    outer loop
+      vertex -56.3325 27.3867 0
+      vertex -56.2633 27.6092 4
+      vertex -56.2633 27.6092 0
+    endloop
+  endfacet
+  facet normal -0.954884 0.29698 0
+    outer loop
+      vertex -56.2633 27.6092 4
+      vertex -56.3325 27.3867 0
+      vertex -56.3325 27.3867 4
+    endloop
+  endfacet
+  facet normal -0.549939 0.835205 0
+    outer loop
+      vertex -57.1616 26.285 0
+      vertex -57.3563 26.1568 4
+      vertex -57.1616 26.285 4
+    endloop
+  endfacet
+  facet normal -0.549939 0.835205 0
+    outer loop
+      vertex -57.3563 26.1568 4
+      vertex -57.1616 26.285 0
+      vertex -57.3563 26.1568 0
+    endloop
+  endfacet
+  facet normal 0.768538 -0.639804 0
+    outer loop
+      vertex -60.4606 29.6306 4
+      vertex -60.3115 29.8097 0
+      vertex -60.3115 29.8097 4
+    endloop
+  endfacet
+  facet normal 0.768538 -0.639804 0
+    outer loop
+      vertex -60.3115 29.8097 0
+      vertex -60.4606 29.6306 4
+      vertex -60.4606 29.6306 0
+    endloop
+  endfacet
+  facet normal -0.465145 0.885234 0
+    outer loop
+      vertex -57.3563 26.1568 0
+      vertex -57.5626 26.0484 4
+      vertex -57.3563 26.1568 4
+    endloop
+  endfacet
+  facet normal -0.465145 0.885234 0
+    outer loop
+      vertex -57.5626 26.0484 4
+      vertex -57.3563 26.1568 0
+      vertex -57.5626 26.0484 0
+    endloop
+  endfacet
+  facet normal 0.629186 -0.777255 0
+    outer loop
+      vertex -60.1455 29.9733 0
+      vertex -59.9644 30.1199 4
+      vertex -60.1455 29.9733 4
+    endloop
+  endfacet
+  facet normal 0.629186 -0.777255 0
+    outer loop
+      vertex -59.9644 30.1199 4
+      vertex -60.1455 29.9733 0
+      vertex -59.9644 30.1199 0
+    endloop
+  endfacet
+  facet normal 0.561218 0.827668 -0
+    outer loop
+      vertex -59.7982 26.174 0
+      vertex -59.9911 26.3048 4
+      vertex -59.7982 26.174 4
+    endloop
+  endfacet
+  facet normal 0.561218 0.827668 0
+    outer loop
+      vertex -59.9911 26.3048 4
+      vertex -59.7982 26.174 0
+      vertex -59.9911 26.3048 0
+    endloop
+  endfacet
+  facet normal -0.297249 -0.9548 0
+    outer loop
+      vertex -57.9698 30.5022 0
+      vertex -57.7472 30.4329 4
+      vertex -57.9698 30.5022 4
+    endloop
+  endfacet
+  facet normal -0.297249 -0.9548 -0
+    outer loop
+      vertex -57.7472 30.4329 4
+      vertex -57.9698 30.5022 0
+      vertex -57.7472 30.4329 0
+    endloop
+  endfacet
+  facet normal 0.885234 0.465145 0
+    outer loop
+      vertex -60.6086 26.9958 4
+      vertex -60.717 27.2021 0
+      vertex -60.717 27.2021 4
+    endloop
+  endfacet
+  facet normal 0.885234 0.465145 0
+    outer loop
+      vertex -60.717 27.2021 0
+      vertex -60.6086 26.9958 4
+      vertex -60.6086 26.9958 0
+    endloop
+  endfacet
+  facet normal 0.982101 0.188354 0
+    outer loop
+      vertex -60.8708 27.6415 4
+      vertex -60.9147 27.8704 0
+      vertex -60.9147 27.8704 4
+    endloop
+  endfacet
+  facet normal 0.982101 0.188354 0
+    outer loop
+      vertex -60.9147 27.8704 0
+      vertex -60.8708 27.6415 4
+      vertex -60.8708 27.6415 0
+    endloop
+  endfacet
+  facet normal 0.47783 0.878452 -0
+    outer loop
+      vertex -59.5934 26.0626 0
+      vertex -59.7982 26.174 4
+      vertex -59.5934 26.0626 4
+    endloop
+  endfacet
+  facet normal 0.47783 0.878452 0
+    outer loop
+      vertex -59.7982 26.174 4
+      vertex -59.5934 26.0626 0
+      vertex -59.7982 26.174 0
+    endloop
+  endfacet
+  facet normal -0.702157 0.712022 0
+    outer loop
+      vertex -56.8144 26.5952 0
+      vertex -56.9804 26.4315 4
+      vertex -56.8144 26.5952 4
+    endloop
+  endfacet
+  facet normal -0.702157 0.712022 0
+    outer loop
+      vertex -56.9804 26.4315 4
+      vertex -56.8144 26.5952 0
+      vertex -56.9804 26.4315 0
+    endloop
+  endfacet
+  facet normal 0.104685 0.994505 -0
+    outer loop
+      vertex -58.6961 25.8312 0
+      vertex -58.9279 25.8556 4
+      vertex -58.6961 25.8312 4
+    endloop
+  endfacet
+  facet normal 0.104685 0.994505 0
+    outer loop
+      vertex -58.9279 25.8556 4
+      vertex -58.6961 25.8312 0
+      vertex -58.9279 25.8556 0
     endloop
   endfacet
   facet normal -0.777425 -0.628976 0
     outer loop
       vertex -56.6455 29.6038 0
-      vertex -56.7921 29.785 7
+      vertex -56.7921 29.785 4
       vertex -56.7921 29.785 0
     endloop
   endfacet
   facet normal -0.777425 -0.628976 0
     outer loop
-      vertex -56.7921 29.785 7
+      vertex -56.7921 29.785 4
       vertex -56.6455 29.6038 0
-      vertex -56.6455 29.6038 7
+      vertex -56.6455 29.6038 4
+    endloop
+  endfacet
+  facet normal -0.921174 0.38915 0
+    outer loop
+      vertex -56.4232 27.172 0
+      vertex -56.3325 27.3867 4
+      vertex -56.3325 27.3867 0
+    endloop
+  endfacet
+  facet normal -0.921174 0.38915 0
+    outer loop
+      vertex -56.3325 27.3867 4
+      vertex -56.4232 27.172 0
+      vertex -56.4232 27.172 4
+    endloop
+  endfacet
+  facet normal 0.549939 -0.835205 0
+    outer loop
+      vertex -59.9644 30.1199 0
+      vertex -59.7697 30.2481 4
+      vertex -59.9644 30.1199 4
+    endloop
+  endfacet
+  facet normal 0.549939 -0.835205 0
+    outer loop
+      vertex -59.7697 30.2481 4
+      vertex -59.9644 30.1199 0
+      vertex -59.7697 30.2481 0
+    endloop
+  endfacet
+  facet normal 0.283606 -0.958941 0
+    outer loop
+      vertex -59.3474 30.4442 0
+      vertex -59.1239 30.5103 4
+      vertex -59.3474 30.4442 4
+    endloop
+  endfacet
+  facet normal 0.283606 -0.958941 0
+    outer loop
+      vertex -59.1239 30.5103 4
+      vertex -59.3474 30.4442 0
+      vertex -59.1239 30.5103 0
+    endloop
+  endfacet
+  facet normal 0.00729594 0.999973 -0
+    outer loop
+      vertex -58.4631 25.8295 0
+      vertex -58.6961 25.8312 4
+      vertex -58.4631 25.8295 4
+    endloop
+  endfacet
+  facet normal 0.00729594 0.999973 0
+    outer loop
+      vertex -58.6961 25.8312 4
+      vertex -58.4631 25.8295 0
+      vertex -58.6961 25.8312 0
+    endloop
+  endfacet
+  facet normal -0.477499 -0.878632 0
+    outer loop
+      vertex -57.5325 30.3422 0
+      vertex -57.3277 30.2309 4
+      vertex -57.5325 30.3422 4
+    endloop
+  endfacet
+  facet normal -0.477499 -0.878632 -0
+    outer loop
+      vertex -57.3277 30.2309 4
+      vertex -57.5325 30.3422 0
+      vertex -57.3277 30.2309 0
+    endloop
+  endfacet
+  facet normal 0.777425 0.628976 0
+    outer loop
+      vertex -60.3339 26.6199 4
+      vertex -60.4805 26.8011 0
+      vertex -60.4805 26.8011 4
+    endloop
+  endfacet
+  facet normal 0.777425 0.628976 0
+    outer loop
+      vertex -60.4805 26.8011 0
+      vertex -60.3339 26.6199 4
+      vertex -60.3339 26.6199 0
+    endloop
+  endfacet
+  facet normal 0.701939 -0.712237 0
+    outer loop
+      vertex -60.3115 29.8097 0
+      vertex -60.1455 29.9733 4
+      vertex -60.3115 29.8097 4
+    endloop
+  endfacet
+  facet normal 0.701939 -0.712237 0
+    outer loop
+      vertex -60.1455 29.9733 4
+      vertex -60.3115 29.8097 0
+      vertex -60.1455 29.9733 0
     endloop
   endfacet
   facet normal -0.835402 -0.54964 0
     outer loop
       vertex -56.5174 29.4091 0
-      vertex -56.6455 29.6038 7
+      vertex -56.6455 29.6038 4
       vertex -56.6455 29.6038 0
     endloop
   endfacet
   facet normal -0.835402 -0.54964 0
     outer loop
-      vertex -56.6455 29.6038 7
+      vertex -56.6455 29.6038 4
       vertex -56.5174 29.4091 0
-      vertex -56.5174 29.4091 7
+      vertex -56.5174 29.4091 4
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex -60.9342 28.3356 4
+      vertex -60.9098 28.5674 0
+      vertex -60.9098 28.5674 4
+    endloop
+  endfacet
+  facet normal 0.994505 -0.104685 0
+    outer loop
+      vertex -60.9098 28.5674 0
+      vertex -60.9342 28.3356 4
+      vertex -60.9342 28.3356 0
+    endloop
+  endfacet
+  facet normal -0.283606 0.958941 0
+    outer loop
+      vertex -57.7786 25.9607 0
+      vertex -58.0021 25.8946 4
+      vertex -57.7786 25.9607 4
+    endloop
+  endfacet
+  facet normal -0.283606 0.958941 0
+    outer loop
+      vertex -58.0021 25.8946 4
+      vertex -57.7786 25.9607 0
+      vertex -58.0021 25.8946 0
+    endloop
+  endfacet
+  facet normal 0.827469 -0.561512 0
+    outer loop
+      vertex -60.5915 29.4377 4
+      vertex -60.4606 29.6306 0
+      vertex -60.4606 29.6306 4
+    endloop
+  endfacet
+  facet normal 0.827469 -0.561512 0
+    outer loop
+      vertex -60.4606 29.6306 0
+      vertex -60.5915 29.4377 4
+      vertex -60.5915 29.4377 0
+    endloop
+  endfacet
+  facet normal 0.999973 -0.00729281 0
+    outer loop
+      vertex -60.9359 28.1025 4
+      vertex -60.9342 28.3356 0
+      vertex -60.9342 28.3356 4
+    endloop
+  endfacet
+  facet normal 0.999973 -0.00729281 0
+    outer loop
+      vertex -60.9342 28.3356 0
+      vertex -60.9359 28.1025 4
+      vertex -60.9359 28.1025 0
+    endloop
+  endfacet
+  facet normal -0.958941 -0.283606 0
+    outer loop
+      vertex -56.2552 28.7634 0
+      vertex -56.3213 28.9869 4
+      vertex -56.3213 28.9869 0
+    endloop
+  endfacet
+  facet normal -0.958941 -0.283606 0
+    outer loop
+      vertex -56.3213 28.9869 4
+      vertex -56.2552 28.7634 0
+      vertex -56.2552 28.7634 4
+    endloop
+  endfacet
+  facet normal 0.376343 -0.926481 0
+    outer loop
+      vertex -59.5633 30.3565 0
+      vertex -59.3474 30.4442 4
+      vertex -59.5633 30.3565 4
+    endloop
+  endfacet
+  facet normal 0.376343 -0.926481 0
+    outer loop
+      vertex -59.3474 30.4442 4
+      vertex -59.5633 30.3565 0
+      vertex -59.3474 30.4442 0
+    endloop
+  endfacet
+  facet normal 0.995854 0.0909613 0
+    outer loop
+      vertex -60.9147 27.8704 4
+      vertex -60.9359 28.1025 0
+      vertex -60.9359 28.1025 4
+    endloop
+  endfacet
+  facet normal 0.995854 0.0909613 0
+    outer loop
+      vertex -60.9359 28.1025 0
+      vertex -60.9147 27.8704 4
+      vertex -60.9147 27.8704 0
+    endloop
+  endfacet
+  facet normal -0.994461 0.105109 0
+    outer loop
+      vertex -56.2162 27.8375 0
+      vertex -56.1917 28.0693 4
+      vertex -56.1917 28.0693 0
+    endloop
+  endfacet
+  facet normal -0.994461 0.105109 0
+    outer loop
+      vertex -56.1917 28.0693 4
+      vertex -56.2162 27.8375 0
+      vertex -56.2162 27.8375 4
     endloop
   endfacet
   facet normal -0.561218 -0.827668 0
     outer loop
       vertex -57.3277 30.2309 0
-      vertex -57.1348 30.1001 7
-      vertex -57.3277 30.2309 7
+      vertex -57.1348 30.1001 4
+      vertex -57.3277 30.2309 4
     endloop
   endfacet
   facet normal -0.561218 -0.827668 -0
     outer loop
-      vertex -57.1348 30.1001 7
+      vertex -57.1348 30.1001 4
       vertex -57.3277 30.2309 0
       vertex -57.1348 30.1001 0
     endloop
   endfacet
-  facet normal -0.712237 -0.701939 0
+  facet normal -0.92663 -0.375974 0
     outer loop
-      vertex -56.7921 29.785 0
-      vertex -56.9557 29.951 7
+      vertex -56.3213 28.9869 0
+      vertex -56.4089 29.2028 4
+      vertex -56.4089 29.2028 0
+    endloop
+  endfacet
+  facet normal -0.92663 -0.375974 0
+    outer loop
+      vertex -56.4089 29.2028 4
+      vertex -56.3213 28.9869 0
+      vertex -56.3213 28.9869 4
+    endloop
+  endfacet
+  facet normal 0.958941 0.283606 0
+    outer loop
+      vertex -60.8047 27.418 4
+      vertex -60.8708 27.6415 0
+      vertex -60.8708 27.6415 4
+    endloop
+  endfacet
+  facet normal 0.958941 0.283606 0
+    outer loop
+      vertex -60.8708 27.6415 0
+      vertex -60.8047 27.418 4
+      vertex -60.8047 27.418 0
+    endloop
+  endfacet
+  facet normal -0.376193 0.926541 0
+    outer loop
+      vertex -57.5626 26.0484 0
+      vertex -57.7786 25.9607 4
+      vertex -57.5626 26.0484 4
+    endloop
+  endfacet
+  facet normal -0.376193 0.926541 0
+    outer loop
+      vertex -57.7786 25.9607 4
+      vertex -57.5626 26.0484 0
+      vertex -57.7786 25.9607 0
+    endloop
+  endfacet
+  facet normal -0.979375 0.202052 0
+    outer loop
+      vertex -56.2633 27.6092 0
+      vertex -56.2162 27.8375 4
+      vertex -56.2162 27.8375 0
+    endloop
+  endfacet
+  facet normal -0.979375 0.202052 0
+    outer loop
+      vertex -56.2162 27.8375 4
+      vertex -56.2633 27.6092 0
+      vertex -56.2633 27.6092 4
+    endloop
+  endfacet
+  facet normal 0.18794 -0.98218 0
+    outer loop
+      vertex -59.1239 30.5103 0
+      vertex -58.895 30.5541 4
+      vertex -59.1239 30.5103 4
+    endloop
+  endfacet
+  facet normal 0.18794 -0.98218 0
+    outer loop
+      vertex -58.895 30.5541 4
+      vertex -59.1239 30.5103 0
+      vertex -58.895 30.5541 0
+    endloop
+  endfacet
+  facet normal -0.639804 -0.768538 0
+    outer loop
+      vertex -57.1348 30.1001 0
+      vertex -56.9557 29.951 4
+      vertex -57.1348 30.1001 4
+    endloop
+  endfacet
+  facet normal -0.639804 -0.768538 -0
+    outer loop
+      vertex -56.9557 29.951 4
+      vertex -57.1348 30.1001 0
       vertex -56.9557 29.951 0
     endloop
   endfacet
-  facet normal -0.712237 -0.701939 0
+  facet normal 0.926481 0.376343 0
     outer loop
-      vertex -56.9557 29.951 7
-      vertex -56.7921 29.785 0
-      vertex -56.7921 29.785 7
+      vertex -60.717 27.2021 4
+      vertex -60.8047 27.418 0
+      vertex -60.8047 27.418 4
+    endloop
+  endfacet
+  facet normal 0.926481 0.376343 0
+    outer loop
+      vertex -60.8047 27.418 0
+      vertex -60.717 27.2021 4
+      vertex -60.717 27.2021 0
+    endloop
+  endfacet
+  facet normal -0.995854 -0.0909613 0
+    outer loop
+      vertex -56.1901 28.3023 0
+      vertex -56.2113 28.5344 4
+      vertex -56.2113 28.5344 0
+    endloop
+  endfacet
+  facet normal -0.995854 -0.0909613 0
+    outer loop
+      vertex -56.2113 28.5344 4
+      vertex -56.1901 28.3023 0
+      vertex -56.1901 28.3023 4
+    endloop
+  endfacet
+  facet normal -0.768538 0.639804 0
+    outer loop
+      vertex -56.8144 26.5952 0
+      vertex -56.6653 26.7743 4
+      vertex -56.6653 26.7743 0
+    endloop
+  endfacet
+  facet normal -0.768538 0.639804 0
+    outer loop
+      vertex -56.6653 26.7743 4
+      vertex -56.8144 26.5952 0
+      vertex -56.8144 26.5952 4
+    endloop
+  endfacet
+  facet normal -0.885058 -0.465481 0
+    outer loop
+      vertex -56.4089 29.2028 0
+      vertex -56.5174 29.4091 4
+      vertex -56.5174 29.4091 0
+    endloop
+  endfacet
+  facet normal -0.885058 -0.465481 0
+    outer loop
+      vertex -56.5174 29.4091 4
+      vertex -56.4089 29.2028 0
+      vertex -56.4089 29.2028 4
+    endloop
+  endfacet
+  facet normal -0.0913868 0.995815 0
+    outer loop
+      vertex -58.231 25.8508 0
+      vertex -58.4631 25.8295 4
+      vertex -58.231 25.8508 4
+    endloop
+  endfacet
+  facet normal -0.0913868 0.995815 0
+    outer loop
+      vertex -58.4631 25.8295 4
+      vertex -58.231 25.8508 0
+      vertex -58.4631 25.8295 0
+    endloop
+  endfacet
+  facet normal -0.201726 -0.979442 0
+    outer loop
+      vertex -58.198 30.5492 0
+      vertex -57.9698 30.5022 4
+      vertex -58.198 30.5492 4
+    endloop
+  endfacet
+  facet normal -0.201726 -0.979442 -0
+    outer loop
+      vertex -57.9698 30.5022 4
+      vertex -58.198 30.5492 0
+      vertex -57.9698 30.5022 0
+    endloop
+  endfacet
+  facet normal -0.878632 0.477499 0
+    outer loop
+      vertex -56.5345 26.9672 0
+      vertex -56.4232 27.172 4
+      vertex -56.4232 27.172 0
+    endloop
+  endfacet
+  facet normal -0.878632 0.477499 0
+    outer loop
+      vertex -56.4232 27.172 4
+      vertex -56.5345 26.9672 0
+      vertex -56.5345 26.9672 4
+    endloop
+  endfacet
+  facet normal -0.999976 0.00686679 0
+    outer loop
+      vertex -56.1917 28.0693 0
+      vertex -56.1901 28.3023 4
+      vertex -56.1901 28.3023 0
+    endloop
+  endfacet
+  facet normal -0.999976 0.00686679 0
+    outer loop
+      vertex -56.1901 28.3023 4
+      vertex -56.1917 28.0693 0
+      vertex -56.1917 28.0693 4
+    endloop
+  endfacet
+  facet normal -0.628717 0.777634 0
+    outer loop
+      vertex -56.9804 26.4315 0
+      vertex -57.1616 26.285 4
+      vertex -56.9804 26.4315 4
+    endloop
+  endfacet
+  facet normal -0.628717 0.777634 0
+    outer loop
+      vertex -57.1616 26.285 4
+      vertex -56.9804 26.4315 0
+      vertex -57.1616 26.285 0
+    endloop
+  endfacet
+  facet normal 0.900968 -0.433886 0
+    outer loop
+      vertex -67.4067 21.3622 7
+      vertex -58.729 39.3815 4
+      vertex -58.729 39.3815 7
+    endloop
+  endfacet
+  facet normal 0.900968 -0.433886 0
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -67.4067 21.3622 7
+      vertex -67.4067 21.3622 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.2113 28.5344 4
+      vertex -56.1901 28.3023 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.2552 28.7634 4
+      vertex -56.2113 28.5344 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.3213 28.9869 4
+      vertex -56.2552 28.7634 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.4089 29.2028 4
+      vertex -56.3213 28.9869 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.5174 29.4091 4
+      vertex -56.4089 29.2028 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.6455 29.6038 4
+      vertex -56.5174 29.4091 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.7921 29.785 4
+      vertex -56.6455 29.6038 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -56.9557 29.951 4
+      vertex -56.7921 29.785 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -57.1348 30.1001 4
+      vertex -56.9557 29.951 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -57.3277 30.2309 4
+      vertex -57.1348 30.1001 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 35.0427 4
+      vertex -57.5325 30.3422 4
+      vertex -57.3277 30.2309 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -57.5325 30.3422 4
+      vertex -49.7193 35.0427 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57.5325 30.3422 4
+      vertex -58.729 39.3815 4
+      vertex -57.7472 30.4329 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57.7472 30.4329 4
+      vertex -58.729 39.3815 4
+      vertex -57.9698 30.5022 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57.9698 30.5022 4
+      vertex -58.729 39.3815 4
+      vertex -58.198 30.5492 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.198 30.5492 4
+      vertex -58.729 39.3815 4
+      vertex -58.4298 30.5737 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.4298 30.5737 4
+      vertex -58.729 39.3815 4
+      vertex -58.6629 30.5753 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -58.895 30.5541 4
+      vertex -58.6629 30.5753 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -59.1239 30.5103 4
+      vertex -58.895 30.5541 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -59.3474 30.4442 4
+      vertex -59.1239 30.5103 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -59.5633 30.3565 4
+      vertex -59.3474 30.4442 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -59.7697 30.2481 4
+      vertex -59.5633 30.3565 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -59.9644 30.1199 4
+      vertex -59.7697 30.2481 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -60.1455 29.9733 4
+      vertex -59.9644 30.1199 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -60.3115 29.8097 4
+      vertex -60.1455 29.9733 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -60.4606 29.6306 4
+      vertex -60.3115 29.8097 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -60.5915 29.4377 4
+      vertex -60.4606 29.6306 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -60.7028 29.2329 4
+      vertex -60.5915 29.4377 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.7028 29.2329 4
+      vertex -58.729 39.3815 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.7028 29.2329 4
+      vertex -67.4067 21.3622 4
+      vertex -60.7935 29.0182 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.7935 29.0182 4
+      vertex -67.4067 21.3622 4
+      vertex -60.8627 28.7957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.9342 28.3356 4
+      vertex -67.4067 21.3622 4
+      vertex -60.9359 28.1025 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.9098 28.5674 4
+      vertex -67.4067 21.3622 4
+      vertex -60.9342 28.3356 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.8627 28.7957 4
+      vertex -67.4067 21.3622 4
+      vertex -60.9098 28.5674 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.1917 28.0693 4
+      vertex -49.7193 35.0427 4
+      vertex -56.1901 28.3023 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.2162 27.8375 4
+      vertex -49.7193 35.0427 4
+      vertex -56.1917 28.0693 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.2633 27.6092 4
+      vertex -49.7193 35.0427 4
+      vertex -56.2162 27.8375 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.3325 27.3867 4
+      vertex -49.7193 35.0427 4
+      vertex -56.2633 27.6092 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.4232 27.172 4
+      vertex -49.7193 35.0427 4
+      vertex -56.3325 27.3867 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 17.0233 4
+      vertex -56.4232 27.172 4
+      vertex -56.5345 26.9672 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 17.0233 4
+      vertex -56.5345 26.9672 4
+      vertex -56.6653 26.7743 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 17.0233 4
+      vertex -56.6653 26.7743 4
+      vertex -56.8144 26.5952 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.4232 27.172 4
+      vertex -58.397 17.0233 4
+      vertex -49.7193 35.0427 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.9804 26.4315 4
+      vertex -58.397 17.0233 4
+      vertex -56.8144 26.5952 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.1616 26.285 4
+      vertex -58.397 17.0233 4
+      vertex -56.9804 26.4315 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.3563 26.1568 4
+      vertex -58.397 17.0233 4
+      vertex -57.1616 26.285 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.5626 26.0484 4
+      vertex -58.397 17.0233 4
+      vertex -57.3563 26.1568 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.7786 25.9607 4
+      vertex -58.397 17.0233 4
+      vertex -57.5626 26.0484 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -58.0021 25.8946 4
+      vertex -58.397 17.0233 4
+      vertex -57.7786 25.9607 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -58.231 25.8508 4
+      vertex -58.397 17.0233 4
+      vertex -58.0021 25.8946 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -58.4631 25.8295 4
+      vertex -58.397 17.0233 4
+      vertex -58.231 25.8508 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.6961 25.8312 4
+      vertex -58.397 17.0233 4
+      vertex -58.4631 25.8295 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.9279 25.8556 4
+      vertex -58.397 17.0233 4
+      vertex -58.6961 25.8312 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1562 25.9027 4
+      vertex -58.397 17.0233 4
+      vertex -58.9279 25.8556 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3787 25.9719 4
+      vertex -58.397 17.0233 4
+      vertex -59.1562 25.9027 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5934 26.0626 4
+      vertex -58.397 17.0233 4
+      vertex -59.3787 25.9719 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -59.5934 26.0626 4
+      vertex -59.7982 26.174 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -59.7982 26.174 4
+      vertex -59.9911 26.3048 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -59.9911 26.3048 4
+      vertex -60.1702 26.4539 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.1702 26.4539 4
+      vertex -60.3339 26.6199 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.3339 26.6199 4
+      vertex -60.4805 26.8011 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.4805 26.8011 4
+      vertex -60.6086 26.9958 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.6086 26.9958 4
+      vertex -60.717 27.2021 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.717 27.2021 4
+      vertex -60.8047 27.418 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.8047 27.418 4
+      vertex -60.8708 27.6415 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5934 26.0626 4
+      vertex -67.4067 21.3622 4
+      vertex -58.397 17.0233 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.9147 27.8704 4
+      vertex -67.4067 21.3622 4
+      vertex -60.8708 27.6415 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 21.3622 4
+      vertex -60.9147 27.8704 4
+      vertex -60.9359 28.1025 4
+    endloop
+  endfacet
+  facet normal -0.900969 0.433884 0
+    outer loop
+      vertex -58.397 17.0233 4
+      vertex -49.7193 35.0427 7
+      vertex -49.7193 35.0427 4
+    endloop
+  endfacet
+  facet normal -0.900969 0.433884 0
+    outer loop
+      vertex -49.7193 35.0427 7
+      vertex -58.397 17.0233 4
+      vertex -58.397 17.0233 7
+    endloop
+  endfacet
+  facet normal 0.433888 0.900967 -0
+    outer loop
+      vertex -58.397 17.0233 4
+      vertex -67.4067 21.3622 7
+      vertex -58.397 17.0233 7
+    endloop
+  endfacet
+  facet normal 0.433888 0.900967 0
+    outer loop
+      vertex -67.4067 21.3622 7
+      vertex -58.397 17.0233 4
+      vertex -67.4067 21.3622 4
+    endloop
+  endfacet
+  facet normal -0.43388 -0.900971 0
+    outer loop
+      vertex -58.729 39.3815 4
+      vertex -49.7193 35.0427 7
+      vertex -58.729 39.3815 7
+    endloop
+  endfacet
+  facet normal -0.43388 -0.900971 -0
+    outer loop
+      vertex -49.7193 35.0427 7
+      vertex -58.729 39.3815 4
+      vertex -49.7193 35.0427 4
     endloop
   endfacet
   facet normal -0.900969 -0.433884 0
@@ -9673,900 +8329,1432 @@ solid OpenSCAD_Model
       vertex -37.1096 -46.534 0
     endloop
   endfacet
-  facet normal 0.549939 0.835205 -0
-    outer loop
-      vertex -59.7697 -30.2481 0
-      vertex -59.9644 -30.1199 7
-      vertex -59.7697 -30.2481 7
-    endloop
-  endfacet
-  facet normal 0.549939 0.835205 0
-    outer loop
-      vertex -59.9644 -30.1199 7
-      vertex -59.7697 -30.2481 0
-      vertex -59.9644 -30.1199 0
-    endloop
-  endfacet
-  facet normal -0.105109 0.994461 0
-    outer loop
-      vertex -58.198 -30.5492 0
-      vertex -58.4298 -30.5737 7
-      vertex -58.198 -30.5492 7
-    endloop
-  endfacet
-  facet normal -0.105109 0.994461 0
-    outer loop
-      vertex -58.4298 -30.5737 7
-      vertex -58.198 -30.5492 0
-      vertex -58.4298 -30.5737 0
-    endloop
-  endfacet
-  facet normal -0.777425 0.628976 0
-    outer loop
-      vertex -56.7921 -29.785 0
-      vertex -56.6455 -29.6038 7
-      vertex -56.6455 -29.6038 0
-    endloop
-  endfacet
-  facet normal -0.777425 0.628976 0
-    outer loop
-      vertex -56.6455 -29.6038 7
-      vertex -56.7921 -29.785 0
-      vertex -56.7921 -29.785 7
-    endloop
-  endfacet
-  facet normal -0.994461 -0.105109 0
-    outer loop
-      vertex -56.1917 -28.0693 0
-      vertex -56.2162 -27.8375 7
-      vertex -56.2162 -27.8375 0
-    endloop
-  endfacet
-  facet normal -0.994461 -0.105109 0
-    outer loop
-      vertex -56.2162 -27.8375 7
-      vertex -56.1917 -28.0693 0
-      vertex -56.1917 -28.0693 7
-    endloop
-  endfacet
-  facet normal 0.921174 0.38915 0
-    outer loop
-      vertex -60.7028 -29.2329 7
-      vertex -60.7935 -29.0182 0
-      vertex -60.7935 -29.0182 7
-    endloop
-  endfacet
-  facet normal 0.921174 0.38915 0
-    outer loop
-      vertex -60.7935 -29.0182 0
-      vertex -60.7028 -29.2329 7
-      vertex -60.7028 -29.2329 0
-    endloop
-  endfacet
   facet normal 0.0909613 0.995854 -0
     outer loop
       vertex -58.6629 -30.5753 0
-      vertex -58.895 -30.5541 7
-      vertex -58.6629 -30.5753 7
+      vertex -58.895 -30.5541 4
+      vertex -58.6629 -30.5753 4
     endloop
   endfacet
   facet normal 0.0909613 0.995854 0
     outer loop
-      vertex -58.895 -30.5541 7
+      vertex -58.895 -30.5541 4
       vertex -58.6629 -30.5753 0
       vertex -58.895 -30.5541 0
     endloop
   endfacet
-  facet normal -0.982116 0.188275 0
-    outer loop
-      vertex -56.2552 -28.7634 0
-      vertex -56.2113 -28.5344 7
-      vertex -56.2113 -28.5344 0
-    endloop
-  endfacet
-  facet normal -0.982116 0.188275 0
-    outer loop
-      vertex -56.2113 -28.5344 7
-      vertex -56.2552 -28.7634 0
-      vertex -56.2552 -28.7634 7
-    endloop
-  endfacet
-  facet normal -0.639804 0.768538 0
-    outer loop
-      vertex -56.9557 -29.951 0
-      vertex -57.1348 -30.1001 7
-      vertex -56.9557 -29.951 7
-    endloop
-  endfacet
-  facet normal -0.639804 0.768538 0
-    outer loop
-      vertex -57.1348 -30.1001 7
-      vertex -56.9557 -29.951 0
-      vertex -57.1348 -30.1001 0
-    endloop
-  endfacet
   facet normal 0.827469 0.561512 0
     outer loop
-      vertex -60.4606 -29.6306 7
+      vertex -60.4606 -29.6306 4
       vertex -60.5915 -29.4377 0
-      vertex -60.5915 -29.4377 7
+      vertex -60.5915 -29.4377 4
     endloop
   endfacet
   facet normal 0.827469 0.561512 0
     outer loop
       vertex -60.5915 -29.4377 0
-      vertex -60.4606 -29.6306 7
+      vertex -60.4606 -29.6306 4
       vertex -60.4606 -29.6306 0
     endloop
   endfacet
-  facet normal 0.464968 0.885327 -0
-    outer loop
-      vertex -59.5633 -30.3565 0
-      vertex -59.7697 -30.2481 7
-      vertex -59.5633 -30.3565 7
-    endloop
-  endfacet
-  facet normal 0.464968 0.885327 0
-    outer loop
-      vertex -59.7697 -30.2481 7
-      vertex -59.5633 -30.3565 0
-      vertex -59.7697 -30.2481 0
-    endloop
-  endfacet
-  facet normal 0.283606 0.958941 -0
-    outer loop
-      vertex -59.1239 -30.5103 0
-      vertex -59.3474 -30.4442 7
-      vertex -59.1239 -30.5103 7
-    endloop
-  endfacet
-  facet normal 0.283606 0.958941 0
-    outer loop
-      vertex -59.3474 -30.4442 7
-      vertex -59.1239 -30.5103 0
-      vertex -59.3474 -30.4442 0
-    endloop
-  endfacet
-  facet normal -0.477499 0.878632 0
-    outer loop
-      vertex -57.3277 -30.2309 0
-      vertex -57.5325 -30.3422 7
-      vertex -57.3277 -30.2309 7
-    endloop
-  endfacet
-  facet normal -0.477499 0.878632 0
-    outer loop
-      vertex -57.5325 -30.3422 7
-      vertex -57.3277 -30.2309 0
-      vertex -57.5325 -30.3422 0
-    endloop
-  endfacet
-  facet normal -0.201726 0.979442 0
-    outer loop
-      vertex -57.9698 -30.5022 0
-      vertex -58.198 -30.5492 7
-      vertex -57.9698 -30.5022 7
-    endloop
-  endfacet
-  facet normal -0.201726 0.979442 0
-    outer loop
-      vertex -58.198 -30.5492 7
-      vertex -57.9698 -30.5022 0
-      vertex -58.198 -30.5492 0
-    endloop
-  endfacet
-  facet normal -0.297249 0.9548 0
-    outer loop
-      vertex -57.7472 -30.4329 0
-      vertex -57.9698 -30.5022 7
-      vertex -57.7472 -30.4329 7
-    endloop
-  endfacet
-  facet normal -0.297249 0.9548 0
-    outer loop
-      vertex -57.9698 -30.5022 7
-      vertex -57.7472 -30.4329 0
-      vertex -57.9698 -30.5022 0
-    endloop
-  endfacet
-  facet normal -0.00686385 0.999976 0
-    outer loop
-      vertex -58.4298 -30.5737 0
-      vertex -58.6629 -30.5753 7
-      vertex -58.4298 -30.5737 7
-    endloop
-  endfacet
-  facet normal -0.00686385 0.999976 0
-    outer loop
-      vertex -58.6629 -30.5753 7
-      vertex -58.4298 -30.5737 0
-      vertex -58.6629 -30.5753 0
-    endloop
-  endfacet
-  facet normal 0.18794 0.98218 -0
-    outer loop
-      vertex -58.895 -30.5541 0
-      vertex -59.1239 -30.5103 7
-      vertex -58.895 -30.5541 7
-    endloop
-  endfacet
-  facet normal 0.18794 0.98218 0
-    outer loop
-      vertex -59.1239 -30.5103 7
-      vertex -58.895 -30.5541 0
-      vertex -59.1239 -30.5103 0
-    endloop
-  endfacet
-  facet normal -0.878632 -0.477499 0
-    outer loop
-      vertex -56.4232 -27.172 0
-      vertex -56.5345 -26.9672 7
-      vertex -56.5345 -26.9672 0
-    endloop
-  endfacet
-  facet normal -0.878632 -0.477499 0
-    outer loop
-      vertex -56.5345 -26.9672 7
-      vertex -56.4232 -27.172 0
-      vertex -56.4232 -27.172 7
-    endloop
-  endfacet
-  facet normal -0.979375 -0.202052 0
-    outer loop
-      vertex -56.2162 -27.8375 0
-      vertex -56.2633 -27.6092 7
-      vertex -56.2633 -27.6092 0
-    endloop
-  endfacet
-  facet normal -0.979375 -0.202052 0
-    outer loop
-      vertex -56.2633 -27.6092 7
-      vertex -56.2162 -27.8375 0
-      vertex -56.2162 -27.8375 7
-    endloop
-  endfacet
-  facet normal -0.954884 -0.29698 0
-    outer loop
-      vertex -56.2633 -27.6092 0
-      vertex -56.3325 -27.3867 7
-      vertex -56.3325 -27.3867 0
-    endloop
-  endfacet
-  facet normal -0.954884 -0.29698 0
-    outer loop
-      vertex -56.3325 -27.3867 7
-      vertex -56.2633 -27.6092 0
-      vertex -56.2633 -27.6092 7
-    endloop
-  endfacet
-  facet normal -0.999976 -0.00686679 0
-    outer loop
-      vertex -56.1901 -28.3023 0
-      vertex -56.1917 -28.0693 7
-      vertex -56.1917 -28.0693 0
-    endloop
-  endfacet
-  facet normal -0.999976 -0.00686679 0
-    outer loop
-      vertex -56.1917 -28.0693 7
-      vertex -56.1901 -28.3023 0
-      vertex -56.1901 -28.3023 7
-    endloop
-  endfacet
-  facet normal -0.995854 0.0909613 0
-    outer loop
-      vertex -56.2113 -28.5344 0
-      vertex -56.1901 -28.3023 7
-      vertex -56.1901 -28.3023 0
-    endloop
-  endfacet
-  facet normal -0.995854 0.0909613 0
-    outer loop
-      vertex -56.1901 -28.3023 7
-      vertex -56.2113 -28.5344 0
-      vertex -56.2113 -28.5344 7
-    endloop
-  endfacet
-  facet normal -0.712237 0.701939 0
-    outer loop
-      vertex -56.9557 -29.951 0
-      vertex -56.7921 -29.785 7
-      vertex -56.7921 -29.785 0
-    endloop
-  endfacet
-  facet normal -0.712237 0.701939 0
-    outer loop
-      vertex -56.7921 -29.785 7
-      vertex -56.9557 -29.951 0
-      vertex -56.9557 -29.951 7
-    endloop
-  endfacet
-  facet normal -0.561218 0.827668 0
-    outer loop
-      vertex -57.1348 -30.1001 0
-      vertex -57.3277 -30.2309 7
-      vertex -57.1348 -30.1001 7
-    endloop
-  endfacet
-  facet normal -0.561218 0.827668 0
-    outer loop
-      vertex -57.3277 -30.2309 7
-      vertex -57.1348 -30.1001 0
-      vertex -57.3277 -30.2309 0
-    endloop
-  endfacet
-  facet normal -0.885058 0.465481 0
-    outer loop
-      vertex -56.5174 -29.4091 0
-      vertex -56.4089 -29.2028 7
-      vertex -56.4089 -29.2028 0
-    endloop
-  endfacet
-  facet normal -0.885058 0.465481 0
-    outer loop
-      vertex -56.4089 -29.2028 7
-      vertex -56.5174 -29.4091 0
-      vertex -56.5174 -29.4091 7
-    endloop
-  endfacet
-  facet normal -0.92663 0.375974 0
-    outer loop
-      vertex -56.4089 -29.2028 0
-      vertex -56.3213 -28.9869 7
-      vertex -56.3213 -28.9869 0
-    endloop
-  endfacet
-  facet normal -0.92663 0.375974 0
-    outer loop
-      vertex -56.3213 -28.9869 7
-      vertex -56.4089 -29.2028 0
-      vertex -56.4089 -29.2028 7
-    endloop
-  endfacet
-  facet normal -0.835402 0.54964 0
-    outer loop
-      vertex -56.6455 -29.6038 0
-      vertex -56.5174 -29.4091 7
-      vertex -56.5174 -29.4091 0
-    endloop
-  endfacet
-  facet normal -0.835402 0.54964 0
-    outer loop
-      vertex -56.5174 -29.4091 7
-      vertex -56.6455 -29.6038 0
-      vertex -56.6455 -29.6038 7
-    endloop
-  endfacet
-  facet normal -0.958941 0.283606 0
-    outer loop
-      vertex -56.3213 -28.9869 0
-      vertex -56.2552 -28.7634 7
-      vertex -56.2552 -28.7634 0
-    endloop
-  endfacet
-  facet normal -0.958941 0.283606 0
-    outer loop
-      vertex -56.2552 -28.7634 7
-      vertex -56.3213 -28.9869 0
-      vertex -56.3213 -28.9869 7
-    endloop
-  endfacet
   facet normal 0.878632 0.477499 0
     outer loop
-      vertex -60.5915 -29.4377 7
+      vertex -60.5915 -29.4377 4
       vertex -60.7028 -29.2329 0
-      vertex -60.7028 -29.2329 7
+      vertex -60.7028 -29.2329 4
     endloop
   endfacet
   facet normal 0.878632 0.477499 0
     outer loop
       vertex -60.7028 -29.2329 0
-      vertex -60.5915 -29.4377 7
+      vertex -60.5915 -29.4377 4
       vertex -60.5915 -29.4377 0
     endloop
   endfacet
-  facet normal 0.979375 0.202052 0
-    outer loop
-      vertex -60.8627 -28.7957 7
-      vertex -60.9098 -28.5674 0
-      vertex -60.9098 -28.5674 7
-    endloop
-  endfacet
-  facet normal 0.979375 0.202052 0
-    outer loop
-      vertex -60.9098 -28.5674 0
-      vertex -60.8627 -28.7957 7
-      vertex -60.8627 -28.7957 0
-    endloop
-  endfacet
-  facet normal -0.827668 -0.561218 0
-    outer loop
-      vertex -56.5345 -26.9672 0
-      vertex -56.6653 -26.7743 7
-      vertex -56.6653 -26.7743 0
-    endloop
-  endfacet
-  facet normal -0.827668 -0.561218 0
-    outer loop
-      vertex -56.6653 -26.7743 7
-      vertex -56.5345 -26.9672 0
-      vertex -56.5345 -26.9672 7
-    endloop
-  endfacet
-  facet normal 0.561218 -0.827668 0
-    outer loop
-      vertex -59.9911 -26.3048 0
-      vertex -59.7982 -26.174 7
-      vertex -59.9911 -26.3048 7
-    endloop
-  endfacet
-  facet normal 0.561218 -0.827668 0
-    outer loop
-      vertex -59.7982 -26.174 7
-      vertex -59.9911 -26.3048 0
-      vertex -59.7982 -26.174 0
-    endloop
-  endfacet
-  facet normal 0.777425 -0.628976 0
-    outer loop
-      vertex -60.4805 -26.8011 7
-      vertex -60.3339 -26.6199 0
-      vertex -60.3339 -26.6199 7
-    endloop
-  endfacet
-  facet normal 0.777425 -0.628976 0
-    outer loop
-      vertex -60.3339 -26.6199 0
-      vertex -60.4805 -26.8011 7
-      vertex -60.4805 -26.8011 0
-    endloop
-  endfacet
-  facet normal 0.629186 0.777255 -0
-    outer loop
-      vertex -59.9644 -30.1199 0
-      vertex -60.1455 -29.9733 7
-      vertex -59.9644 -30.1199 7
-    endloop
-  endfacet
-  facet normal 0.629186 0.777255 0
-    outer loop
-      vertex -60.1455 -29.9733 7
-      vertex -59.9644 -30.1199 0
-      vertex -60.1455 -29.9733 0
-    endloop
-  endfacet
-  facet normal 0.701939 0.712237 -0
-    outer loop
-      vertex -60.1455 -29.9733 0
-      vertex -60.3115 -29.8097 7
-      vertex -60.1455 -29.9733 7
-    endloop
-  endfacet
-  facet normal 0.701939 0.712237 0
-    outer loop
-      vertex -60.3115 -29.8097 7
-      vertex -60.1455 -29.9733 0
-      vertex -60.3115 -29.8097 0
-    endloop
-  endfacet
-  facet normal 0.376343 0.926481 -0
-    outer loop
-      vertex -59.3474 -30.4442 0
-      vertex -59.5633 -30.3565 7
-      vertex -59.3474 -30.4442 7
-    endloop
-  endfacet
-  facet normal 0.376343 0.926481 0
-    outer loop
-      vertex -59.5633 -30.3565 7
-      vertex -59.3474 -30.4442 0
-      vertex -59.5633 -30.3565 0
-    endloop
-  endfacet
-  facet normal -0.38915 0.921174 0
-    outer loop
-      vertex -57.5325 -30.3422 0
-      vertex -57.7472 -30.4329 7
-      vertex -57.5325 -30.3422 7
-    endloop
-  endfacet
-  facet normal -0.38915 0.921174 0
-    outer loop
-      vertex -57.7472 -30.4329 7
-      vertex -57.5325 -30.3422 0
-      vertex -57.7472 -30.4329 0
-    endloop
-  endfacet
-  facet normal -0.921174 -0.38915 0
-    outer loop
-      vertex -56.3325 -27.3867 0
-      vertex -56.4232 -27.172 7
-      vertex -56.4232 -27.172 0
-    endloop
-  endfacet
-  facet normal -0.921174 -0.38915 0
-    outer loop
-      vertex -56.4232 -27.172 7
-      vertex -56.3325 -27.3867 0
-      vertex -56.3325 -27.3867 7
-    endloop
-  endfacet
-  facet normal 0.958941 -0.283606 0
-    outer loop
-      vertex -60.8708 -27.6415 7
-      vertex -60.8047 -27.418 0
-      vertex -60.8047 -27.418 7
-    endloop
-  endfacet
-  facet normal 0.958941 -0.283606 0
-    outer loop
-      vertex -60.8047 -27.418 0
-      vertex -60.8708 -27.6415 7
-      vertex -60.8708 -27.6415 0
-    endloop
-  endfacet
-  facet normal 0.995854 -0.0909613 0
-    outer loop
-      vertex -60.9359 -28.1025 7
-      vertex -60.9147 -27.8704 0
-      vertex -60.9147 -27.8704 7
-    endloop
-  endfacet
-  facet normal 0.995854 -0.0909613 0
-    outer loop
-      vertex -60.9147 -27.8704 0
-      vertex -60.9359 -28.1025 7
-      vertex -60.9359 -28.1025 0
-    endloop
-  endfacet
-  facet normal 0.999973 0.00729281 0
-    outer loop
-      vertex -60.9342 -28.3356 7
-      vertex -60.9359 -28.1025 0
-      vertex -60.9359 -28.1025 7
-    endloop
-  endfacet
-  facet normal 0.999973 0.00729281 0
-    outer loop
-      vertex -60.9359 -28.1025 0
-      vertex -60.9342 -28.3356 7
-      vertex -60.9342 -28.3356 0
-    endloop
-  endfacet
-  facet normal 0.38915 -0.921174 0
-    outer loop
-      vertex -59.5934 -26.0626 0
-      vertex -59.3787 -25.9719 7
-      vertex -59.5934 -26.0626 7
-    endloop
-  endfacet
-  facet normal 0.38915 -0.921174 0
-    outer loop
-      vertex -59.3787 -25.9719 7
-      vertex -59.5934 -26.0626 0
-      vertex -59.3787 -25.9719 0
-    endloop
-  endfacet
-  facet normal 0.639804 -0.768538 0
-    outer loop
-      vertex -60.1702 -26.4539 0
-      vertex -59.9911 -26.3048 7
-      vertex -60.1702 -26.4539 7
-    endloop
-  endfacet
-  facet normal 0.639804 -0.768538 0
-    outer loop
-      vertex -59.9911 -26.3048 7
-      vertex -60.1702 -26.4539 0
-      vertex -59.9911 -26.3048 0
-    endloop
-  endfacet
-  facet normal 0.712022 -0.702157 0
-    outer loop
-      vertex -60.3339 -26.6199 7
-      vertex -60.1702 -26.4539 0
-      vertex -60.1702 -26.4539 7
-    endloop
-  endfacet
-  facet normal 0.712022 -0.702157 0
-    outer loop
-      vertex -60.1702 -26.4539 0
-      vertex -60.3339 -26.6199 7
-      vertex -60.3339 -26.6199 0
-    endloop
-  endfacet
   facet normal 0.768538 0.639804 0
     outer loop
-      vertex -60.3115 -29.8097 7
+      vertex -60.3115 -29.8097 4
       vertex -60.4606 -29.6306 0
-      vertex -60.4606 -29.6306 7
+      vertex -60.4606 -29.6306 4
     endloop
   endfacet
   facet normal 0.768538 0.639804 0
     outer loop
       vertex -60.4606 -29.6306 0
-      vertex -60.3115 -29.8097 7
+      vertex -60.3115 -29.8097 4
       vertex -60.3115 -29.8097 0
     endloop
   endfacet
-  facet normal 0.954884 0.29698 0
+  facet normal 0.712022 -0.702157 0
     outer loop
-      vertex -60.7935 -29.0182 7
-      vertex -60.8627 -28.7957 0
-      vertex -60.8627 -28.7957 7
+      vertex -60.3339 -26.6199 4
+      vertex -60.1702 -26.4539 0
+      vertex -60.1702 -26.4539 4
     endloop
   endfacet
-  facet normal 0.954884 0.29698 0
+  facet normal 0.712022 -0.702157 0
     outer loop
-      vertex -60.8627 -28.7957 0
-      vertex -60.7935 -29.0182 7
-      vertex -60.7935 -29.0182 0
+      vertex -60.1702 -26.4539 0
+      vertex -60.3339 -26.6199 4
+      vertex -60.3339 -26.6199 0
     endloop
   endfacet
-  facet normal 0.926481 -0.376343 0
+  facet normal 0.104685 -0.994505 0
     outer loop
-      vertex -60.8047 -27.418 7
-      vertex -60.717 -27.2021 0
-      vertex -60.717 -27.2021 7
-    endloop
-  endfacet
-  facet normal 0.926481 -0.376343 0
-    outer loop
-      vertex -60.717 -27.2021 0
-      vertex -60.8047 -27.418 7
-      vertex -60.8047 -27.418 0
-    endloop
-  endfacet
-  facet normal 0.885234 -0.465145 0
-    outer loop
-      vertex -60.717 -27.2021 7
-      vertex -60.6086 -26.9958 0
-      vertex -60.6086 -26.9958 7
-    endloop
-  endfacet
-  facet normal 0.885234 -0.465145 0
-    outer loop
-      vertex -60.6086 -26.9958 0
-      vertex -60.717 -27.2021 7
-      vertex -60.717 -27.2021 0
-    endloop
-  endfacet
-  facet normal 0.835402 -0.54964 0
-    outer loop
-      vertex -60.6086 -26.9958 7
-      vertex -60.4805 -26.8011 0
-      vertex -60.4805 -26.8011 7
-    endloop
-  endfacet
-  facet normal 0.835402 -0.54964 0
-    outer loop
-      vertex -60.4805 -26.8011 0
-      vertex -60.6086 -26.9958 7
-      vertex -60.6086 -26.9958 0
-    endloop
-  endfacet
-  facet normal 0.982101 -0.188354 0
-    outer loop
-      vertex -60.9147 -27.8704 7
-      vertex -60.8708 -27.6415 0
-      vertex -60.8708 -27.6415 7
-    endloop
-  endfacet
-  facet normal 0.982101 -0.188354 0
-    outer loop
-      vertex -60.8708 -27.6415 0
-      vertex -60.9147 -27.8704 7
-      vertex -60.9147 -27.8704 0
-    endloop
-  endfacet
-  facet normal 0.994505 0.104685 0
-    outer loop
-      vertex -60.9098 -28.5674 7
-      vertex -60.9342 -28.3356 0
-      vertex -60.9342 -28.3356 7
-    endloop
-  endfacet
-  facet normal 0.994505 0.104685 0
-    outer loop
-      vertex -60.9342 -28.3356 0
-      vertex -60.9098 -28.5674 7
-      vertex -60.9098 -28.5674 0
-    endloop
-  endfacet
-  facet normal 0.202052 -0.979375 0
-    outer loop
-      vertex -59.1562 -25.9027 0
-      vertex -58.9279 -25.8556 7
-      vertex -59.1562 -25.9027 7
-    endloop
-  endfacet
-  facet normal 0.202052 -0.979375 0
-    outer loop
-      vertex -58.9279 -25.8556 7
-      vertex -59.1562 -25.9027 0
       vertex -58.9279 -25.8556 0
+      vertex -58.6961 -25.8312 4
+      vertex -58.9279 -25.8556 4
+    endloop
+  endfacet
+  facet normal 0.104685 -0.994505 0
+    outer loop
+      vertex -58.6961 -25.8312 4
+      vertex -58.9279 -25.8556 0
+      vertex -58.6961 -25.8312 0
+    endloop
+  endfacet
+  facet normal -0.954884 -0.29698 0
+    outer loop
+      vertex -56.2633 -27.6092 0
+      vertex -56.3325 -27.3867 4
+      vertex -56.3325 -27.3867 0
+    endloop
+  endfacet
+  facet normal -0.954884 -0.29698 0
+    outer loop
+      vertex -56.3325 -27.3867 4
+      vertex -56.2633 -27.6092 0
+      vertex -56.2633 -27.6092 4
+    endloop
+  endfacet
+  facet normal -0.477499 0.878632 0
+    outer loop
+      vertex -57.3277 -30.2309 0
+      vertex -57.5325 -30.3422 4
+      vertex -57.3277 -30.2309 4
+    endloop
+  endfacet
+  facet normal -0.477499 0.878632 0
+    outer loop
+      vertex -57.5325 -30.3422 4
+      vertex -57.3277 -30.2309 0
+      vertex -57.5325 -30.3422 0
+    endloop
+  endfacet
+  facet normal 0.921174 0.38915 0
+    outer loop
+      vertex -60.7028 -29.2329 4
+      vertex -60.7935 -29.0182 0
+      vertex -60.7935 -29.0182 4
+    endloop
+  endfacet
+  facet normal 0.921174 0.38915 0
+    outer loop
+      vertex -60.7935 -29.0182 0
+      vertex -60.7028 -29.2329 4
+      vertex -60.7028 -29.2329 0
+    endloop
+  endfacet
+  facet normal -0.105109 0.994461 0
+    outer loop
+      vertex -58.198 -30.5492 0
+      vertex -58.4298 -30.5737 4
+      vertex -58.198 -30.5492 4
+    endloop
+  endfacet
+  facet normal -0.105109 0.994461 0
+    outer loop
+      vertex -58.4298 -30.5737 4
+      vertex -58.198 -30.5492 0
+      vertex -58.4298 -30.5737 0
     endloop
   endfacet
   facet normal 0.47783 -0.878452 0
     outer loop
       vertex -59.7982 -26.174 0
-      vertex -59.5934 -26.0626 7
-      vertex -59.7982 -26.174 7
+      vertex -59.5934 -26.0626 4
+      vertex -59.7982 -26.174 4
     endloop
   endfacet
   facet normal 0.47783 -0.878452 0
     outer loop
-      vertex -59.5934 -26.0626 7
+      vertex -59.5934 -26.0626 4
       vertex -59.7982 -26.174 0
       vertex -59.5934 -26.0626 0
     endloop
   endfacet
-  facet normal -0.702157 -0.712022 0
+  facet normal 0.835402 -0.54964 0
     outer loop
-      vertex -56.9804 -26.4315 0
-      vertex -56.8144 -26.5952 7
-      vertex -56.9804 -26.4315 7
+      vertex -60.6086 -26.9958 4
+      vertex -60.4805 -26.8011 0
+      vertex -60.4805 -26.8011 4
     endloop
   endfacet
-  facet normal -0.702157 -0.712022 -0
+  facet normal 0.835402 -0.54964 0
     outer loop
-      vertex -56.8144 -26.5952 7
-      vertex -56.9804 -26.4315 0
-      vertex -56.8144 -26.5952 0
-    endloop
-  endfacet
-  facet normal -0.768538 -0.639804 0
-    outer loop
-      vertex -56.6653 -26.7743 0
-      vertex -56.8144 -26.5952 7
-      vertex -56.8144 -26.5952 0
-    endloop
-  endfacet
-  facet normal -0.768538 -0.639804 0
-    outer loop
-      vertex -56.8144 -26.5952 7
-      vertex -56.6653 -26.7743 0
-      vertex -56.6653 -26.7743 7
-    endloop
-  endfacet
-  facet normal -0.628717 -0.777634 0
-    outer loop
-      vertex -57.1616 -26.285 0
-      vertex -56.9804 -26.4315 7
-      vertex -57.1616 -26.285 7
-    endloop
-  endfacet
-  facet normal -0.628717 -0.777634 -0
-    outer loop
-      vertex -56.9804 -26.4315 7
-      vertex -57.1616 -26.285 0
-      vertex -56.9804 -26.4315 0
-    endloop
-  endfacet
-  facet normal -0.549939 -0.835205 0
-    outer loop
-      vertex -57.3563 -26.1568 0
-      vertex -57.1616 -26.285 7
-      vertex -57.3563 -26.1568 7
-    endloop
-  endfacet
-  facet normal -0.549939 -0.835205 -0
-    outer loop
-      vertex -57.1616 -26.285 7
-      vertex -57.3563 -26.1568 0
-      vertex -57.1616 -26.285 0
-    endloop
-  endfacet
-  facet normal -0.376193 -0.926541 0
-    outer loop
-      vertex -57.7786 -25.9607 0
-      vertex -57.5626 -26.0484 7
-      vertex -57.7786 -25.9607 7
-    endloop
-  endfacet
-  facet normal -0.376193 -0.926541 -0
-    outer loop
-      vertex -57.5626 -26.0484 7
-      vertex -57.7786 -25.9607 0
-      vertex -57.5626 -26.0484 0
+      vertex -60.4805 -26.8011 0
+      vertex -60.6086 -26.9958 4
+      vertex -60.6086 -26.9958 0
     endloop
   endfacet
   facet normal -0.465145 -0.885234 0
     outer loop
       vertex -57.5626 -26.0484 0
-      vertex -57.3563 -26.1568 7
-      vertex -57.5626 -26.0484 7
+      vertex -57.3563 -26.1568 4
+      vertex -57.5626 -26.0484 4
     endloop
   endfacet
   facet normal -0.465145 -0.885234 -0
     outer loop
-      vertex -57.3563 -26.1568 7
+      vertex -57.3563 -26.1568 4
       vertex -57.5626 -26.0484 0
       vertex -57.3563 -26.1568 0
     endloop
   endfacet
-  facet normal -0.283606 -0.958941 0
+  facet normal -0.885058 0.465481 0
     outer loop
-      vertex -58.0021 -25.8946 0
-      vertex -57.7786 -25.9607 7
-      vertex -58.0021 -25.8946 7
+      vertex -56.5174 -29.4091 0
+      vertex -56.4089 -29.2028 4
+      vertex -56.4089 -29.2028 0
     endloop
   endfacet
-  facet normal -0.283606 -0.958941 -0
+  facet normal -0.885058 0.465481 0
     outer loop
-      vertex -57.7786 -25.9607 7
-      vertex -58.0021 -25.8946 0
-      vertex -57.7786 -25.9607 0
+      vertex -56.4089 -29.2028 4
+      vertex -56.5174 -29.4091 0
+      vertex -56.5174 -29.4091 4
     endloop
   endfacet
-  facet normal -0.18794 -0.98218 0
+  facet normal -0.561218 0.827668 0
     outer loop
-      vertex -58.231 -25.8508 0
-      vertex -58.0021 -25.8946 7
-      vertex -58.231 -25.8508 7
+      vertex -57.1348 -30.1001 0
+      vertex -57.3277 -30.2309 4
+      vertex -57.1348 -30.1001 4
     endloop
   endfacet
-  facet normal -0.18794 -0.98218 -0
+  facet normal -0.561218 0.827668 0
     outer loop
-      vertex -58.0021 -25.8946 7
-      vertex -58.231 -25.8508 0
-      vertex -58.0021 -25.8946 0
+      vertex -57.3277 -30.2309 4
+      vertex -57.1348 -30.1001 0
+      vertex -57.3277 -30.2309 0
+    endloop
+  endfacet
+  facet normal -0.639804 0.768538 0
+    outer loop
+      vertex -56.9557 -29.951 0
+      vertex -57.1348 -30.1001 4
+      vertex -56.9557 -29.951 4
+    endloop
+  endfacet
+  facet normal -0.639804 0.768538 0
+    outer loop
+      vertex -57.1348 -30.1001 4
+      vertex -56.9557 -29.951 0
+      vertex -57.1348 -30.1001 0
+    endloop
+  endfacet
+  facet normal 0.777425 -0.628976 0
+    outer loop
+      vertex -60.4805 -26.8011 4
+      vertex -60.3339 -26.6199 0
+      vertex -60.3339 -26.6199 4
+    endloop
+  endfacet
+  facet normal 0.777425 -0.628976 0
+    outer loop
+      vertex -60.3339 -26.6199 0
+      vertex -60.4805 -26.8011 4
+      vertex -60.4805 -26.8011 0
+    endloop
+  endfacet
+  facet normal -0.201726 0.979442 0
+    outer loop
+      vertex -57.9698 -30.5022 0
+      vertex -58.198 -30.5492 4
+      vertex -57.9698 -30.5022 4
+    endloop
+  endfacet
+  facet normal -0.201726 0.979442 0
+    outer loop
+      vertex -58.198 -30.5492 4
+      vertex -57.9698 -30.5022 0
+      vertex -58.198 -30.5492 0
+    endloop
+  endfacet
+  facet normal 0.982101 -0.188354 0
+    outer loop
+      vertex -60.9147 -27.8704 4
+      vertex -60.8708 -27.6415 0
+      vertex -60.8708 -27.6415 4
+    endloop
+  endfacet
+  facet normal 0.982101 -0.188354 0
+    outer loop
+      vertex -60.8708 -27.6415 0
+      vertex -60.9147 -27.8704 4
+      vertex -60.9147 -27.8704 0
+    endloop
+  endfacet
+  facet normal -0.827668 -0.561218 0
+    outer loop
+      vertex -56.5345 -26.9672 0
+      vertex -56.6653 -26.7743 4
+      vertex -56.6653 -26.7743 0
+    endloop
+  endfacet
+  facet normal -0.827668 -0.561218 0
+    outer loop
+      vertex -56.6653 -26.7743 4
+      vertex -56.5345 -26.9672 0
+      vertex -56.5345 -26.9672 4
+    endloop
+  endfacet
+  facet normal -0.995854 0.0909613 0
+    outer loop
+      vertex -56.2113 -28.5344 0
+      vertex -56.1901 -28.3023 4
+      vertex -56.1901 -28.3023 0
+    endloop
+  endfacet
+  facet normal -0.995854 0.0909613 0
+    outer loop
+      vertex -56.1901 -28.3023 4
+      vertex -56.2113 -28.5344 0
+      vertex -56.2113 -28.5344 4
+    endloop
+  endfacet
+  facet normal 0.979375 0.202052 0
+    outer loop
+      vertex -60.8627 -28.7957 4
+      vertex -60.9098 -28.5674 0
+      vertex -60.9098 -28.5674 4
+    endloop
+  endfacet
+  facet normal 0.979375 0.202052 0
+    outer loop
+      vertex -60.9098 -28.5674 0
+      vertex -60.8627 -28.7957 4
+      vertex -60.8627 -28.7957 0
+    endloop
+  endfacet
+  facet normal -0.982116 0.188275 0
+    outer loop
+      vertex -56.2552 -28.7634 0
+      vertex -56.2113 -28.5344 4
+      vertex -56.2113 -28.5344 0
+    endloop
+  endfacet
+  facet normal -0.982116 0.188275 0
+    outer loop
+      vertex -56.2113 -28.5344 4
+      vertex -56.2552 -28.7634 0
+      vertex -56.2552 -28.7634 4
+    endloop
+  endfacet
+  facet normal 0.999973 0.00729281 0
+    outer loop
+      vertex -60.9342 -28.3356 4
+      vertex -60.9359 -28.1025 0
+      vertex -60.9359 -28.1025 4
+    endloop
+  endfacet
+  facet normal 0.999973 0.00729281 0
+    outer loop
+      vertex -60.9359 -28.1025 0
+      vertex -60.9342 -28.3356 4
+      vertex -60.9342 -28.3356 0
+    endloop
+  endfacet
+  facet normal -0.297249 0.9548 0
+    outer loop
+      vertex -57.7472 -30.4329 0
+      vertex -57.9698 -30.5022 4
+      vertex -57.7472 -30.4329 4
+    endloop
+  endfacet
+  facet normal -0.297249 0.9548 0
+    outer loop
+      vertex -57.9698 -30.5022 4
+      vertex -57.7472 -30.4329 0
+      vertex -57.9698 -30.5022 0
+    endloop
+  endfacet
+  facet normal 0.561218 -0.827668 0
+    outer loop
+      vertex -59.9911 -26.3048 0
+      vertex -59.7982 -26.174 4
+      vertex -59.9911 -26.3048 4
+    endloop
+  endfacet
+  facet normal 0.561218 -0.827668 0
+    outer loop
+      vertex -59.7982 -26.174 4
+      vertex -59.9911 -26.3048 0
+      vertex -59.7982 -26.174 0
+    endloop
+  endfacet
+  facet normal 0.18794 0.98218 -0
+    outer loop
+      vertex -58.895 -30.5541 0
+      vertex -59.1239 -30.5103 4
+      vertex -58.895 -30.5541 4
+    endloop
+  endfacet
+  facet normal 0.18794 0.98218 0
+    outer loop
+      vertex -59.1239 -30.5103 4
+      vertex -58.895 -30.5541 0
+      vertex -59.1239 -30.5103 0
+    endloop
+  endfacet
+  facet normal 0.464968 0.885327 -0
+    outer loop
+      vertex -59.5633 -30.3565 0
+      vertex -59.7697 -30.2481 4
+      vertex -59.5633 -30.3565 4
+    endloop
+  endfacet
+  facet normal 0.464968 0.885327 0
+    outer loop
+      vertex -59.7697 -30.2481 4
+      vertex -59.5633 -30.3565 0
+      vertex -59.7697 -30.2481 0
+    endloop
+  endfacet
+  facet normal -0.38915 0.921174 0
+    outer loop
+      vertex -57.5325 -30.3422 0
+      vertex -57.7472 -30.4329 4
+      vertex -57.5325 -30.3422 4
+    endloop
+  endfacet
+  facet normal -0.38915 0.921174 0
+    outer loop
+      vertex -57.7472 -30.4329 4
+      vertex -57.5325 -30.3422 0
+      vertex -57.7472 -30.4329 0
+    endloop
+  endfacet
+  facet normal -0.994461 -0.105109 0
+    outer loop
+      vertex -56.1917 -28.0693 0
+      vertex -56.2162 -27.8375 4
+      vertex -56.2162 -27.8375 0
+    endloop
+  endfacet
+  facet normal -0.994461 -0.105109 0
+    outer loop
+      vertex -56.2162 -27.8375 4
+      vertex -56.1917 -28.0693 0
+      vertex -56.1917 -28.0693 4
+    endloop
+  endfacet
+  facet normal -0.712237 0.701939 0
+    outer loop
+      vertex -56.9557 -29.951 0
+      vertex -56.7921 -29.785 4
+      vertex -56.7921 -29.785 0
+    endloop
+  endfacet
+  facet normal -0.712237 0.701939 0
+    outer loop
+      vertex -56.7921 -29.785 4
+      vertex -56.9557 -29.951 0
+      vertex -56.9557 -29.951 4
     endloop
   endfacet
   facet normal 0.00729594 -0.999973 0
     outer loop
       vertex -58.6961 -25.8312 0
-      vertex -58.4631 -25.8295 7
-      vertex -58.6961 -25.8312 7
+      vertex -58.4631 -25.8295 4
+      vertex -58.6961 -25.8312 4
     endloop
   endfacet
   facet normal 0.00729594 -0.999973 0
     outer loop
-      vertex -58.4631 -25.8295 7
+      vertex -58.4631 -25.8295 4
       vertex -58.6961 -25.8312 0
       vertex -58.4631 -25.8295 0
+    endloop
+  endfacet
+  facet normal -0.878632 -0.477499 0
+    outer loop
+      vertex -56.4232 -27.172 0
+      vertex -56.5345 -26.9672 4
+      vertex -56.5345 -26.9672 0
+    endloop
+  endfacet
+  facet normal -0.878632 -0.477499 0
+    outer loop
+      vertex -56.5345 -26.9672 4
+      vertex -56.4232 -27.172 0
+      vertex -56.4232 -27.172 4
+    endloop
+  endfacet
+  facet normal 0.995854 -0.0909613 0
+    outer loop
+      vertex -60.9359 -28.1025 4
+      vertex -60.9147 -27.8704 0
+      vertex -60.9147 -27.8704 4
+    endloop
+  endfacet
+  facet normal 0.995854 -0.0909613 0
+    outer loop
+      vertex -60.9147 -27.8704 0
+      vertex -60.9359 -28.1025 4
+      vertex -60.9359 -28.1025 0
+    endloop
+  endfacet
+  facet normal 0.926481 -0.376343 0
+    outer loop
+      vertex -60.8047 -27.418 4
+      vertex -60.717 -27.2021 0
+      vertex -60.717 -27.2021 4
+    endloop
+  endfacet
+  facet normal 0.926481 -0.376343 0
+    outer loop
+      vertex -60.717 -27.2021 0
+      vertex -60.8047 -27.418 4
+      vertex -60.8047 -27.418 0
+    endloop
+  endfacet
+  facet normal -0.777425 0.628976 0
+    outer loop
+      vertex -56.7921 -29.785 0
+      vertex -56.6455 -29.6038 4
+      vertex -56.6455 -29.6038 0
+    endloop
+  endfacet
+  facet normal -0.777425 0.628976 0
+    outer loop
+      vertex -56.6455 -29.6038 4
+      vertex -56.7921 -29.785 0
+      vertex -56.7921 -29.785 4
+    endloop
+  endfacet
+  facet normal 0.38915 -0.921174 0
+    outer loop
+      vertex -59.5934 -26.0626 0
+      vertex -59.3787 -25.9719 4
+      vertex -59.5934 -26.0626 4
+    endloop
+  endfacet
+  facet normal 0.38915 -0.921174 0
+    outer loop
+      vertex -59.3787 -25.9719 4
+      vertex -59.5934 -26.0626 0
+      vertex -59.3787 -25.9719 0
+    endloop
+  endfacet
+  facet normal -0.00686385 0.999976 0
+    outer loop
+      vertex -58.4298 -30.5737 0
+      vertex -58.6629 -30.5753 4
+      vertex -58.4298 -30.5737 4
+    endloop
+  endfacet
+  facet normal -0.00686385 0.999976 0
+    outer loop
+      vertex -58.6629 -30.5753 4
+      vertex -58.4298 -30.5737 0
+      vertex -58.6629 -30.5753 0
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 0
+    outer loop
+      vertex -60.9098 -28.5674 4
+      vertex -60.9342 -28.3356 0
+      vertex -60.9342 -28.3356 4
+    endloop
+  endfacet
+  facet normal 0.994505 0.104685 0
+    outer loop
+      vertex -60.9342 -28.3356 0
+      vertex -60.9098 -28.5674 4
+      vertex -60.9098 -28.5674 0
     endloop
   endfacet
   facet normal -0.0913868 -0.995815 0
     outer loop
       vertex -58.4631 -25.8295 0
-      vertex -58.231 -25.8508 7
-      vertex -58.4631 -25.8295 7
+      vertex -58.231 -25.8508 4
+      vertex -58.4631 -25.8295 4
     endloop
   endfacet
   facet normal -0.0913868 -0.995815 -0
     outer loop
-      vertex -58.231 -25.8508 7
+      vertex -58.231 -25.8508 4
       vertex -58.4631 -25.8295 0
       vertex -58.231 -25.8508 0
     endloop
   endfacet
-  facet normal 0.29698 -0.954884 0
+  facet normal 0.701939 0.712237 -0
     outer loop
-      vertex -59.3787 -25.9719 0
-      vertex -59.1562 -25.9027 7
-      vertex -59.3787 -25.9719 7
+      vertex -60.1455 -29.9733 0
+      vertex -60.3115 -29.8097 4
+      vertex -60.1455 -29.9733 4
+    endloop
+  endfacet
+  facet normal 0.701939 0.712237 0
+    outer loop
+      vertex -60.3115 -29.8097 4
+      vertex -60.1455 -29.9733 0
+      vertex -60.3115 -29.8097 0
+    endloop
+  endfacet
+  facet normal -0.92663 0.375974 0
+    outer loop
+      vertex -56.4089 -29.2028 0
+      vertex -56.3213 -28.9869 4
+      vertex -56.3213 -28.9869 0
+    endloop
+  endfacet
+  facet normal -0.92663 0.375974 0
+    outer loop
+      vertex -56.3213 -28.9869 4
+      vertex -56.4089 -29.2028 0
+      vertex -56.4089 -29.2028 4
+    endloop
+  endfacet
+  facet normal 0.954884 0.29698 0
+    outer loop
+      vertex -60.7935 -29.0182 4
+      vertex -60.8627 -28.7957 0
+      vertex -60.8627 -28.7957 4
+    endloop
+  endfacet
+  facet normal 0.954884 0.29698 0
+    outer loop
+      vertex -60.8627 -28.7957 0
+      vertex -60.7935 -29.0182 4
+      vertex -60.7935 -29.0182 0
+    endloop
+  endfacet
+  facet normal 0.629186 0.777255 -0
+    outer loop
+      vertex -59.9644 -30.1199 0
+      vertex -60.1455 -29.9733 4
+      vertex -59.9644 -30.1199 4
+    endloop
+  endfacet
+  facet normal 0.629186 0.777255 0
+    outer loop
+      vertex -60.1455 -29.9733 4
+      vertex -59.9644 -30.1199 0
+      vertex -60.1455 -29.9733 0
+    endloop
+  endfacet
+  facet normal -0.376193 -0.926541 0
+    outer loop
+      vertex -57.7786 -25.9607 0
+      vertex -57.5626 -26.0484 4
+      vertex -57.7786 -25.9607 4
+    endloop
+  endfacet
+  facet normal -0.376193 -0.926541 -0
+    outer loop
+      vertex -57.5626 -26.0484 4
+      vertex -57.7786 -25.9607 0
+      vertex -57.5626 -26.0484 0
+    endloop
+  endfacet
+  facet normal 0.958941 -0.283606 0
+    outer loop
+      vertex -60.8708 -27.6415 4
+      vertex -60.8047 -27.418 0
+      vertex -60.8047 -27.418 4
+    endloop
+  endfacet
+  facet normal 0.958941 -0.283606 0
+    outer loop
+      vertex -60.8047 -27.418 0
+      vertex -60.8708 -27.6415 4
+      vertex -60.8708 -27.6415 0
+    endloop
+  endfacet
+  facet normal 0.549939 0.835205 -0
+    outer loop
+      vertex -59.7697 -30.2481 0
+      vertex -59.9644 -30.1199 4
+      vertex -59.7697 -30.2481 4
+    endloop
+  endfacet
+  facet normal 0.549939 0.835205 0
+    outer loop
+      vertex -59.9644 -30.1199 4
+      vertex -59.7697 -30.2481 0
+      vertex -59.9644 -30.1199 0
+    endloop
+  endfacet
+  facet normal -0.702157 -0.712022 0
+    outer loop
+      vertex -56.9804 -26.4315 0
+      vertex -56.8144 -26.5952 4
+      vertex -56.9804 -26.4315 4
+    endloop
+  endfacet
+  facet normal -0.702157 -0.712022 -0
+    outer loop
+      vertex -56.8144 -26.5952 4
+      vertex -56.9804 -26.4315 0
+      vertex -56.8144 -26.5952 0
     endloop
   endfacet
   facet normal 0.29698 -0.954884 0
     outer loop
-      vertex -59.1562 -25.9027 7
+      vertex -59.3787 -25.9719 0
+      vertex -59.1562 -25.9027 4
+      vertex -59.3787 -25.9719 4
+    endloop
+  endfacet
+  facet normal 0.29698 -0.954884 0
+    outer loop
+      vertex -59.1562 -25.9027 4
       vertex -59.3787 -25.9719 0
       vertex -59.1562 -25.9027 0
     endloop
   endfacet
-  facet normal 0.104685 -0.994505 0
+  facet normal -0.283606 -0.958941 0
     outer loop
-      vertex -58.9279 -25.8556 0
-      vertex -58.6961 -25.8312 7
-      vertex -58.9279 -25.8556 7
+      vertex -58.0021 -25.8946 0
+      vertex -57.7786 -25.9607 4
+      vertex -58.0021 -25.8946 4
     endloop
   endfacet
-  facet normal 0.104685 -0.994505 0
+  facet normal -0.283606 -0.958941 -0
     outer loop
-      vertex -58.6961 -25.8312 7
+      vertex -57.7786 -25.9607 4
+      vertex -58.0021 -25.8946 0
+      vertex -57.7786 -25.9607 0
+    endloop
+  endfacet
+  facet normal 0.376343 0.926481 -0
+    outer loop
+      vertex -59.3474 -30.4442 0
+      vertex -59.5633 -30.3565 4
+      vertex -59.3474 -30.4442 4
+    endloop
+  endfacet
+  facet normal 0.376343 0.926481 0
+    outer loop
+      vertex -59.5633 -30.3565 4
+      vertex -59.3474 -30.4442 0
+      vertex -59.5633 -30.3565 0
+    endloop
+  endfacet
+  facet normal -0.958941 0.283606 0
+    outer loop
+      vertex -56.3213 -28.9869 0
+      vertex -56.2552 -28.7634 4
+      vertex -56.2552 -28.7634 0
+    endloop
+  endfacet
+  facet normal -0.958941 0.283606 0
+    outer loop
+      vertex -56.2552 -28.7634 4
+      vertex -56.3213 -28.9869 0
+      vertex -56.3213 -28.9869 4
+    endloop
+  endfacet
+  facet normal -0.768538 -0.639804 0
+    outer loop
+      vertex -56.6653 -26.7743 0
+      vertex -56.8144 -26.5952 4
+      vertex -56.8144 -26.5952 0
+    endloop
+  endfacet
+  facet normal -0.768538 -0.639804 0
+    outer loop
+      vertex -56.8144 -26.5952 4
+      vertex -56.6653 -26.7743 0
+      vertex -56.6653 -26.7743 4
+    endloop
+  endfacet
+  facet normal 0.885234 -0.465145 0
+    outer loop
+      vertex -60.717 -27.2021 4
+      vertex -60.6086 -26.9958 0
+      vertex -60.6086 -26.9958 4
+    endloop
+  endfacet
+  facet normal 0.885234 -0.465145 0
+    outer loop
+      vertex -60.6086 -26.9958 0
+      vertex -60.717 -27.2021 4
+      vertex -60.717 -27.2021 0
+    endloop
+  endfacet
+  facet normal 0.202052 -0.979375 0
+    outer loop
+      vertex -59.1562 -25.9027 0
+      vertex -58.9279 -25.8556 4
+      vertex -59.1562 -25.9027 4
+    endloop
+  endfacet
+  facet normal 0.202052 -0.979375 0
+    outer loop
+      vertex -58.9279 -25.8556 4
+      vertex -59.1562 -25.9027 0
       vertex -58.9279 -25.8556 0
-      vertex -58.6961 -25.8312 0
+    endloop
+  endfacet
+  facet normal 0.283606 0.958941 -0
+    outer loop
+      vertex -59.1239 -30.5103 0
+      vertex -59.3474 -30.4442 4
+      vertex -59.1239 -30.5103 4
+    endloop
+  endfacet
+  facet normal 0.283606 0.958941 0
+    outer loop
+      vertex -59.3474 -30.4442 4
+      vertex -59.1239 -30.5103 0
+      vertex -59.3474 -30.4442 0
+    endloop
+  endfacet
+  facet normal -0.549939 -0.835205 0
+    outer loop
+      vertex -57.3563 -26.1568 0
+      vertex -57.1616 -26.285 4
+      vertex -57.3563 -26.1568 4
+    endloop
+  endfacet
+  facet normal -0.549939 -0.835205 -0
+    outer loop
+      vertex -57.1616 -26.285 4
+      vertex -57.3563 -26.1568 0
+      vertex -57.1616 -26.285 0
+    endloop
+  endfacet
+  facet normal -0.979375 -0.202052 0
+    outer loop
+      vertex -56.2162 -27.8375 0
+      vertex -56.2633 -27.6092 4
+      vertex -56.2633 -27.6092 0
+    endloop
+  endfacet
+  facet normal -0.979375 -0.202052 0
+    outer loop
+      vertex -56.2633 -27.6092 4
+      vertex -56.2162 -27.8375 0
+      vertex -56.2162 -27.8375 4
+    endloop
+  endfacet
+  facet normal -0.18794 -0.98218 0
+    outer loop
+      vertex -58.231 -25.8508 0
+      vertex -58.0021 -25.8946 4
+      vertex -58.231 -25.8508 4
+    endloop
+  endfacet
+  facet normal -0.18794 -0.98218 -0
+    outer loop
+      vertex -58.0021 -25.8946 4
+      vertex -58.231 -25.8508 0
+      vertex -58.0021 -25.8946 0
+    endloop
+  endfacet
+  facet normal -0.835402 0.54964 0
+    outer loop
+      vertex -56.6455 -29.6038 0
+      vertex -56.5174 -29.4091 4
+      vertex -56.5174 -29.4091 0
+    endloop
+  endfacet
+  facet normal -0.835402 0.54964 0
+    outer loop
+      vertex -56.5174 -29.4091 4
+      vertex -56.6455 -29.6038 0
+      vertex -56.6455 -29.6038 4
+    endloop
+  endfacet
+  facet normal 0.639804 -0.768538 0
+    outer loop
+      vertex -60.1702 -26.4539 0
+      vertex -59.9911 -26.3048 4
+      vertex -60.1702 -26.4539 4
+    endloop
+  endfacet
+  facet normal 0.639804 -0.768538 0
+    outer loop
+      vertex -59.9911 -26.3048 4
+      vertex -60.1702 -26.4539 0
+      vertex -59.9911 -26.3048 0
+    endloop
+  endfacet
+  facet normal -0.921174 -0.38915 0
+    outer loop
+      vertex -56.3325 -27.3867 0
+      vertex -56.4232 -27.172 4
+      vertex -56.4232 -27.172 0
+    endloop
+  endfacet
+  facet normal -0.921174 -0.38915 0
+    outer loop
+      vertex -56.4232 -27.172 4
+      vertex -56.3325 -27.3867 0
+      vertex -56.3325 -27.3867 4
+    endloop
+  endfacet
+  facet normal -0.628717 -0.777634 0
+    outer loop
+      vertex -57.1616 -26.285 0
+      vertex -56.9804 -26.4315 4
+      vertex -57.1616 -26.285 4
+    endloop
+  endfacet
+  facet normal -0.628717 -0.777634 -0
+    outer loop
+      vertex -56.9804 -26.4315 4
+      vertex -57.1616 -26.285 0
+      vertex -56.9804 -26.4315 0
+    endloop
+  endfacet
+  facet normal -0.999976 -0.00686679 0
+    outer loop
+      vertex -56.1901 -28.3023 0
+      vertex -56.1917 -28.0693 4
+      vertex -56.1917 -28.0693 0
+    endloop
+  endfacet
+  facet normal -0.999976 -0.00686679 0
+    outer loop
+      vertex -56.1917 -28.0693 4
+      vertex -56.1901 -28.3023 0
+      vertex -56.1901 -28.3023 4
+    endloop
+  endfacet
+  facet normal 0.900968 0.433886 0
+    outer loop
+      vertex -58.729 -39.3815 7
+      vertex -67.4067 -21.3622 4
+      vertex -67.4067 -21.3622 7
+    endloop
+  endfacet
+  facet normal 0.900968 0.433886 0
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -58.729 -39.3815 7
+      vertex -58.729 -39.3815 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -56.1917 -28.0693 4
+      vertex -56.1901 -28.3023 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -56.2162 -27.8375 4
+      vertex -56.1917 -28.0693 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -56.2633 -27.6092 4
+      vertex -56.2162 -27.8375 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -56.3325 -27.3867 4
+      vertex -56.2633 -27.6092 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -56.4232 -27.172 4
+      vertex -56.3325 -27.3867 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -56.4232 -27.172 4
+      vertex -49.7193 -35.0427 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.4232 -27.172 4
+      vertex -58.397 -17.0233 4
+      vertex -56.5345 -26.9672 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.5345 -26.9672 4
+      vertex -58.397 -17.0233 4
+      vertex -56.6653 -26.7743 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -56.6653 -26.7743 4
+      vertex -58.397 -17.0233 4
+      vertex -56.8144 -26.5952 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -56.9804 -26.4315 4
+      vertex -56.8144 -26.5952 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -57.1616 -26.285 4
+      vertex -56.9804 -26.4315 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -57.3563 -26.1568 4
+      vertex -57.1616 -26.285 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -57.5626 -26.0484 4
+      vertex -57.3563 -26.1568 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -57.7786 -25.9607 4
+      vertex -57.5626 -26.0484 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -58.0021 -25.8946 4
+      vertex -57.7786 -25.9607 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -58.231 -25.8508 4
+      vertex -58.0021 -25.8946 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -58.4631 -25.8295 4
+      vertex -58.231 -25.8508 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -58.6961 -25.8312 4
+      vertex -58.4631 -25.8295 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -58.9279 -25.8556 4
+      vertex -58.6961 -25.8312 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -59.1562 -25.9027 4
+      vertex -58.9279 -25.8556 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -59.3787 -25.9719 4
+      vertex -59.1562 -25.9027 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.397 -17.0233 4
+      vertex -59.5934 -26.0626 4
+      vertex -59.3787 -25.9719 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -59.5934 -26.0626 4
+      vertex -58.397 -17.0233 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5934 -26.0626 4
+      vertex -67.4067 -21.3622 4
+      vertex -59.7982 -26.174 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.7982 -26.174 4
+      vertex -67.4067 -21.3622 4
+      vertex -59.9911 -26.3048 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.9911 -26.3048 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.1702 -26.4539 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.1702 -26.4539 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.3339 -26.6199 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.3339 -26.6199 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.4805 -26.8011 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.4805 -26.8011 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.6086 -26.9958 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.6086 -26.9958 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.717 -27.2021 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.717 -27.2021 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.8047 -27.418 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.9147 -27.8704 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.9359 -28.1025 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.8708 -27.6415 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.9147 -27.8704 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.8047 -27.418 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.8708 -27.6415 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.2113 -28.5344 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.1901 -28.3023 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.2552 -28.7634 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.2113 -28.5344 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.3213 -28.9869 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.2552 -28.7634 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.4089 -29.2028 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.3213 -28.9869 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.5174 -29.4091 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.4089 -29.2028 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.6455 -29.6038 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.5174 -29.4091 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.7921 -29.785 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.6455 -29.6038 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -56.9557 -29.951 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.7921 -29.785 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.1348 -30.1001 4
+      vertex -49.7193 -35.0427 4
+      vertex -56.9557 -29.951 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.3277 -30.2309 4
+      vertex -49.7193 -35.0427 4
+      vertex -57.1348 -30.1001 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -57.5325 -30.3422 4
+      vertex -49.7193 -35.0427 4
+      vertex -57.3277 -30.2309 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 -39.3815 4
+      vertex -57.5325 -30.3422 4
+      vertex -57.7472 -30.4329 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 -39.3815 4
+      vertex -57.7472 -30.4329 4
+      vertex -57.9698 -30.5022 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 -39.3815 4
+      vertex -57.9698 -30.5022 4
+      vertex -58.198 -30.5492 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 -39.3815 4
+      vertex -58.198 -30.5492 4
+      vertex -58.4298 -30.5737 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.729 -39.3815 4
+      vertex -58.4298 -30.5737 4
+      vertex -58.6629 -30.5753 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -57.5325 -30.3422 4
+      vertex -58.729 -39.3815 4
+      vertex -49.7193 -35.0427 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -58.895 -30.5541 4
+      vertex -58.729 -39.3815 4
+      vertex -58.6629 -30.5753 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.1239 -30.5103 4
+      vertex -58.729 -39.3815 4
+      vertex -58.895 -30.5541 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.3474 -30.4442 4
+      vertex -58.729 -39.3815 4
+      vertex -59.1239 -30.5103 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.5633 -30.3565 4
+      vertex -58.729 -39.3815 4
+      vertex -59.3474 -30.4442 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.7697 -30.2481 4
+      vertex -58.729 -39.3815 4
+      vertex -59.5633 -30.3565 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -59.9644 -30.1199 4
+      vertex -58.729 -39.3815 4
+      vertex -59.7697 -30.2481 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.1455 -29.9733 4
+      vertex -58.729 -39.3815 4
+      vertex -59.9644 -30.1199 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.3115 -29.8097 4
+      vertex -58.729 -39.3815 4
+      vertex -60.1455 -29.9733 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.4606 -29.6306 4
+      vertex -58.729 -39.3815 4
+      vertex -60.3115 -29.8097 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.5915 -29.4377 4
+      vertex -58.729 -39.3815 4
+      vertex -60.4606 -29.6306 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.7028 -29.2329 4
+      vertex -58.729 -39.3815 4
+      vertex -60.5915 -29.4377 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -60.7028 -29.2329 4
+      vertex -60.7935 -29.0182 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -60.7935 -29.0182 4
+      vertex -60.8627 -28.7957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -60.8627 -28.7957 4
+      vertex -60.9098 -28.5674 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.7028 -29.2329 4
+      vertex -67.4067 -21.3622 4
+      vertex -58.729 -39.3815 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -60.9342 -28.3356 4
+      vertex -67.4067 -21.3622 4
+      vertex -60.9098 -28.5674 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -60.9342 -28.3356 4
+      vertex -60.9359 -28.1025 4
+    endloop
+  endfacet
+  facet normal -0.900969 -0.433884 0
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -58.397 -17.0233 7
+      vertex -58.397 -17.0233 4
+    endloop
+  endfacet
+  facet normal -0.900969 -0.433884 0
+    outer loop
+      vertex -58.397 -17.0233 7
+      vertex -49.7193 -35.0427 4
+      vertex -49.7193 -35.0427 7
+    endloop
+  endfacet
+  facet normal -0.43388 0.900971 0
+    outer loop
+      vertex -49.7193 -35.0427 4
+      vertex -58.729 -39.3815 7
+      vertex -49.7193 -35.0427 7
+    endloop
+  endfacet
+  facet normal -0.43388 0.900971 0
+    outer loop
+      vertex -58.729 -39.3815 7
+      vertex -49.7193 -35.0427 4
+      vertex -58.729 -39.3815 4
+    endloop
+  endfacet
+  facet normal 0.433888 -0.900967 0
+    outer loop
+      vertex -67.4067 -21.3622 4
+      vertex -58.397 -17.0233 7
+      vertex -67.4067 -21.3622 7
+    endloop
+  endfacet
+  facet normal 0.433888 -0.900967 0
+    outer loop
+      vertex -58.397 -17.0233 7
+      vertex -67.4067 -21.3622 4
+      vertex -58.397 -17.0233 4
     endloop
   endfacet
   facet normal -0.222522 -0.974928 0
@@ -10611,900 +9799,1432 @@ solid OpenSCAD_Model
       vertex -37.1096 -46.534 0
     endloop
   endfacet
-  facet normal -0.310299 0.950639 0
-    outer loop
-      vertex -13.6169 -65.5892 0
-      vertex -13.8384 -65.6615 7
-      vertex -13.6169 -65.5892 7
-    endloop
-  endfacet
-  facet normal -0.310299 0.950639 0
-    outer loop
-      vertex -13.8384 -65.6615 7
-      vertex -13.6169 -65.5892 0
-      vertex -13.8384 -65.6615 0
-    endloop
-  endfacet
-  facet normal -0.842972 0.537958 0
-    outer loop
-      vertex -12.5269 -64.7447 0
-      vertex -12.4015 -64.5482 7
-      vertex -12.4015 -64.5482 0
-    endloop
-  endfacet
-  facet normal -0.842972 0.537958 0
-    outer loop
-      vertex -12.4015 -64.5482 7
-      vertex -12.5269 -64.7447 0
-      vertex -12.5269 -64.7447 7
-    endloop
-  endfacet
-  facet normal -0.976439 -0.215795 0
-    outer loop
-      vertex -12.1224 -62.9725 0
-      vertex -12.1727 -62.7449 7
-      vertex -12.1727 -62.7449 0
-    endloop
-  endfacet
-  facet normal -0.976439 -0.215795 0
-    outer loop
-      vertex -12.1727 -62.7449 7
-      vertex -12.1224 -62.9725 0
-      vertex -12.1224 -62.9725 7
-    endloop
-  endfacet
-  facet normal -0.537958 -0.842972 0
-    outer loop
-      vertex -13.286 -61.308 0
-      vertex -13.0895 -61.4334 7
-      vertex -13.286 -61.308 7
-    endloop
-  endfacet
-  facet normal -0.537958 -0.842972 -0
-    outer loop
-      vertex -13.0895 -61.4334 7
-      vertex -13.286 -61.308 0
-      vertex -13.0895 -61.4334 0
-    endloop
-  endfacet
-  facet normal 0.270187 0.962808 -0
-    outer loop
-      vertex -14.9923 -65.6858 0
-      vertex -15.2168 -65.6228 7
-      vertex -14.9923 -65.6858 7
-    endloop
-  endfacet
-  facet normal 0.270187 0.962808 0
-    outer loop
-      vertex -15.2168 -65.6228 7
-      vertex -14.9923 -65.6858 0
-      vertex -15.2168 -65.6228 0
-    endloop
-  endfacet
   facet normal -0.721756 0.692148 0
     outer loop
       vertex -12.8322 -65.0961 0
-      vertex -12.6709 -64.9279 7
+      vertex -12.6709 -64.9279 4
       vertex -12.6709 -64.9279 0
     endloop
   endfacet
   facet normal -0.721756 0.692148 0
     outer loop
-      vertex -12.6709 -64.9279 7
+      vertex -12.6709 -64.9279 4
       vertex -12.8322 -65.0961 0
-      vertex -12.8322 -65.0961 7
-    endloop
-  endfacet
-  facet normal -0.759499 -0.650509 0
-    outer loop
-      vertex -12.5864 -61.9157 0
-      vertex -12.738 -61.7387 7
-      vertex -12.738 -61.7387 0
-    endloop
-  endfacet
-  facet normal -0.759499 -0.650509 0
-    outer loop
-      vertex -12.738 -61.7387 7
-      vertex -12.5864 -61.9157 0
-      vertex -12.5864 -61.9157 7
-    endloop
-  endfacet
-  facet normal -0.999779 -0.0210254 0
-    outer loop
-      vertex -12.0898 -63.4369 0
-      vertex -12.0947 -63.2039 7
-      vertex -12.0947 -63.2039 0
-    endloop
-  endfacet
-  facet normal -0.999779 -0.0210254 0
-    outer loop
-      vertex -12.0947 -63.2039 7
-      vertex -12.0898 -63.4369 0
-      vertex -12.0898 -63.4369 7
+      vertex -12.8322 -65.0961 4
     endloop
   endfacet
   facet normal 0.0772544 0.997011 -0
     outer loop
       vertex -14.5305 -65.7444 0
-      vertex -14.7628 -65.7264 7
-      vertex -14.5305 -65.7444 7
+      vertex -14.7628 -65.7264 4
+      vertex -14.5305 -65.7444 4
     endloop
   endfacet
   facet normal 0.0772544 0.997011 0
     outer loop
-      vertex -14.7628 -65.7264 7
+      vertex -14.7628 -65.7264 4
       vertex -14.5305 -65.7444 0
       vertex -14.7628 -65.7264 0
-    endloop
-  endfacet
-  facet normal -0.402034 0.915625 0
-    outer loop
-      vertex -13.4035 -65.4955 0
-      vertex -13.6169 -65.5892 7
-      vertex -13.4035 -65.4955 7
-    endloop
-  endfacet
-  facet normal -0.402034 0.915625 0
-    outer loop
-      vertex -13.6169 -65.5892 7
-      vertex -13.4035 -65.4955 0
-      vertex -13.6169 -65.5892 0
-    endloop
-  endfacet
-  facet normal -0.573174 0.819433 0
-    outer loop
-      vertex -13.0093 -65.2477 0
-      vertex -13.2003 -65.3813 7
-      vertex -13.0093 -65.2477 7
-    endloop
-  endfacet
-  facet normal -0.573174 0.819433 0
-    outer loop
-      vertex -13.2003 -65.3813 7
-      vertex -13.0093 -65.2477 0
-      vertex -13.2003 -65.3813 0
-    endloop
-  endfacet
-  facet normal -0.98471 0.174201 0
-    outer loop
-      vertex -12.1484 -63.8988 0
-      vertex -12.1078 -63.6693 7
-      vertex -12.1078 -63.6693 0
-    endloop
-  endfacet
-  facet normal -0.98471 0.174201 0
-    outer loop
-      vertex -12.1078 -63.6693 7
-      vertex -12.1484 -63.8988 0
-      vertex -12.1484 -63.8988 7
-    endloop
-  endfacet
-  facet normal -0.891664 0.452698 0
-    outer loop
-      vertex -12.4015 -64.5482 0
-      vertex -12.296 -64.3404 7
-      vertex -12.296 -64.3404 0
-    endloop
-  endfacet
-  facet normal -0.891664 0.452698 0
-    outer loop
-      vertex -12.296 -64.3404 7
-      vertex -12.4015 -64.5482 0
-      vertex -12.4015 -64.5482 7
-    endloop
-  endfacet
-  facet normal -0.931811 0.362943 0
-    outer loop
-      vertex -12.296 -64.3404 0
-      vertex -12.2114 -64.1232 7
-      vertex -12.2114 -64.1232 0
-    endloop
-  endfacet
-  facet normal -0.931811 0.362943 0
-    outer loop
-      vertex -12.2114 -64.1232 7
-      vertex -12.296 -64.3404 0
-      vertex -12.296 -64.3404 7
-    endloop
-  endfacet
-  facet normal -0.786199 0.617973 0
-    outer loop
-      vertex -12.6709 -64.9279 0
-      vertex -12.5269 -64.7447 7
-      vertex -12.5269 -64.7447 0
-    endloop
-  endfacet
-  facet normal -0.786199 0.617973 0
-    outer loop
-      vertex -12.5269 -64.7447 7
-      vertex -12.6709 -64.9279 0
-      vertex -12.6709 -64.9279 7
-    endloop
-  endfacet
-  facet normal -0.650297 0.75968 0
-    outer loop
-      vertex -12.8322 -65.0961 0
-      vertex -13.0093 -65.2477 7
-      vertex -12.8322 -65.0961 7
-    endloop
-  endfacet
-  facet normal -0.650297 0.75968 0
-    outer loop
-      vertex -13.0093 -65.2477 7
-      vertex -12.8322 -65.0961 0
-      vertex -13.0093 -65.2477 0
-    endloop
-  endfacet
-  facet normal -0.174617 -0.984636 0
-    outer loop
-      vertex -14.1649 -61.0142 0
-      vertex -13.9354 -61.0549 7
-      vertex -14.1649 -61.0142 7
-    endloop
-  endfacet
-  facet normal -0.174617 -0.984636 -0
-    outer loop
-      vertex -13.9354 -61.0549 7
-      vertex -14.1649 -61.0142 0
-      vertex -13.9354 -61.0549 0
-    endloop
-  endfacet
-  facet normal -0.452698 -0.891664 0
-    outer loop
-      vertex -13.4938 -61.2025 0
-      vertex -13.286 -61.308 7
-      vertex -13.4938 -61.2025 7
-    endloop
-  endfacet
-  facet normal -0.452698 -0.891664 -0
-    outer loop
-      vertex -13.286 -61.308 7
-      vertex -13.4938 -61.2025 0
-      vertex -13.286 -61.308 0
-    endloop
-  endfacet
-  facet normal -0.363315 -0.931666 0
-    outer loop
-      vertex -13.711 -61.1178 0
-      vertex -13.4938 -61.2025 7
-      vertex -13.711 -61.1178 7
-    endloop
-  endfacet
-  facet normal -0.363315 -0.931666 -0
-    outer loop
-      vertex -13.4938 -61.2025 7
-      vertex -13.711 -61.1178 0
-      vertex -13.4938 -61.2025 0
-    endloop
-  endfacet
-  facet normal -0.617973 -0.786199 0
-    outer loop
-      vertex -13.0895 -61.4334 0
-      vertex -12.9063 -61.5774 7
-      vertex -13.0895 -61.4334 7
-    endloop
-  endfacet
-  facet normal -0.617973 -0.786199 -0
-    outer loop
-      vertex -12.9063 -61.5774 7
-      vertex -13.0895 -61.4334 0
-      vertex -12.9063 -61.5774 0
-    endloop
-  endfacet
-  facet normal -0.691933 -0.721961 0
-    outer loop
-      vertex -12.9063 -61.5774 0
-      vertex -12.738 -61.7387 7
-      vertex -12.9063 -61.5774 7
-    endloop
-  endfacet
-  facet normal -0.691933 -0.721961 -0
-    outer loop
-      vertex -12.738 -61.7387 7
-      vertex -12.9063 -61.5774 0
-      vertex -12.738 -61.7387 0
-    endloop
-  endfacet
-  facet normal -0.992911 -0.118858 0
-    outer loop
-      vertex -12.0947 -63.2039 0
-      vertex -12.1224 -62.9725 7
-      vertex -12.1224 -62.9725 0
-    endloop
-  endfacet
-  facet normal -0.992911 -0.118858 0
-    outer loop
-      vertex -12.1224 -62.9725 7
-      vertex -12.0947 -63.2039 0
-      vertex -12.0947 -63.2039 7
-    endloop
-  endfacet
-  facet normal -0.997014 0.0772214 0
-    outer loop
-      vertex -12.1078 -63.6693 0
-      vertex -12.0898 -63.4369 7
-      vertex -12.0898 -63.4369 0
-    endloop
-  endfacet
-  facet normal -0.997014 0.0772214 0
-    outer loop
-      vertex -12.0898 -63.4369 7
-      vertex -12.1078 -63.6693 0
-      vertex -12.1078 -63.6693 7
-    endloop
-  endfacet
-  facet normal -0.915625 -0.402034 0
-    outer loop
-      vertex -12.245 -62.5233 0
-      vertex -12.3387 -62.3099 7
-      vertex -12.3387 -62.3099 0
-    endloop
-  endfacet
-  facet normal -0.915625 -0.402034 0
-    outer loop
-      vertex -12.3387 -62.3099 7
-      vertex -12.245 -62.5233 0
-      vertex -12.245 -62.5233 7
-    endloop
-  endfacet
-  facet normal -0.871759 -0.489935 0
-    outer loop
-      vertex -12.3387 -62.3099 0
-      vertex -12.4529 -62.1067 7
-      vertex -12.4529 -62.1067 0
-    endloop
-  endfacet
-  facet normal -0.871759 -0.489935 0
-    outer loop
-      vertex -12.4529 -62.1067 7
-      vertex -12.3387 -62.3099 0
-      vertex -12.3387 -62.3099 7
-    endloop
-  endfacet
-  facet normal -0.95068 -0.310172 0
-    outer loop
-      vertex -12.1727 -62.7449 0
-      vertex -12.245 -62.5233 7
-      vertex -12.245 -62.5233 0
-    endloop
-  endfacet
-  facet normal -0.95068 -0.310172 0
-    outer loop
-      vertex -12.245 -62.5233 7
-      vertex -12.1727 -62.7449 0
-      vertex -12.1727 -62.7449 7
-    endloop
-  endfacet
-  facet normal -0.819635 -0.572886 0
-    outer loop
-      vertex -12.4529 -62.1067 0
-      vertex -12.5864 -61.9157 7
-      vertex -12.5864 -61.9157 0
-    endloop
-  endfacet
-  facet normal -0.819635 -0.572886 0
-    outer loop
-      vertex -12.5864 -61.9157 7
-      vertex -12.4529 -62.1067 0
-      vertex -12.4529 -62.1067 7
     endloop
   endfacet
   facet normal 0.174201 0.98471 -0
     outer loop
       vertex -14.7628 -65.7264 0
-      vertex -14.9923 -65.6858 7
-      vertex -14.7628 -65.7264 7
+      vertex -14.9923 -65.6858 4
+      vertex -14.7628 -65.7264 4
     endloop
   endfacet
   facet normal 0.174201 0.98471 0
     outer loop
-      vertex -14.9923 -65.6858 7
+      vertex -14.9923 -65.6858 4
       vertex -14.7628 -65.7264 0
       vertex -14.9923 -65.6858 0
     endloop
   endfacet
-  facet normal 0.452698 0.891664 -0
+  facet normal -0.0210254 0.999779 0
     outer loop
-      vertex -15.4339 -65.5382 0
-      vertex -15.6417 -65.4327 7
-      vertex -15.4339 -65.5382 7
+      vertex -14.2975 -65.7395 0
+      vertex -14.5305 -65.7444 4
+      vertex -14.2975 -65.7395 4
     endloop
   endfacet
-  facet normal 0.452698 0.891664 0
+  facet normal -0.0210254 0.999779 0
     outer loop
-      vertex -15.6417 -65.4327 7
-      vertex -15.4339 -65.5382 0
-      vertex -15.6417 -65.4327 0
+      vertex -14.5305 -65.7444 4
+      vertex -14.2975 -65.7395 0
+      vertex -14.5305 -65.7444 0
+    endloop
+  endfacet
+  facet normal 0.992911 0.118858 0
+    outer loop
+      vertex -16.8053 -63.7681 4
+      vertex -16.833 -63.5367 0
+      vertex -16.833 -63.5367 4
+    endloop
+  endfacet
+  facet normal 0.992911 0.118858 0
+    outer loop
+      vertex -16.833 -63.5367 0
+      vertex -16.8053 -63.7681 4
+      vertex -16.8053 -63.7681 0
+    endloop
+  endfacet
+  facet normal 0.842848 -0.538152 0
+    outer loop
+      vertex -16.5262 -62.1924 4
+      vertex -16.4008 -61.996 0
+      vertex -16.4008 -61.996 4
+    endloop
+  endfacet
+  facet normal 0.842848 -0.538152 0
+    outer loop
+      vertex -16.4008 -61.996 0
+      vertex -16.5262 -62.1924 4
+      vertex -16.5262 -62.1924 0
+    endloop
+  endfacet
+  facet normal -0.363315 -0.931666 0
+    outer loop
+      vertex -13.711 -61.1178 0
+      vertex -13.4938 -61.2025 4
+      vertex -13.711 -61.1178 4
+    endloop
+  endfacet
+  facet normal -0.363315 -0.931666 -0
+    outer loop
+      vertex -13.4938 -61.2025 4
+      vertex -13.711 -61.1178 0
+      vertex -13.4938 -61.2025 0
+    endloop
+  endfacet
+  facet normal -0.98471 0.174201 0
+    outer loop
+      vertex -12.1484 -63.8988 0
+      vertex -12.1078 -63.6693 4
+      vertex -12.1078 -63.6693 0
+    endloop
+  endfacet
+  facet normal -0.98471 0.174201 0
+    outer loop
+      vertex -12.1078 -63.6693 4
+      vertex -12.1484 -63.8988 0
+      vertex -12.1484 -63.8988 4
+    endloop
+  endfacet
+  facet normal 0.270187 0.962808 -0
+    outer loop
+      vertex -14.9923 -65.6858 0
+      vertex -15.2168 -65.6228 4
+      vertex -14.9923 -65.6858 4
+    endloop
+  endfacet
+  facet normal 0.270187 0.962808 0
+    outer loop
+      vertex -15.2168 -65.6228 4
+      vertex -14.9923 -65.6858 0
+      vertex -15.2168 -65.6228 0
+    endloop
+  endfacet
+  facet normal -0.842972 0.537958 0
+    outer loop
+      vertex -12.5269 -64.7447 0
+      vertex -12.4015 -64.5482 4
+      vertex -12.4015 -64.5482 0
+    endloop
+  endfacet
+  facet normal -0.842972 0.537958 0
+    outer loop
+      vertex -12.4015 -64.5482 4
+      vertex -12.5269 -64.7447 0
+      vertex -12.5269 -64.7447 4
+    endloop
+  endfacet
+  facet normal 0.984636 -0.174617 0
+    outer loop
+      vertex -16.82 -63.0713 4
+      vertex -16.7793 -62.8418 0
+      vertex -16.7793 -62.8418 4
+    endloop
+  endfacet
+  facet normal 0.984636 -0.174617 0
+    outer loop
+      vertex -16.7793 -62.8418 0
+      vertex -16.82 -63.0713 4
+      vertex -16.82 -63.0713 0
+    endloop
+  endfacet
+  facet normal 0.95068 0.310172 0
+    outer loop
+      vertex -16.6827 -64.2173 4
+      vertex -16.755 -63.9957 0
+      vertex -16.755 -63.9957 4
+    endloop
+  endfacet
+  facet normal 0.95068 0.310172 0
+    outer loop
+      vertex -16.755 -63.9957 0
+      vertex -16.6827 -64.2173 4
+      vertex -16.6827 -64.2173 0
+    endloop
+  endfacet
+  facet normal 0.402034 -0.915625 0
+    outer loop
+      vertex -15.5242 -61.2452 0
+      vertex -15.3108 -61.1515 4
+      vertex -15.5242 -61.2452 4
+    endloop
+  endfacet
+  facet normal 0.402034 -0.915625 0
+    outer loop
+      vertex -15.3108 -61.1515 4
+      vertex -15.5242 -61.2452 0
+      vertex -15.3108 -61.1515 0
+    endloop
+  endfacet
+  facet normal -0.915625 -0.402034 0
+    outer loop
+      vertex -12.245 -62.5233 0
+      vertex -12.3387 -62.3099 4
+      vertex -12.3387 -62.3099 0
+    endloop
+  endfacet
+  facet normal -0.915625 -0.402034 0
+    outer loop
+      vertex -12.3387 -62.3099 4
+      vertex -12.245 -62.5233 0
+      vertex -12.245 -62.5233 4
+    endloop
+  endfacet
+  facet normal -0.997014 0.0772214 0
+    outer loop
+      vertex -12.1078 -63.6693 0
+      vertex -12.0898 -63.4369 4
+      vertex -12.0898 -63.4369 0
+    endloop
+  endfacet
+  facet normal -0.997014 0.0772214 0
+    outer loop
+      vertex -12.0898 -63.4369 4
+      vertex -12.1078 -63.6693 0
+      vertex -12.1078 -63.6693 4
+    endloop
+  endfacet
+  facet normal -0.999779 -0.0210254 0
+    outer loop
+      vertex -12.0898 -63.4369 0
+      vertex -12.0947 -63.2039 4
+      vertex -12.0947 -63.2039 0
+    endloop
+  endfacet
+  facet normal -0.999779 -0.0210254 0
+    outer loop
+      vertex -12.0947 -63.2039 4
+      vertex -12.0898 -63.4369 0
+      vertex -12.0898 -63.4369 4
+    endloop
+  endfacet
+  facet normal 0.976439 0.215795 0
+    outer loop
+      vertex -16.755 -63.9957 4
+      vertex -16.8053 -63.7681 0
+      vertex -16.8053 -63.7681 4
+    endloop
+  endfacet
+  facet normal 0.976439 0.215795 0
+    outer loop
+      vertex -16.8053 -63.7681 0
+      vertex -16.755 -63.9957 4
+      vertex -16.755 -63.9957 0
+    endloop
+  endfacet
+  facet normal -0.891664 0.452698 0
+    outer loop
+      vertex -12.4015 -64.5482 0
+      vertex -12.296 -64.3404 4
+      vertex -12.296 -64.3404 0
+    endloop
+  endfacet
+  facet normal -0.891664 0.452698 0
+    outer loop
+      vertex -12.296 -64.3404 4
+      vertex -12.4015 -64.5482 0
+      vertex -12.4015 -64.5482 4
+    endloop
+  endfacet
+  facet normal 0.759499 0.650509 0
+    outer loop
+      vertex -16.1897 -65.0019 4
+      vertex -16.3413 -64.8249 0
+      vertex -16.3413 -64.8249 4
+    endloop
+  endfacet
+  facet normal 0.759499 0.650509 0
+    outer loop
+      vertex -16.3413 -64.8249 0
+      vertex -16.1897 -65.0019 4
+      vertex -16.1897 -65.0019 0
     endloop
   endfacet
   facet normal -0.0772214 -0.997014 0
     outer loop
       vertex -14.3973 -60.9962 0
-      vertex -14.1649 -61.0142 7
-      vertex -14.3973 -60.9962 7
+      vertex -14.1649 -61.0142 4
+      vertex -14.3973 -60.9962 4
     endloop
   endfacet
   facet normal -0.0772214 -0.997014 -0
     outer loop
-      vertex -14.1649 -61.0142 7
+      vertex -14.1649 -61.0142 4
       vertex -14.3973 -60.9962 0
       vertex -14.1649 -61.0142 0
     endloop
   endfacet
-  facet normal 0.997047 -0.0767949 0
+  facet normal -0.691933 -0.721961 0
     outer loop
-      vertex -16.8379 -63.3037 7
-      vertex -16.82 -63.0713 0
-      vertex -16.82 -63.0713 7
+      vertex -12.9063 -61.5774 0
+      vertex -12.738 -61.7387 4
+      vertex -12.9063 -61.5774 4
     endloop
   endfacet
-  facet normal 0.997047 -0.0767949 0
+  facet normal -0.691933 -0.721961 -0
     outer loop
-      vertex -16.82 -63.0713 0
-      vertex -16.8379 -63.3037 7
-      vertex -16.8379 -63.3037 0
+      vertex -12.738 -61.7387 4
+      vertex -12.9063 -61.5774 0
+      vertex -12.738 -61.7387 0
     endloop
   endfacet
-  facet normal 0.976439 0.215795 0
+  facet normal 0.452698 0.891664 -0
     outer loop
-      vertex -16.755 -63.9957 7
-      vertex -16.8053 -63.7681 0
-      vertex -16.8053 -63.7681 7
+      vertex -15.4339 -65.5382 0
+      vertex -15.6417 -65.4327 4
+      vertex -15.4339 -65.5382 4
     endloop
   endfacet
-  facet normal 0.976439 0.215795 0
+  facet normal 0.452698 0.891664 0
     outer loop
-      vertex -16.8053 -63.7681 0
-      vertex -16.755 -63.9957 7
-      vertex -16.755 -63.9957 0
+      vertex -15.6417 -65.4327 4
+      vertex -15.4339 -65.5382 0
+      vertex -15.6417 -65.4327 0
     endloop
   endfacet
-  facet normal -0.215795 0.976439 0
+  facet normal -0.759499 -0.650509 0
     outer loop
-      vertex -13.8384 -65.6615 0
-      vertex -14.066 -65.7118 7
-      vertex -13.8384 -65.6615 7
+      vertex -12.5864 -61.9157 0
+      vertex -12.738 -61.7387 4
+      vertex -12.738 -61.7387 0
     endloop
   endfacet
-  facet normal -0.215795 0.976439 0
+  facet normal -0.759499 -0.650509 0
     outer loop
-      vertex -14.066 -65.7118 7
-      vertex -13.8384 -65.6615 0
-      vertex -14.066 -65.7118 0
-    endloop
-  endfacet
-  facet normal -0.118807 0.992917 0
-    outer loop
-      vertex -14.066 -65.7118 0
-      vertex -14.2975 -65.7395 7
-      vertex -14.066 -65.7118 7
-    endloop
-  endfacet
-  facet normal -0.118807 0.992917 0
-    outer loop
-      vertex -14.2975 -65.7395 7
-      vertex -14.066 -65.7118 0
-      vertex -14.2975 -65.7395 0
-    endloop
-  endfacet
-  facet normal -0.489935 0.871759 0
-    outer loop
-      vertex -13.2003 -65.3813 0
-      vertex -13.4035 -65.4955 7
-      vertex -13.2003 -65.3813 7
-    endloop
-  endfacet
-  facet normal -0.489935 0.871759 0
-    outer loop
-      vertex -13.4035 -65.4955 7
-      vertex -13.2003 -65.3813 0
-      vertex -13.4035 -65.4955 0
-    endloop
-  endfacet
-  facet normal -0.962777 0.270298 0
-    outer loop
-      vertex -12.2114 -64.1232 0
-      vertex -12.1484 -63.8988 7
-      vertex -12.1484 -63.8988 0
-    endloop
-  endfacet
-  facet normal -0.962777 0.270298 0
-    outer loop
-      vertex -12.1484 -63.8988 7
-      vertex -12.2114 -64.1232 0
-      vertex -12.2114 -64.1232 7
-    endloop
-  endfacet
-  facet normal -0.2699 -0.962888 0
-    outer loop
-      vertex -13.9354 -61.0549 0
-      vertex -13.711 -61.1178 7
-      vertex -13.9354 -61.0549 7
-    endloop
-  endfacet
-  facet normal -0.2699 -0.962888 -0
-    outer loop
-      vertex -13.711 -61.1178 7
-      vertex -13.9354 -61.0549 0
-      vertex -13.711 -61.1178 0
-    endloop
-  endfacet
-  facet normal 0.819635 0.572886 0
-    outer loop
-      vertex -16.3413 -64.8249 7
-      vertex -16.4748 -64.6339 0
-      vertex -16.4748 -64.6339 7
-    endloop
-  endfacet
-  facet normal 0.819635 0.572886 0
-    outer loop
-      vertex -16.4748 -64.6339 0
-      vertex -16.3413 -64.8249 7
-      vertex -16.3413 -64.8249 0
-    endloop
-  endfacet
-  facet normal 0.691933 0.721961 -0
-    outer loop
-      vertex -16.0214 -65.1632 0
-      vertex -16.1897 -65.0019 7
-      vertex -16.0214 -65.1632 7
-    endloop
-  endfacet
-  facet normal 0.691933 0.721961 0
-    outer loop
-      vertex -16.1897 -65.0019 7
-      vertex -16.0214 -65.1632 0
-      vertex -16.1897 -65.0019 0
+      vertex -12.738 -61.7387 4
+      vertex -12.5864 -61.9157 0
+      vertex -12.5864 -61.9157 4
     endloop
   endfacet
   facet normal 0.618238 0.785991 -0
     outer loop
       vertex -15.8382 -65.3073 0
-      vertex -16.0214 -65.1632 7
-      vertex -15.8382 -65.3073 7
+      vertex -16.0214 -65.1632 4
+      vertex -15.8382 -65.3073 4
     endloop
   endfacet
   facet normal 0.618238 0.785991 0
     outer loop
-      vertex -16.0214 -65.1632 7
+      vertex -16.0214 -65.1632 4
       vertex -15.8382 -65.3073 0
       vertex -16.0214 -65.1632 0
     endloop
   endfacet
-  facet normal 0.962888 -0.2699 0
+  facet normal -0.931811 0.362943 0
     outer loop
-      vertex -16.7793 -62.8418 7
-      vertex -16.7164 -62.6174 0
-      vertex -16.7164 -62.6174 7
+      vertex -12.296 -64.3404 0
+      vertex -12.2114 -64.1232 4
+      vertex -12.2114 -64.1232 0
     endloop
   endfacet
-  facet normal 0.962888 -0.2699 0
+  facet normal -0.931811 0.362943 0
     outer loop
-      vertex -16.7164 -62.6174 0
-      vertex -16.7793 -62.8418 7
-      vertex -16.7793 -62.8418 0
+      vertex -12.2114 -64.1232 4
+      vertex -12.296 -64.3404 0
+      vertex -12.296 -64.3404 4
     endloop
   endfacet
-  facet normal 0.999779 0.0210254 0
+  facet normal 0.997047 -0.0767949 0
     outer loop
-      vertex -16.833 -63.5367 7
+      vertex -16.8379 -63.3037 4
+      vertex -16.82 -63.0713 0
+      vertex -16.82 -63.0713 4
+    endloop
+  endfacet
+  facet normal 0.997047 -0.0767949 0
+    outer loop
+      vertex -16.82 -63.0713 0
+      vertex -16.8379 -63.3037 4
       vertex -16.8379 -63.3037 0
-      vertex -16.8379 -63.3037 7
     endloop
   endfacet
-  facet normal 0.999779 0.0210254 0
+  facet normal -0.650297 0.75968 0
     outer loop
-      vertex -16.8379 -63.3037 0
-      vertex -16.833 -63.5367 7
-      vertex -16.833 -63.5367 0
+      vertex -12.8322 -65.0961 0
+      vertex -13.0093 -65.2477 4
+      vertex -12.8322 -65.0961 4
     endloop
   endfacet
-  facet normal 0.992911 0.118858 0
+  facet normal -0.650297 0.75968 0
     outer loop
-      vertex -16.8053 -63.7681 7
-      vertex -16.833 -63.5367 0
-      vertex -16.833 -63.5367 7
+      vertex -13.0093 -65.2477 4
+      vertex -12.8322 -65.0961 0
+      vertex -13.0093 -65.2477 0
     endloop
   endfacet
-  facet normal 0.992911 0.118858 0
+  facet normal -0.402034 0.915625 0
     outer loop
-      vertex -16.833 -63.5367 0
-      vertex -16.8053 -63.7681 7
-      vertex -16.8053 -63.7681 0
+      vertex -13.4035 -65.4955 0
+      vertex -13.6169 -65.5892 4
+      vertex -13.4035 -65.4955 4
     endloop
   endfacet
-  facet normal -0.0210254 0.999779 0
+  facet normal -0.402034 0.915625 0
     outer loop
-      vertex -14.2975 -65.7395 0
-      vertex -14.5305 -65.7444 7
-      vertex -14.2975 -65.7395 7
+      vertex -13.6169 -65.5892 4
+      vertex -13.4035 -65.4955 0
+      vertex -13.6169 -65.5892 0
     endloop
   endfacet
-  facet normal -0.0210254 0.999779 0
+  facet normal -0.962777 0.270298 0
     outer loop
-      vertex -14.5305 -65.7444 7
-      vertex -14.2975 -65.7395 0
-      vertex -14.5305 -65.7444 0
+      vertex -12.2114 -64.1232 0
+      vertex -12.1484 -63.8988 4
+      vertex -12.1484 -63.8988 0
     endloop
   endfacet
-  facet normal 0.363088 0.931755 -0
+  facet normal -0.962777 0.270298 0
     outer loop
-      vertex -15.2168 -65.6228 0
-      vertex -15.4339 -65.5382 7
-      vertex -15.2168 -65.6228 7
+      vertex -12.1484 -63.8988 4
+      vertex -12.2114 -64.1232 0
+      vertex -12.2114 -64.1232 4
     endloop
   endfacet
-  facet normal 0.363088 0.931755 0
+  facet normal -0.537958 -0.842972 0
     outer loop
-      vertex -15.4339 -65.5382 7
-      vertex -15.2168 -65.6228 0
-      vertex -15.4339 -65.5382 0
+      vertex -13.286 -61.308 0
+      vertex -13.0895 -61.4334 4
+      vertex -13.286 -61.308 4
+    endloop
+  endfacet
+  facet normal -0.537958 -0.842972 -0
+    outer loop
+      vertex -13.0895 -61.4334 4
+      vertex -13.286 -61.308 0
+      vertex -13.0895 -61.4334 0
+    endloop
+  endfacet
+  facet normal -0.992911 -0.118858 0
+    outer loop
+      vertex -12.0947 -63.2039 0
+      vertex -12.1224 -62.9725 4
+      vertex -12.1224 -62.9725 0
+    endloop
+  endfacet
+  facet normal -0.992911 -0.118858 0
+    outer loop
+      vertex -12.1224 -62.9725 4
+      vertex -12.0947 -63.2039 0
+      vertex -12.0947 -63.2039 4
+    endloop
+  endfacet
+  facet normal 0.786363 -0.617765 0
+    outer loop
+      vertex -16.4008 -61.996 4
+      vertex -16.2568 -61.8127 0
+      vertex -16.2568 -61.8127 4
+    endloop
+  endfacet
+  facet normal 0.786363 -0.617765 0
+    outer loop
+      vertex -16.2568 -61.8127 0
+      vertex -16.4008 -61.996 4
+      vertex -16.4008 -61.996 0
+    endloop
+  endfacet
+  facet normal -0.174617 -0.984636 0
+    outer loop
+      vertex -14.1649 -61.0142 0
+      vertex -13.9354 -61.0549 4
+      vertex -14.1649 -61.0142 4
+    endloop
+  endfacet
+  facet normal -0.174617 -0.984636 -0
+    outer loop
+      vertex -13.9354 -61.0549 4
+      vertex -14.1649 -61.0142 0
+      vertex -13.9354 -61.0549 0
+    endloop
+  endfacet
+  facet normal 0.691933 0.721961 -0
+    outer loop
+      vertex -16.0214 -65.1632 0
+      vertex -16.1897 -65.0019 4
+      vertex -16.0214 -65.1632 4
+    endloop
+  endfacet
+  facet normal 0.691933 0.721961 0
+    outer loop
+      vertex -16.1897 -65.0019 4
+      vertex -16.0214 -65.1632 0
+      vertex -16.1897 -65.0019 0
     endloop
   endfacet
   facet normal 0.871759 0.489935 0
     outer loop
-      vertex -16.4748 -64.6339 7
+      vertex -16.4748 -64.6339 4
       vertex -16.589 -64.4307 0
-      vertex -16.589 -64.4307 7
+      vertex -16.589 -64.4307 4
     endloop
   endfacet
   facet normal 0.871759 0.489935 0
     outer loop
       vertex -16.589 -64.4307 0
-      vertex -16.4748 -64.6339 7
+      vertex -16.4748 -64.6339 4
       vertex -16.4748 -64.6339 0
     endloop
   endfacet
-  facet normal 0.915625 0.402034 0
+  facet normal -0.976439 -0.215795 0
     outer loop
-      vertex -16.589 -64.4307 7
-      vertex -16.6827 -64.2173 0
-      vertex -16.6827 -64.2173 7
+      vertex -12.1224 -62.9725 0
+      vertex -12.1727 -62.7449 4
+      vertex -12.1727 -62.7449 0
     endloop
   endfacet
-  facet normal 0.915625 0.402034 0
+  facet normal -0.976439 -0.215795 0
     outer loop
-      vertex -16.6827 -64.2173 0
-      vertex -16.589 -64.4307 7
-      vertex -16.589 -64.4307 0
+      vertex -12.1727 -62.7449 4
+      vertex -12.1224 -62.9725 0
+      vertex -12.1224 -62.9725 4
     endloop
   endfacet
-  facet normal 0.95068 0.310172 0
+  facet normal 0.962888 -0.2699 0
     outer loop
-      vertex -16.6827 -64.2173 7
-      vertex -16.755 -63.9957 0
-      vertex -16.755 -63.9957 7
+      vertex -16.7793 -62.8418 4
+      vertex -16.7164 -62.6174 0
+      vertex -16.7164 -62.6174 4
     endloop
   endfacet
-  facet normal 0.95068 0.310172 0
+  facet normal 0.962888 -0.2699 0
     outer loop
-      vertex -16.755 -63.9957 0
-      vertex -16.6827 -64.2173 7
-      vertex -16.6827 -64.2173 0
+      vertex -16.7164 -62.6174 0
+      vertex -16.7793 -62.8418 4
+      vertex -16.7793 -62.8418 0
     endloop
   endfacet
-  facet normal 0.759499 0.650509 0
+  facet normal -0.786199 0.617973 0
     outer loop
-      vertex -16.1897 -65.0019 7
-      vertex -16.3413 -64.8249 0
-      vertex -16.3413 -64.8249 7
+      vertex -12.6709 -64.9279 0
+      vertex -12.5269 -64.7447 4
+      vertex -12.5269 -64.7447 0
     endloop
   endfacet
-  facet normal 0.759499 0.650509 0
+  facet normal -0.786199 0.617973 0
     outer loop
-      vertex -16.3413 -64.8249 0
-      vertex -16.1897 -65.0019 7
-      vertex -16.1897 -65.0019 0
+      vertex -12.5269 -64.7447 4
+      vertex -12.6709 -64.9279 0
+      vertex -12.6709 -64.9279 4
     endloop
   endfacet
   facet normal 0.537958 0.842972 -0
     outer loop
       vertex -15.6417 -65.4327 0
-      vertex -15.8382 -65.3073 7
-      vertex -15.6417 -65.4327 7
+      vertex -15.8382 -65.3073 4
+      vertex -15.6417 -65.4327 4
     endloop
   endfacet
   facet normal 0.537958 0.842972 0
     outer loop
-      vertex -15.8382 -65.3073 7
+      vertex -15.8382 -65.3073 4
       vertex -15.6417 -65.4327 0
       vertex -15.8382 -65.3073 0
     endloop
   endfacet
-  facet normal 0.891752 -0.452524 0
+  facet normal 0.721756 -0.692148 0
     outer loop
-      vertex -16.6317 -62.4003 7
-      vertex -16.5262 -62.1924 0
-      vertex -16.5262 -62.1924 7
+      vertex -16.2568 -61.8127 4
+      vertex -16.0955 -61.6445 0
+      vertex -16.0955 -61.6445 4
     endloop
   endfacet
-  facet normal 0.891752 -0.452524 0
+  facet normal 0.721756 -0.692148 0
     outer loop
-      vertex -16.5262 -62.1924 0
-      vertex -16.6317 -62.4003 7
+      vertex -16.0955 -61.6445 0
+      vertex -16.2568 -61.8127 4
+      vertex -16.2568 -61.8127 0
+    endloop
+  endfacet
+  facet normal -0.118807 0.992917 0
+    outer loop
+      vertex -14.066 -65.7118 0
+      vertex -14.2975 -65.7395 4
+      vertex -14.066 -65.7118 4
+    endloop
+  endfacet
+  facet normal -0.118807 0.992917 0
+    outer loop
+      vertex -14.2975 -65.7395 4
+      vertex -14.066 -65.7118 0
+      vertex -14.2975 -65.7395 0
+    endloop
+  endfacet
+  facet normal -0.871759 -0.489935 0
+    outer loop
+      vertex -12.3387 -62.3099 0
+      vertex -12.4529 -62.1067 4
+      vertex -12.4529 -62.1067 0
+    endloop
+  endfacet
+  facet normal -0.871759 -0.489935 0
+    outer loop
+      vertex -12.4529 -62.1067 4
+      vertex -12.3387 -62.3099 0
+      vertex -12.3387 -62.3099 4
+    endloop
+  endfacet
+  facet normal 0.363088 0.931755 -0
+    outer loop
+      vertex -15.2168 -65.6228 0
+      vertex -15.4339 -65.5382 4
+      vertex -15.2168 -65.6228 4
+    endloop
+  endfacet
+  facet normal 0.363088 0.931755 0
+    outer loop
+      vertex -15.4339 -65.5382 4
+      vertex -15.2168 -65.6228 0
+      vertex -15.4339 -65.5382 0
+    endloop
+  endfacet
+  facet normal -0.215795 0.976439 0
+    outer loop
+      vertex -13.8384 -65.6615 0
+      vertex -14.066 -65.7118 4
+      vertex -13.8384 -65.6615 4
+    endloop
+  endfacet
+  facet normal -0.215795 0.976439 0
+    outer loop
+      vertex -14.066 -65.7118 4
+      vertex -13.8384 -65.6615 0
+      vertex -14.066 -65.7118 0
+    endloop
+  endfacet
+  facet normal 0.489609 -0.871942 0
+    outer loop
+      vertex -15.7274 -61.3593 0
+      vertex -15.5242 -61.2452 4
+      vertex -15.7274 -61.3593 4
+    endloop
+  endfacet
+  facet normal 0.489609 -0.871942 0
+    outer loop
+      vertex -15.5242 -61.2452 4
+      vertex -15.7274 -61.3593 0
+      vertex -15.5242 -61.2452 0
+    endloop
+  endfacet
+  facet normal 0.819635 0.572886 0
+    outer loop
+      vertex -16.3413 -64.8249 4
+      vertex -16.4748 -64.6339 0
+      vertex -16.4748 -64.6339 4
+    endloop
+  endfacet
+  facet normal 0.819635 0.572886 0
+    outer loop
+      vertex -16.4748 -64.6339 0
+      vertex -16.3413 -64.8249 4
+      vertex -16.3413 -64.8249 0
+    endloop
+  endfacet
+  facet normal -0.310299 0.950639 0
+    outer loop
+      vertex -13.6169 -65.5892 0
+      vertex -13.8384 -65.6615 4
+      vertex -13.6169 -65.5892 4
+    endloop
+  endfacet
+  facet normal -0.310299 0.950639 0
+    outer loop
+      vertex -13.8384 -65.6615 4
+      vertex -13.6169 -65.5892 0
+      vertex -13.8384 -65.6615 0
+    endloop
+  endfacet
+  facet normal 0.118858 -0.992911 0
+    outer loop
+      vertex -14.8617 -61.0289 0
+      vertex -14.6303 -61.0012 4
+      vertex -14.8617 -61.0289 4
+    endloop
+  endfacet
+  facet normal 0.118858 -0.992911 0
+    outer loop
+      vertex -14.6303 -61.0012 4
+      vertex -14.8617 -61.0289 0
+      vertex -14.6303 -61.0012 0
+    endloop
+  endfacet
+  facet normal 0.93161 -0.363461 0
+    outer loop
+      vertex -16.7164 -62.6174 4
       vertex -16.6317 -62.4003 0
+      vertex -16.6317 -62.4003 4
     endloop
   endfacet
-  facet normal 0.984636 -0.174617 0
+  facet normal 0.93161 -0.363461 0
     outer loop
-      vertex -16.82 -63.0713 7
-      vertex -16.7793 -62.8418 0
-      vertex -16.7793 -62.8418 7
+      vertex -16.6317 -62.4003 0
+      vertex -16.7164 -62.6174 4
+      vertex -16.7164 -62.6174 0
     endloop
   endfacet
-  facet normal 0.984636 -0.174617 0
+  facet normal 0.572973 -0.819574 0
     outer loop
-      vertex -16.7793 -62.8418 0
-      vertex -16.82 -63.0713 7
-      vertex -16.82 -63.0713 0
+      vertex -15.9185 -61.4929 0
+      vertex -15.7274 -61.3593 4
+      vertex -15.9185 -61.4929 4
     endloop
   endfacet
-  facet normal 0.118858 -0.992911 0
+  facet normal 0.572973 -0.819574 0
     outer loop
-      vertex -14.8617 -61.0289 0
-      vertex -14.6303 -61.0012 7
-      vertex -14.8617 -61.0289 7
+      vertex -15.7274 -61.3593 4
+      vertex -15.9185 -61.4929 0
+      vertex -15.7274 -61.3593 0
     endloop
   endfacet
-  facet normal 0.118858 -0.992911 0
+  facet normal -0.489935 0.871759 0
     outer loop
-      vertex -14.6303 -61.0012 7
-      vertex -14.8617 -61.0289 0
-      vertex -14.6303 -61.0012 0
+      vertex -13.2003 -65.3813 0
+      vertex -13.4035 -65.4955 4
+      vertex -13.2003 -65.3813 4
+    endloop
+  endfacet
+  facet normal -0.489935 0.871759 0
+    outer loop
+      vertex -13.4035 -65.4955 4
+      vertex -13.2003 -65.3813 0
+      vertex -13.4035 -65.4955 0
+    endloop
+  endfacet
+  facet normal -0.819635 -0.572886 0
+    outer loop
+      vertex -12.4529 -62.1067 0
+      vertex -12.5864 -61.9157 4
+      vertex -12.5864 -61.9157 0
+    endloop
+  endfacet
+  facet normal -0.819635 -0.572886 0
+    outer loop
+      vertex -12.5864 -61.9157 4
+      vertex -12.4529 -62.1067 0
+      vertex -12.4529 -62.1067 4
     endloop
   endfacet
   facet normal 0.0214543 -0.99977 0
     outer loop
       vertex -14.6303 -61.0012 0
-      vertex -14.3973 -60.9962 7
-      vertex -14.6303 -61.0012 7
+      vertex -14.3973 -60.9962 4
+      vertex -14.6303 -61.0012 4
     endloop
   endfacet
   facet normal 0.0214543 -0.99977 0
     outer loop
-      vertex -14.3973 -60.9962 7
+      vertex -14.3973 -60.9962 4
       vertex -14.6303 -61.0012 0
       vertex -14.3973 -60.9962 0
     endloop
   endfacet
-  facet normal 0.215386 -0.976529 0
+  facet normal 0.915625 0.402034 0
     outer loop
+      vertex -16.589 -64.4307 4
+      vertex -16.6827 -64.2173 0
+      vertex -16.6827 -64.2173 4
+    endloop
+  endfacet
+  facet normal 0.915625 0.402034 0
+    outer loop
+      vertex -16.6827 -64.2173 0
+      vertex -16.589 -64.4307 4
+      vertex -16.589 -64.4307 0
+    endloop
+  endfacet
+  facet normal 0.891752 -0.452524 0
+    outer loop
+      vertex -16.6317 -62.4003 4
+      vertex -16.5262 -62.1924 0
+      vertex -16.5262 -62.1924 4
+    endloop
+  endfacet
+  facet normal 0.891752 -0.452524 0
+    outer loop
+      vertex -16.5262 -62.1924 0
+      vertex -16.6317 -62.4003 4
+      vertex -16.6317 -62.4003 0
+    endloop
+  endfacet
+  facet normal -0.573174 0.819433 0
+    outer loop
+      vertex -13.0093 -65.2477 0
+      vertex -13.2003 -65.3813 4
+      vertex -13.0093 -65.2477 4
+    endloop
+  endfacet
+  facet normal -0.573174 0.819433 0
+    outer loop
+      vertex -13.2003 -65.3813 4
+      vertex -13.0093 -65.2477 0
+      vertex -13.2003 -65.3813 0
+    endloop
+  endfacet
+  facet normal 0.310687 -0.950512 0
+    outer loop
+      vertex -15.3108 -61.1515 0
+      vertex -15.0893 -61.0791 4
+      vertex -15.3108 -61.1515 4
+    endloop
+  endfacet
+  facet normal 0.310687 -0.950512 0
+    outer loop
+      vertex -15.0893 -61.0791 4
+      vertex -15.3108 -61.1515 0
       vertex -15.0893 -61.0791 0
-      vertex -14.8617 -61.0289 7
-      vertex -15.0893 -61.0791 7
+    endloop
+  endfacet
+  facet normal -0.452698 -0.891664 0
+    outer loop
+      vertex -13.4938 -61.2025 0
+      vertex -13.286 -61.308 4
+      vertex -13.4938 -61.2025 4
+    endloop
+  endfacet
+  facet normal -0.452698 -0.891664 -0
+    outer loop
+      vertex -13.286 -61.308 4
+      vertex -13.4938 -61.2025 0
+      vertex -13.286 -61.308 0
+    endloop
+  endfacet
+  facet normal 0.650509 -0.759499 0
+    outer loop
+      vertex -16.0955 -61.6445 0
+      vertex -15.9185 -61.4929 4
+      vertex -16.0955 -61.6445 4
+    endloop
+  endfacet
+  facet normal 0.650509 -0.759499 0
+    outer loop
+      vertex -15.9185 -61.4929 4
+      vertex -16.0955 -61.6445 0
+      vertex -15.9185 -61.4929 0
+    endloop
+  endfacet
+  facet normal -0.95068 -0.310172 0
+    outer loop
+      vertex -12.1727 -62.7449 0
+      vertex -12.245 -62.5233 4
+      vertex -12.245 -62.5233 0
+    endloop
+  endfacet
+  facet normal -0.95068 -0.310172 0
+    outer loop
+      vertex -12.245 -62.5233 4
+      vertex -12.1727 -62.7449 0
+      vertex -12.1727 -62.7449 4
+    endloop
+  endfacet
+  facet normal 0.999779 0.0210254 0
+    outer loop
+      vertex -16.833 -63.5367 4
+      vertex -16.8379 -63.3037 0
+      vertex -16.8379 -63.3037 4
+    endloop
+  endfacet
+  facet normal 0.999779 0.0210254 0
+    outer loop
+      vertex -16.8379 -63.3037 0
+      vertex -16.833 -63.5367 4
+      vertex -16.833 -63.5367 0
+    endloop
+  endfacet
+  facet normal -0.2699 -0.962888 0
+    outer loop
+      vertex -13.9354 -61.0549 0
+      vertex -13.711 -61.1178 4
+      vertex -13.9354 -61.0549 4
+    endloop
+  endfacet
+  facet normal -0.2699 -0.962888 -0
+    outer loop
+      vertex -13.711 -61.1178 4
+      vertex -13.9354 -61.0549 0
+      vertex -13.711 -61.1178 0
     endloop
   endfacet
   facet normal 0.215386 -0.976529 0
     outer loop
-      vertex -14.8617 -61.0289 7
+      vertex -15.0893 -61.0791 0
+      vertex -14.8617 -61.0289 4
+      vertex -15.0893 -61.0791 4
+    endloop
+  endfacet
+  facet normal 0.215386 -0.976529 0
+    outer loop
+      vertex -14.8617 -61.0289 4
       vertex -15.0893 -61.0791 0
       vertex -14.8617 -61.0289 0
     endloop
   endfacet
-  facet normal 0.310687 -0.950512 0
+  facet normal -0.617973 -0.786199 0
     outer loop
-      vertex -15.3108 -61.1515 0
-      vertex -15.0893 -61.0791 7
-      vertex -15.3108 -61.1515 7
+      vertex -13.0895 -61.4334 0
+      vertex -12.9063 -61.5774 4
+      vertex -13.0895 -61.4334 4
     endloop
   endfacet
-  facet normal 0.310687 -0.950512 0
+  facet normal -0.617973 -0.786199 -0
     outer loop
-      vertex -15.0893 -61.0791 7
-      vertex -15.3108 -61.1515 0
-      vertex -15.0893 -61.0791 0
+      vertex -12.9063 -61.5774 4
+      vertex -13.0895 -61.4334 0
+      vertex -12.9063 -61.5774 0
     endloop
   endfacet
-  facet normal 0.489609 -0.871942 0
+  facet normal 0.222525 0.974927 -0
     outer loop
-      vertex -15.7274 -61.3593 0
-      vertex -15.5242 -61.2452 7
-      vertex -15.7274 -61.3593 7
+      vertex -5.82719 -70.4702 4
+      vertex -25.3257 -66.0197 7
+      vertex -5.82719 -70.4702 7
     endloop
   endfacet
-  facet normal 0.489609 -0.871942 0
+  facet normal 0.222525 0.974927 0
     outer loop
-      vertex -15.5242 -61.2452 7
-      vertex -15.7274 -61.3593 0
-      vertex -15.5242 -61.2452 0
+      vertex -25.3257 -66.0197 7
+      vertex -5.82719 -70.4702 4
+      vertex -25.3257 -66.0197 4
     endloop
   endfacet
-  facet normal 0.402034 -0.915625 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.5242 -61.2452 0
-      vertex -15.3108 -61.1515 7
-      vertex -15.5242 -61.2452 7
+      vertex -12.1078 -63.6693 4
+      vertex -3.60198 -60.7209 4
+      vertex -12.0898 -63.4369 4
     endloop
   endfacet
-  facet normal 0.402034 -0.915625 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.3108 -61.1515 7
-      vertex -15.5242 -61.2452 0
-      vertex -15.3108 -61.1515 0
+      vertex -3.60198 -60.7209 4
+      vertex -12.0947 -63.2039 4
+      vertex -12.0898 -63.4369 4
     endloop
   endfacet
-  facet normal 0.572973 -0.819574 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.9185 -61.4929 0
-      vertex -15.7274 -61.3593 7
-      vertex -15.9185 -61.4929 7
+      vertex -3.60198 -60.7209 4
+      vertex -12.1224 -62.9725 4
+      vertex -12.0947 -63.2039 4
     endloop
   endfacet
-  facet normal 0.572973 -0.819574 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.7274 -61.3593 7
-      vertex -15.9185 -61.4929 0
-      vertex -15.7274 -61.3593 0
+      vertex -3.60198 -60.7209 4
+      vertex -12.1727 -62.7449 4
+      vertex -12.1224 -62.9725 4
     endloop
   endfacet
-  facet normal 0.650509 -0.759499 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.0955 -61.6445 0
-      vertex -15.9185 -61.4929 7
-      vertex -16.0955 -61.6445 7
+      vertex -3.60198 -60.7209 4
+      vertex -12.245 -62.5233 4
+      vertex -12.1727 -62.7449 4
     endloop
   endfacet
-  facet normal 0.650509 -0.759499 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.9185 -61.4929 7
-      vertex -16.0955 -61.6445 0
-      vertex -15.9185 -61.4929 0
+      vertex -3.60198 -60.7209 4
+      vertex -12.3387 -62.3099 4
+      vertex -12.245 -62.5233 4
     endloop
   endfacet
-  facet normal 0.786363 -0.617765 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.4008 -61.996 7
-      vertex -16.2568 -61.8127 0
-      vertex -16.2568 -61.8127 7
+      vertex -3.60198 -60.7209 4
+      vertex -12.4529 -62.1067 4
+      vertex -12.3387 -62.3099 4
     endloop
   endfacet
-  facet normal 0.786363 -0.617765 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.2568 -61.8127 0
-      vertex -16.4008 -61.996 7
-      vertex -16.4008 -61.996 0
+      vertex -3.60198 -60.7209 4
+      vertex -12.5864 -61.9157 4
+      vertex -12.4529 -62.1067 4
     endloop
   endfacet
-  facet normal 0.721756 -0.692148 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.2568 -61.8127 7
-      vertex -16.0955 -61.6445 0
-      vertex -16.0955 -61.6445 7
+      vertex -3.60198 -60.7209 4
+      vertex -12.738 -61.7387 4
+      vertex -12.5864 -61.9157 4
     endloop
   endfacet
-  facet normal 0.721756 -0.692148 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.0955 -61.6445 0
-      vertex -16.2568 -61.8127 7
-      vertex -16.2568 -61.8127 0
+      vertex -3.60198 -60.7209 4
+      vertex -12.9063 -61.5774 4
+      vertex -12.738 -61.7387 4
     endloop
   endfacet
-  facet normal 0.93161 -0.363461 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.7164 -62.6174 7
-      vertex -16.6317 -62.4003 0
-      vertex -16.6317 -62.4003 7
+      vertex -3.60198 -60.7209 4
+      vertex -13.0895 -61.4334 4
+      vertex -12.9063 -61.5774 4
     endloop
   endfacet
-  facet normal 0.93161 -0.363461 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.6317 -62.4003 0
-      vertex -16.7164 -62.6174 7
-      vertex -16.7164 -62.6174 0
+      vertex -3.60198 -60.7209 4
+      vertex -13.286 -61.308 4
+      vertex -13.0895 -61.4334 4
     endloop
   endfacet
-  facet normal 0.842848 -0.538152 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.5262 -62.1924 7
-      vertex -16.4008 -61.996 0
-      vertex -16.4008 -61.996 7
+      vertex -3.60198 -60.7209 4
+      vertex -13.4938 -61.2025 4
+      vertex -13.286 -61.308 4
     endloop
   endfacet
-  facet normal 0.842848 -0.538152 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.4008 -61.996 0
-      vertex -16.5262 -62.1924 7
-      vertex -16.5262 -62.1924 0
+      vertex -3.60198 -60.7209 4
+      vertex -13.711 -61.1178 4
+      vertex -13.4938 -61.2025 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.60198 -60.7209 4
+      vertex -13.9354 -61.0549 4
+      vertex -13.711 -61.1178 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -23.1005 -56.2705 4
+      vertex -13.9354 -61.0549 4
+      vertex -3.60198 -60.7209 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.9354 -61.0549 4
+      vertex -23.1005 -56.2705 4
+      vertex -14.1649 -61.0142 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1649 -61.0142 4
+      vertex -23.1005 -56.2705 4
+      vertex -14.3973 -60.9962 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7793 -62.8418 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.82 -63.0713 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 -66.0197 4
+      vertex -16.7793 -62.8418 4
+      vertex -23.1005 -56.2705 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.7164 -62.6174 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.7793 -62.8418 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6317 -62.4003 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.7164 -62.6174 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.5262 -62.1924 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.6317 -62.4003 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4008 -61.996 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.5262 -62.1924 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.2568 -61.8127 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.4008 -61.996 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0955 -61.6445 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.2568 -61.8127 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9185 -61.4929 4
+      vertex -23.1005 -56.2705 4
+      vertex -16.0955 -61.6445 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.7274 -61.3593 4
+      vertex -23.1005 -56.2705 4
+      vertex -15.9185 -61.4929 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5242 -61.2452 4
+      vertex -23.1005 -56.2705 4
+      vertex -15.7274 -61.3593 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3108 -61.1515 4
+      vertex -23.1005 -56.2705 4
+      vertex -15.5242 -61.2452 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.0893 -61.0791 4
+      vertex -23.1005 -56.2705 4
+      vertex -15.3108 -61.1515 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.8617 -61.0289 4
+      vertex -23.1005 -56.2705 4
+      vertex -15.0893 -61.0791 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6303 -61.0012 4
+      vertex -23.1005 -56.2705 4
+      vertex -14.8617 -61.0289 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3973 -60.9962 4
+      vertex -23.1005 -56.2705 4
+      vertex -14.6303 -61.0012 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.1484 -63.8988 4
+      vertex -3.60198 -60.7209 4
+      vertex -12.1078 -63.6693 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.60198 -60.7209 4
+      vertex -12.1484 -63.8988 4
+      vertex -5.82719 -70.4702 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.2114 -64.1232 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.1484 -63.8988 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.296 -64.3404 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.2114 -64.1232 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.4015 -64.5482 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.296 -64.3404 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.5269 -64.7447 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.4015 -64.5482 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.6709 -64.9279 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.5269 -64.7447 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.8322 -65.0961 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.6709 -64.9279 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.0093 -65.2477 4
+      vertex -5.82719 -70.4702 4
+      vertex -12.8322 -65.0961 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.2003 -65.3813 4
+      vertex -5.82719 -70.4702 4
+      vertex -13.0093 -65.2477 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.4035 -65.4955 4
+      vertex -5.82719 -70.4702 4
+      vertex -13.2003 -65.3813 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.6169 -65.5892 4
+      vertex -5.82719 -70.4702 4
+      vertex -13.4035 -65.4955 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8384 -65.6615 4
+      vertex -5.82719 -70.4702 4
+      vertex -13.6169 -65.5892 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.066 -65.7118 4
+      vertex -5.82719 -70.4702 4
+      vertex -13.8384 -65.6615 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.2975 -65.7395 4
+      vertex -5.82719 -70.4702 4
+      vertex -14.066 -65.7118 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.5305 -65.7444 4
+      vertex -5.82719 -70.4702 4
+      vertex -14.2975 -65.7395 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7628 -65.7264 4
+      vertex -5.82719 -70.4702 4
+      vertex -14.5305 -65.7444 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.9923 -65.6858 4
+      vertex -5.82719 -70.4702 4
+      vertex -14.7628 -65.7264 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 -66.0197 4
+      vertex -14.9923 -65.6858 4
+      vertex -15.2168 -65.6228 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 -66.0197 4
+      vertex -15.2168 -65.6228 4
+      vertex -15.4339 -65.5382 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -25.3257 -66.0197 4
+      vertex -15.4339 -65.5382 4
+      vertex -15.6417 -65.4327 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.82 -63.0713 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.8379 -63.3037 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.8379 -63.3037 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.833 -63.5367 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.833 -63.5367 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.8053 -63.7681 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.8053 -63.7681 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.755 -63.9957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.755 -63.9957 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.6827 -64.2173 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6827 -64.2173 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.589 -64.4307 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.589 -64.4307 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.4748 -64.6339 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.9923 -65.6858 4
+      vertex -25.3257 -66.0197 4
+      vertex -5.82719 -70.4702 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8382 -65.3073 4
+      vertex -25.3257 -66.0197 4
+      vertex -15.6417 -65.4327 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0214 -65.1632 4
+      vertex -25.3257 -66.0197 4
+      vertex -15.8382 -65.3073 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1897 -65.0019 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.0214 -65.1632 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3413 -64.8249 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.1897 -65.0019 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.4748 -64.6339 4
+      vertex -25.3257 -66.0197 4
+      vertex -16.3413 -64.8249 4
+    endloop
+  endfacet
+  facet normal -0.22252 -0.974928 0
+    outer loop
+      vertex -23.1005 -56.2705 4
+      vertex -3.60198 -60.7209 7
+      vertex -23.1005 -56.2705 7
+    endloop
+  endfacet
+  facet normal -0.22252 -0.974928 -0
+    outer loop
+      vertex -3.60198 -60.7209 7
+      vertex -23.1005 -56.2705 4
+      vertex -3.60198 -60.7209 4
+    endloop
+  endfacet
+  facet normal -0.974928 0.222521 0
+    outer loop
+      vertex -5.82719 -70.4702 4
+      vertex -3.60198 -60.7209 7
+      vertex -3.60198 -60.7209 4
+    endloop
+  endfacet
+  facet normal -0.974928 0.222521 0
+    outer loop
+      vertex -3.60198 -60.7209 7
+      vertex -5.82719 -70.4702 4
+      vertex -5.82719 -70.4702 7
+    endloop
+  endfacet
+  facet normal 0.974928 -0.222522 0
+    outer loop
+      vertex -25.3257 -66.0197 7
+      vertex -23.1005 -56.2705 4
+      vertex -23.1005 -56.2705 7
+    endloop
+  endfacet
+  facet normal 0.974928 -0.222522 0
+    outer loop
+      vertex -23.1005 -56.2705 4
+      vertex -25.3257 -66.0197 7
+      vertex -25.3257 -66.0197 4
     endloop
   endfacet
   facet normal 0.62349 -0.781831 0
@@ -11549,900 +11269,1432 @@ solid OpenSCAD_Model
       vertex 13.2443 -58.027 0
     endloop
   endfacet
-  facet normal -0.936699 0.350136 0
-    outer loop
-      vertex 42.7081 -51.7586 0
-      vertex 42.7897 -51.5403 7
-      vertex 42.7897 -51.5403 0
-    endloop
-  endfacet
-  facet normal -0.936699 0.350136 0
-    outer loop
-      vertex 42.7897 -51.5403 7
-      vertex 42.7081 -51.7586 0
-      vertex 42.7081 -51.7586 7
-    endloop
-  endfacet
-  facet normal -0.946254 -0.323425 0
-    outer loop
-      vertex 42.809 -50.1616 0
-      vertex 42.7336 -49.941 7
-      vertex 42.7336 -49.941 0
-    endloop
-  endfacet
-  facet normal -0.946254 -0.323425 0
-    outer loop
-      vertex 42.7336 -49.941 7
-      vertex 42.809 -50.1616 0
-      vertex 42.809 -50.1616 7
-    endloop
-  endfacet
-  facet normal -0.440164 -0.897917 0
-    outer loop
-      vertex 41.4664 -48.6378 0
-      vertex 41.6757 -48.7404 7
-      vertex 41.4664 -48.6378 7
-    endloop
-  endfacet
-  facet normal -0.440164 -0.897917 -0
-    outer loop
-      vertex 41.6757 -48.7404 7
-      vertex 41.4664 -48.6378 0
-      vertex 41.6757 -48.7404 0
-    endloop
-  endfacet
-  facet normal 0.323425 -0.946254 0
-    outer loop
-      vertex 39.6488 -48.6123 0
-      vertex 39.8694 -48.5369 7
-      vertex 39.6488 -48.6123 7
-    endloop
-  endfacet
-  facet normal 0.323425 -0.946254 0
-    outer loop
-      vertex 39.8694 -48.5369 7
-      vertex 39.6488 -48.6123 0
-      vertex 39.8694 -48.5369 0
-    endloop
-  endfacet
-  facet normal -0.58444 0.811437 0
-    outer loop
-      vertex 42.0076 -52.6759 0
-      vertex 41.8185 -52.8121 7
-      vertex 42.0076 -52.6759 7
-    endloop
-  endfacet
-  facet normal -0.58444 0.811437 0
-    outer loop
-      vertex 41.8185 -52.8121 7
-      vertex 42.0076 -52.6759 0
-      vertex 41.8185 -52.8121 0
-    endloop
-  endfacet
   facet normal -0.991172 -0.132585 0
     outer loop
       vertex 42.8934 -50.6194 0
-      vertex 42.8625 -50.3884 7
+      vertex 42.8625 -50.3884 4
       vertex 42.8625 -50.3884 0
     endloop
   endfacet
   facet normal -0.991172 -0.132585 0
     outer loop
-      vertex 42.8625 -50.3884 7
+      vertex 42.8625 -50.3884 4
       vertex 42.8934 -50.6194 0
-      vertex 42.8934 -50.6194 7
-    endloop
-  endfacet
-  facet normal 0.0347579 -0.999396 0
-    outer loop
-      vertex 40.3272 -48.4524 0
-      vertex 40.5601 -48.4443 7
-      vertex 40.3272 -48.4524 7
-    endloop
-  endfacet
-  facet normal 0.0347579 -0.999396 0
-    outer loop
-      vertex 40.5601 -48.4443 7
-      vertex 40.3272 -48.4524 0
-      vertex 40.5601 -48.4443 0
-    endloop
-  endfacet
-  facet normal -0.607116 -0.794614 0
-    outer loop
-      vertex 41.8739 -48.863 0
-      vertex 42.0591 -49.0045 7
-      vertex 41.8739 -48.863 7
-    endloop
-  endfacet
-  facet normal -0.607116 -0.794614 -0
-    outer loop
-      vertex 42.0591 -49.0045 7
-      vertex 41.8739 -48.863 0
-      vertex 42.0591 -49.0045 0
+      vertex 42.8934 -50.6194 4
     endloop
   endfacet
   facet normal -0.731554 0.681783 0
     outer loop
       vertex 42.1825 -52.5218 0
-      vertex 42.3414 -52.3513 7
+      vertex 42.3414 -52.3513 4
       vertex 42.3414 -52.3513 0
     endloop
   endfacet
   facet normal -0.731554 0.681783 0
     outer loop
-      vertex 42.3414 -52.3513 7
+      vertex 42.3414 -52.3513 4
       vertex 42.1825 -52.5218 0
-      vertex 42.1825 -52.5218 7
-    endloop
-  endfacet
-  facet normal -0.966533 0.256541 0
-    outer loop
-      vertex 42.7897 -51.5403 0
-      vertex 42.8495 -51.315 7
-      vertex 42.8495 -51.315 0
-    endloop
-  endfacet
-  facet normal -0.966533 0.256541 0
-    outer loop
-      vertex 42.8495 -51.315 7
-      vertex 42.7897 -51.5403 0
-      vertex 42.7897 -51.5403 7
-    endloop
-  endfacet
-  facet normal -0.998009 0.0630728 0
-    outer loop
-      vertex 42.8869 -51.085 0
-      vertex 42.9016 -50.8524 7
-      vertex 42.9016 -50.8524 0
-    endloop
-  endfacet
-  facet normal -0.998009 0.0630728 0
-    outer loop
-      vertex 42.9016 -50.8524 7
-      vertex 42.8869 -51.085 0
-      vertex 42.8869 -51.085 7
-    endloop
-  endfacet
-  facet normal -0.750313 -0.661082 0
-    outer loop
-      vertex 42.3837 -49.3383 0
-      vertex 42.2296 -49.1634 7
-      vertex 42.2296 -49.1634 0
-    endloop
-  endfacet
-  facet normal -0.750313 -0.661082 0
-    outer loop
-      vertex 42.2296 -49.1634 7
-      vertex 42.3837 -49.3383 0
-      vertex 42.3837 -49.3383 7
-    endloop
-  endfacet
-  facet normal -0.909822 -0.414999 0
-    outer loop
-      vertex 42.7336 -49.941 0
-      vertex 42.6369 -49.729 7
-      vertex 42.6369 -49.729 0
-    endloop
-  endfacet
-  facet normal -0.909822 -0.414999 0
-    outer loop
-      vertex 42.6369 -49.729 7
-      vertex 42.7336 -49.941 0
-      vertex 42.7336 -49.941 7
-    endloop
-  endfacet
-  facet normal -0.864897 -0.501949 0
-    outer loop
-      vertex 42.6369 -49.729 0
-      vertex 42.5199 -49.5274 7
-      vertex 42.5199 -49.5274 0
-    endloop
-  endfacet
-  facet normal -0.864897 -0.501949 0
-    outer loop
-      vertex 42.5199 -49.5274 7
-      vertex 42.6369 -49.729 0
-      vertex 42.6369 -49.729 7
-    endloop
-  endfacet
-  facet normal -0.973288 -0.229589 0
-    outer loop
-      vertex 42.8625 -50.3884 0
-      vertex 42.809 -50.1616 7
-      vertex 42.809 -50.1616 0
-    endloop
-  endfacet
-  facet normal -0.973288 -0.229589 0
-    outer loop
-      vertex 42.809 -50.1616 7
-      vertex 42.8625 -50.3884 0
-      vertex 42.8625 -50.3884 7
-    endloop
-  endfacet
-  facet normal -0.999381 -0.0351714 0
-    outer loop
-      vertex 42.9016 -50.8524 0
-      vertex 42.8934 -50.6194 7
-      vertex 42.8934 -50.6194 0
-    endloop
-  endfacet
-  facet normal -0.999381 -0.0351714 0
-    outer loop
-      vertex 42.8934 -50.6194 7
-      vertex 42.9016 -50.8524 0
-      vertex 42.9016 -50.8524 7
-    endloop
-  endfacet
-  facet normal 0.661295 -0.750126 0
-    outer loop
-      vertex 38.8712 -49.1163 0
-      vertex 39.046 -48.9622 7
-      vertex 38.8712 -49.1163 7
-    endloop
-  endfacet
-  facet normal 0.661295 -0.750126 0
-    outer loop
-      vertex 39.046 -48.9622 7
-      vertex 38.8712 -49.1163 0
-      vertex 39.046 -48.9622 0
-    endloop
-  endfacet
-  facet normal 0.414999 -0.909822 0
-    outer loop
-      vertex 39.4368 -48.709 0
-      vertex 39.6488 -48.6123 7
-      vertex 39.4368 -48.709 7
-    endloop
-  endfacet
-  facet normal 0.414999 -0.909822 0
-    outer loop
-      vertex 39.6488 -48.6123 7
-      vertex 39.4368 -48.709 0
-      vertex 39.6488 -48.6123 0
-    endloop
-  endfacet
-  facet normal 0.501949 -0.864897 0
-    outer loop
-      vertex 39.2352 -48.826 0
-      vertex 39.4368 -48.709 7
-      vertex 39.2352 -48.826 7
-    endloop
-  endfacet
-  facet normal 0.501949 -0.864897 0
-    outer loop
-      vertex 39.4368 -48.709 7
-      vertex 39.2352 -48.826 0
-      vertex 39.4368 -48.709 0
-    endloop
-  endfacet
-  facet normal 0.229589 -0.973288 0
-    outer loop
-      vertex 39.8694 -48.5369 0
-      vertex 40.0962 -48.4834 7
-      vertex 39.8694 -48.5369 7
-    endloop
-  endfacet
-  facet normal 0.229589 -0.973288 0
-    outer loop
-      vertex 40.0962 -48.4834 7
-      vertex 39.8694 -48.5369 0
-      vertex 40.0962 -48.4834 0
-    endloop
-  endfacet
-  facet normal 0.133007 -0.991115 0
-    outer loop
-      vertex 40.0962 -48.4834 0
-      vertex 40.3272 -48.4524 7
-      vertex 40.0962 -48.4834 7
-    endloop
-  endfacet
-  facet normal 0.133007 -0.991115 0
-    outer loop
-      vertex 40.3272 -48.4524 7
-      vertex 40.0962 -48.4834 0
-      vertex 40.3272 -48.4524 0
-    endloop
-  endfacet
-  facet normal -0.526059 -0.850448 0
-    outer loop
-      vertex 41.6757 -48.7404 0
-      vertex 41.8739 -48.863 7
-      vertex 41.6757 -48.7404 7
-    endloop
-  endfacet
-  facet normal -0.526059 -0.850448 -0
-    outer loop
-      vertex 41.8739 -48.863 7
-      vertex 41.6757 -48.7404 0
-      vertex 41.8739 -48.863 0
-    endloop
-  endfacet
-  facet normal -0.681783 -0.731554 0
-    outer loop
-      vertex 42.0591 -49.0045 0
-      vertex 42.2296 -49.1634 7
-      vertex 42.0591 -49.0045 7
-    endloop
-  endfacet
-  facet normal -0.681783 -0.731554 -0
-    outer loop
-      vertex 42.2296 -49.1634 7
-      vertex 42.0591 -49.0045 0
-      vertex 42.2296 -49.1634 0
-    endloop
-  endfacet
-  facet normal -0.256541 -0.966533 0
-    outer loop
-      vertex 41.0228 -48.4964 0
-      vertex 41.2481 -48.5562 7
-      vertex 41.0228 -48.4964 7
-    endloop
-  endfacet
-  facet normal -0.256541 -0.966533 -0
-    outer loop
-      vertex 41.2481 -48.5562 7
-      vertex 41.0228 -48.4964 0
-      vertex 41.2481 -48.5562 0
-    endloop
-  endfacet
-  facet normal -0.160501 -0.987036 0
-    outer loop
-      vertex 40.7928 -48.459 0
-      vertex 41.0228 -48.4964 7
-      vertex 40.7928 -48.459 7
-    endloop
-  endfacet
-  facet normal -0.160501 -0.987036 -0
-    outer loop
-      vertex 41.0228 -48.4964 7
-      vertex 40.7928 -48.459 0
-      vertex 41.0228 -48.4964 0
-    endloop
-  endfacet
-  facet normal -0.350136 -0.936699 0
-    outer loop
-      vertex 41.2481 -48.5562 0
-      vertex 41.4664 -48.6378 7
-      vertex 41.2481 -48.5562 7
-    endloop
-  endfacet
-  facet normal -0.350136 -0.936699 -0
-    outer loop
-      vertex 41.4664 -48.6378 7
-      vertex 41.2481 -48.5562 0
-      vertex 41.4664 -48.6378 0
-    endloop
-  endfacet
-  facet normal -0.0630458 -0.998011 0
-    outer loop
-      vertex 40.5601 -48.4443 0
-      vertex 40.7928 -48.459 7
-      vertex 40.5601 -48.4443 7
-    endloop
-  endfacet
-  facet normal -0.0630458 -0.998011 -0
-    outer loop
-      vertex 40.7928 -48.459 7
-      vertex 40.5601 -48.4443 0
-      vertex 40.7928 -48.459 0
+      vertex 42.1825 -52.5218 4
     endloop
   endfacet
   facet normal -0.661082 0.750313 0
     outer loop
       vertex 42.1825 -52.5218 0
-      vertex 42.0076 -52.6759 7
-      vertex 42.1825 -52.5218 7
+      vertex 42.0076 -52.6759 4
+      vertex 42.1825 -52.5218 4
     endloop
   endfacet
   facet normal -0.661082 0.750313 0
     outer loop
-      vertex 42.0076 -52.6759 7
+      vertex 42.0076 -52.6759 4
       vertex 42.1825 -52.5218 0
       vertex 42.0076 -52.6759 0
     endloop
   endfacet
-  facet normal -0.414999 0.909822 0
+  facet normal -0.794614 0.607116 0
     outer loop
-      vertex 41.6169 -52.9291 0
-      vertex 41.4049 -53.0258 7
-      vertex 41.6169 -52.9291 7
-    endloop
-  endfacet
-  facet normal -0.414999 0.909822 0
-    outer loop
-      vertex 41.4049 -53.0258 7
-      vertex 41.6169 -52.9291 0
-      vertex 41.4049 -53.0258 0
-    endloop
-  endfacet
-  facet normal 0.73134 -0.682013 0
-    outer loop
-      vertex 38.7122 -49.2868 7
-      vertex 38.8712 -49.1163 0
-      vertex 38.8712 -49.1163 7
-    endloop
-  endfacet
-  facet normal 0.73134 -0.682013 0
-    outer loop
-      vertex 38.8712 -49.1163 0
-      vertex 38.7122 -49.2868 7
-      vertex 38.7122 -49.2868 0
-    endloop
-  endfacet
-  facet normal 0.681783 0.731554 -0
-    outer loop
-      vertex 38.9946 -52.6336 0
-      vertex 38.8241 -52.4747 7
-      vertex 38.9946 -52.6336 7
-    endloop
-  endfacet
-  facet normal 0.681783 0.731554 0
-    outer loop
-      vertex 38.8241 -52.4747 7
-      vertex 38.9946 -52.6336 0
-      vertex 38.8241 -52.4747 0
-    endloop
-  endfacet
-  facet normal 0.440164 0.897917 -0
-    outer loop
-      vertex 39.5873 -53.0003 0
-      vertex 39.378 -52.8977 7
-      vertex 39.5873 -53.0003 7
-    endloop
-  endfacet
-  facet normal 0.440164 0.897917 0
-    outer loop
-      vertex 39.378 -52.8977 7
-      vertex 39.5873 -53.0003 0
-      vertex 39.378 -52.8977 0
-    endloop
-  endfacet
-  facet normal -0.897917 0.440164 0
-    outer loop
-      vertex 42.6055 -51.9679 0
-      vertex 42.7081 -51.7586 7
-      vertex 42.7081 -51.7586 0
-    endloop
-  endfacet
-  facet normal -0.897917 0.440164 0
-    outer loop
-      vertex 42.7081 -51.7586 7
-      vertex 42.6055 -51.9679 0
-      vertex 42.6055 -51.9679 7
-    endloop
-  endfacet
-  facet normal -0.850448 0.526059 0
-    outer loop
+      vertex 42.3414 -52.3513 0
+      vertex 42.4829 -52.1661 4
       vertex 42.4829 -52.1661 0
-      vertex 42.6055 -51.9679 7
-      vertex 42.6055 -51.9679 0
     endloop
   endfacet
-  facet normal -0.850448 0.526059 0
+  facet normal -0.794614 0.607116 0
     outer loop
-      vertex 42.6055 -51.9679 7
-      vertex 42.4829 -52.1661 0
-      vertex 42.4829 -52.1661 7
-    endloop
-  endfacet
-  facet normal -0.987036 0.160501 0
-    outer loop
-      vertex 42.8495 -51.315 0
-      vertex 42.8869 -51.085 7
-      vertex 42.8869 -51.085 0
-    endloop
-  endfacet
-  facet normal -0.987036 0.160501 0
-    outer loop
-      vertex 42.8869 -51.085 7
-      vertex 42.8495 -51.315 0
-      vertex 42.8495 -51.315 7
-    endloop
-  endfacet
-  facet normal -0.811437 -0.58444 0
-    outer loop
-      vertex 42.5199 -49.5274 0
-      vertex 42.3837 -49.3383 7
-      vertex 42.3837 -49.3383 0
-    endloop
-  endfacet
-  facet normal -0.811437 -0.58444 0
-    outer loop
-      vertex 42.3837 -49.3383 7
-      vertex 42.5199 -49.5274 0
-      vertex 42.5199 -49.5274 7
-    endloop
-  endfacet
-  facet normal 0.584237 -0.811583 0
-    outer loop
-      vertex 39.046 -48.9622 0
-      vertex 39.2352 -48.826 7
-      vertex 39.046 -48.9622 7
-    endloop
-  endfacet
-  facet normal 0.584237 -0.811583 0
-    outer loop
-      vertex 39.2352 -48.826 7
-      vertex 39.046 -48.9622 0
-      vertex 39.2352 -48.826 0
-    endloop
-  endfacet
-  facet normal 0.0630728 0.998009 -0
-    outer loop
-      vertex 40.4935 -53.1938 0
-      vertex 40.2609 -53.1791 7
-      vertex 40.4935 -53.1938 7
-    endloop
-  endfacet
-  facet normal 0.0630728 0.998009 0
-    outer loop
-      vertex 40.2609 -53.1791 7
-      vertex 40.4935 -53.1938 0
-      vertex 40.2609 -53.1791 0
-    endloop
-  endfacet
-  facet normal -0.132585 0.991172 0
-    outer loop
-      vertex 40.9575 -53.1547 0
-      vertex 40.7265 -53.1856 7
-      vertex 40.9575 -53.1547 7
-    endloop
-  endfacet
-  facet normal -0.132585 0.991172 0
-    outer loop
-      vertex 40.7265 -53.1856 7
-      vertex 40.9575 -53.1547 0
-      vertex 40.7265 -53.1856 0
-    endloop
-  endfacet
-  facet normal -0.229589 0.973288 0
-    outer loop
-      vertex 41.1843 -53.1012 0
-      vertex 40.9575 -53.1547 7
-      vertex 41.1843 -53.1012 7
-    endloop
-  endfacet
-  facet normal -0.229589 0.973288 0
-    outer loop
-      vertex 40.9575 -53.1547 7
-      vertex 41.1843 -53.1012 0
-      vertex 40.9575 -53.1547 0
-    endloop
-  endfacet
-  facet normal 0.811437 0.58444 0
-    outer loop
-      vertex 38.67 -52.2998 7
-      vertex 38.5338 -52.1107 0
-      vertex 38.5338 -52.1107 7
-    endloop
-  endfacet
-  facet normal 0.811437 0.58444 0
-    outer loop
-      vertex 38.5338 -52.1107 0
-      vertex 38.67 -52.2998 7
-      vertex 38.67 -52.2998 0
-    endloop
-  endfacet
-  facet normal 0.607116 0.794614 -0
-    outer loop
-      vertex 39.1798 -52.7751 0
-      vertex 38.9946 -52.6336 7
-      vertex 39.1798 -52.7751 7
-    endloop
-  endfacet
-  facet normal 0.607116 0.794614 0
-    outer loop
-      vertex 38.9946 -52.6336 7
-      vertex 39.1798 -52.7751 0
-      vertex 38.9946 -52.6336 0
+      vertex 42.4829 -52.1661 4
+      vertex 42.3414 -52.3513 0
+      vertex 42.3414 -52.3513 4
     endloop
   endfacet
   facet normal 0.526059 0.850448 -0
     outer loop
       vertex 39.378 -52.8977 0
-      vertex 39.1798 -52.7751 7
-      vertex 39.378 -52.8977 7
+      vertex 39.1798 -52.7751 4
+      vertex 39.378 -52.8977 4
     endloop
   endfacet
   facet normal 0.526059 0.850448 0
     outer loop
-      vertex 39.1798 -52.7751 7
+      vertex 39.1798 -52.7751 4
       vertex 39.378 -52.8977 0
       vertex 39.1798 -52.7751 0
     endloop
   endfacet
-  facet normal -0.794614 0.607116 0
+  facet normal 0.946254 0.323425 0
     outer loop
-      vertex 42.3414 -52.3513 0
-      vertex 42.4829 -52.1661 7
-      vertex 42.4829 -52.1661 0
+      vertex 38.3201 -51.6971 4
+      vertex 38.2447 -51.4765 0
+      vertex 38.2447 -51.4765 4
     endloop
   endfacet
-  facet normal -0.794614 0.607116 0
+  facet normal 0.946254 0.323425 0
     outer loop
-      vertex 42.4829 -52.1661 7
-      vertex 42.3414 -52.3513 0
-      vertex 42.3414 -52.3513 7
+      vertex 38.2447 -51.4765 0
+      vertex 38.3201 -51.6971 4
+      vertex 38.3201 -51.6971 0
     endloop
   endfacet
-  facet normal -0.501949 0.864897 0
+  facet normal 0.501949 -0.864897 0
     outer loop
+      vertex 39.2352 -48.826 0
+      vertex 39.4368 -48.709 4
+      vertex 39.2352 -48.826 4
+    endloop
+  endfacet
+  facet normal 0.501949 -0.864897 0
+    outer loop
+      vertex 39.4368 -48.709 4
+      vertex 39.2352 -48.826 0
+      vertex 39.4368 -48.709 0
+    endloop
+  endfacet
+  facet normal -0.750313 -0.661082 0
+    outer loop
+      vertex 42.3837 -49.3383 0
+      vertex 42.2296 -49.1634 4
+      vertex 42.2296 -49.1634 0
+    endloop
+  endfacet
+  facet normal -0.750313 -0.661082 0
+    outer loop
+      vertex 42.2296 -49.1634 4
+      vertex 42.3837 -49.3383 0
+      vertex 42.3837 -49.3383 4
+    endloop
+  endfacet
+  facet normal -0.58444 0.811437 0
+    outer loop
+      vertex 42.0076 -52.6759 0
+      vertex 41.8185 -52.8121 4
+      vertex 42.0076 -52.6759 4
+    endloop
+  endfacet
+  facet normal -0.58444 0.811437 0
+    outer loop
+      vertex 41.8185 -52.8121 4
+      vertex 42.0076 -52.6759 0
       vertex 41.8185 -52.8121 0
-      vertex 41.6169 -52.9291 7
-      vertex 41.8185 -52.8121 7
     endloop
   endfacet
-  facet normal -0.501949 0.864897 0
+  facet normal -0.946254 -0.323425 0
     outer loop
-      vertex 41.6169 -52.9291 7
-      vertex 41.8185 -52.8121 0
-      vertex 41.6169 -52.9291 0
+      vertex 42.809 -50.1616 0
+      vertex 42.7336 -49.941 4
+      vertex 42.7336 -49.941 0
     endloop
   endfacet
-  facet normal 0.160501 0.987036 -0
+  facet normal -0.946254 -0.323425 0
     outer loop
-      vertex 40.2609 -53.1791 0
-      vertex 40.0309 -53.1417 7
-      vertex 40.2609 -53.1791 7
+      vertex 42.7336 -49.941 4
+      vertex 42.809 -50.1616 0
+      vertex 42.809 -50.1616 4
     endloop
   endfacet
-  facet normal 0.160501 0.987036 0
+  facet normal 0.750313 0.661082 0
     outer loop
-      vertex 40.0309 -53.1417 7
-      vertex 40.2609 -53.1791 0
-      vertex 40.0309 -53.1417 0
+      vertex 38.8241 -52.4747 4
+      vertex 38.67 -52.2998 0
+      vertex 38.67 -52.2998 4
     endloop
   endfacet
-  facet normal 0.256541 0.966533 -0
+  facet normal 0.750313 0.661082 0
     outer loop
-      vertex 40.0309 -53.1417 0
-      vertex 39.8056 -53.0819 7
-      vertex 40.0309 -53.1417 7
-    endloop
-  endfacet
-  facet normal 0.256541 0.966533 0
-    outer loop
-      vertex 39.8056 -53.0819 7
-      vertex 40.0309 -53.1417 0
-      vertex 39.8056 -53.0819 0
+      vertex 38.67 -52.2998 0
+      vertex 38.8241 -52.4747 4
+      vertex 38.8241 -52.4747 0
     endloop
   endfacet
   facet normal 0.350136 0.936699 -0
     outer loop
       vertex 39.8056 -53.0819 0
-      vertex 39.5873 -53.0003 7
-      vertex 39.8056 -53.0819 7
+      vertex 39.5873 -53.0003 4
+      vertex 39.8056 -53.0819 4
     endloop
   endfacet
   facet normal 0.350136 0.936699 0
     outer loop
-      vertex 39.5873 -53.0003 7
+      vertex 39.5873 -53.0003 4
       vertex 39.8056 -53.0819 0
       vertex 39.5873 -53.0003 0
     endloop
   endfacet
-  facet normal -0.0351714 0.999381 0
+  facet normal 0.966533 -0.256541 0
     outer loop
-      vertex 40.7265 -53.1856 0
-      vertex 40.4935 -53.1938 7
-      vertex 40.7265 -53.1856 7
+      vertex 38.2042 -50.3231 4
+      vertex 38.264 -50.0978 0
+      vertex 38.264 -50.0978 4
+    endloop
+  endfacet
+  facet normal 0.966533 -0.256541 0
+    outer loop
+      vertex 38.264 -50.0978 0
+      vertex 38.2042 -50.3231 4
+      vertex 38.2042 -50.3231 0
+    endloop
+  endfacet
+  facet normal -0.256541 -0.966533 0
+    outer loop
+      vertex 41.0228 -48.4964 0
+      vertex 41.2481 -48.5562 4
+      vertex 41.0228 -48.4964 4
+    endloop
+  endfacet
+  facet normal -0.256541 -0.966533 -0
+    outer loop
+      vertex 41.2481 -48.5562 4
+      vertex 41.0228 -48.4964 0
+      vertex 41.2481 -48.5562 0
+    endloop
+  endfacet
+  facet normal -0.681783 -0.731554 0
+    outer loop
+      vertex 42.0591 -49.0045 0
+      vertex 42.2296 -49.1634 4
+      vertex 42.0591 -49.0045 4
+    endloop
+  endfacet
+  facet normal -0.681783 -0.731554 -0
+    outer loop
+      vertex 42.2296 -49.1634 4
+      vertex 42.0591 -49.0045 0
+      vertex 42.2296 -49.1634 0
+    endloop
+  endfacet
+  facet normal -0.607116 -0.794614 0
+    outer loop
+      vertex 41.8739 -48.863 0
+      vertex 42.0591 -49.0045 4
+      vertex 41.8739 -48.863 4
+    endloop
+  endfacet
+  facet normal -0.607116 -0.794614 -0
+    outer loop
+      vertex 42.0591 -49.0045 4
+      vertex 41.8739 -48.863 0
+      vertex 42.0591 -49.0045 0
+    endloop
+  endfacet
+  facet normal 0.440164 0.897917 -0
+    outer loop
+      vertex 39.5873 -53.0003 0
+      vertex 39.378 -52.8977 4
+      vertex 39.5873 -53.0003 4
+    endloop
+  endfacet
+  facet normal 0.440164 0.897917 0
+    outer loop
+      vertex 39.378 -52.8977 4
+      vertex 39.5873 -53.0003 0
+      vertex 39.378 -52.8977 0
+    endloop
+  endfacet
+  facet normal -0.909822 -0.414999 0
+    outer loop
+      vertex 42.7336 -49.941 0
+      vertex 42.6369 -49.729 4
+      vertex 42.6369 -49.729 0
+    endloop
+  endfacet
+  facet normal -0.909822 -0.414999 0
+    outer loop
+      vertex 42.6369 -49.729 4
+      vertex 42.7336 -49.941 0
+      vertex 42.7336 -49.941 4
     endloop
   endfacet
   facet normal -0.0351714 0.999381 0
     outer loop
-      vertex 40.4935 -53.1938 7
+      vertex 40.7265 -53.1856 0
+      vertex 40.4935 -53.1938 4
+      vertex 40.7265 -53.1856 4
+    endloop
+  endfacet
+  facet normal -0.0351714 0.999381 0
+    outer loop
+      vertex 40.4935 -53.1938 4
       vertex 40.7265 -53.1856 0
       vertex 40.4935 -53.1938 0
     endloop
   endfacet
-  facet normal -0.323425 0.946254 0
+  facet normal 0.73134 -0.682013 0
     outer loop
+      vertex 38.7122 -49.2868 4
+      vertex 38.8712 -49.1163 0
+      vertex 38.8712 -49.1163 4
+    endloop
+  endfacet
+  facet normal 0.73134 -0.682013 0
+    outer loop
+      vertex 38.8712 -49.1163 0
+      vertex 38.7122 -49.2868 4
+      vertex 38.7122 -49.2868 0
+    endloop
+  endfacet
+  facet normal 0.133007 -0.991115 0
+    outer loop
+      vertex 40.0962 -48.4834 0
+      vertex 40.3272 -48.4524 4
+      vertex 40.0962 -48.4834 4
+    endloop
+  endfacet
+  facet normal 0.133007 -0.991115 0
+    outer loop
+      vertex 40.3272 -48.4524 4
+      vertex 40.0962 -48.4834 0
+      vertex 40.3272 -48.4524 0
+    endloop
+  endfacet
+  facet normal -0.414999 0.909822 0
+    outer loop
+      vertex 41.6169 -52.9291 0
+      vertex 41.4049 -53.0258 4
+      vertex 41.6169 -52.9291 4
+    endloop
+  endfacet
+  facet normal -0.414999 0.909822 0
+    outer loop
+      vertex 41.4049 -53.0258 4
+      vertex 41.6169 -52.9291 0
       vertex 41.4049 -53.0258 0
-      vertex 41.1843 -53.1012 7
-      vertex 41.4049 -53.0258 7
+    endloop
+  endfacet
+  facet normal 0.0347579 -0.999396 0
+    outer loop
+      vertex 40.3272 -48.4524 0
+      vertex 40.5601 -48.4443 4
+      vertex 40.3272 -48.4524 4
+    endloop
+  endfacet
+  facet normal 0.0347579 -0.999396 0
+    outer loop
+      vertex 40.5601 -48.4443 4
+      vertex 40.3272 -48.4524 0
+      vertex 40.5601 -48.4443 0
+    endloop
+  endfacet
+  facet normal -0.229589 0.973288 0
+    outer loop
+      vertex 41.1843 -53.1012 0
+      vertex 40.9575 -53.1547 4
+      vertex 41.1843 -53.1012 4
+    endloop
+  endfacet
+  facet normal -0.229589 0.973288 0
+    outer loop
+      vertex 40.9575 -53.1547 4
+      vertex 41.1843 -53.1012 0
+      vertex 40.9575 -53.1547 0
+    endloop
+  endfacet
+  facet normal -0.864897 -0.501949 0
+    outer loop
+      vertex 42.6369 -49.729 0
+      vertex 42.5199 -49.5274 4
+      vertex 42.5199 -49.5274 0
+    endloop
+  endfacet
+  facet normal -0.864897 -0.501949 0
+    outer loop
+      vertex 42.5199 -49.5274 4
+      vertex 42.6369 -49.729 0
+      vertex 42.6369 -49.729 4
+    endloop
+  endfacet
+  facet normal 0.681783 0.731554 -0
+    outer loop
+      vertex 38.9946 -52.6336 0
+      vertex 38.8241 -52.4747 4
+      vertex 38.9946 -52.6336 4
+    endloop
+  endfacet
+  facet normal 0.681783 0.731554 0
+    outer loop
+      vertex 38.8241 -52.4747 4
+      vertex 38.9946 -52.6336 0
+      vertex 38.8241 -52.4747 0
+    endloop
+  endfacet
+  facet normal -0.999381 -0.0351714 0
+    outer loop
+      vertex 42.9016 -50.8524 0
+      vertex 42.8934 -50.6194 4
+      vertex 42.8934 -50.6194 0
+    endloop
+  endfacet
+  facet normal -0.999381 -0.0351714 0
+    outer loop
+      vertex 42.8934 -50.6194 4
+      vertex 42.9016 -50.8524 0
+      vertex 42.9016 -50.8524 4
+    endloop
+  endfacet
+  facet normal -0.966533 0.256541 0
+    outer loop
+      vertex 42.7897 -51.5403 0
+      vertex 42.8495 -51.315 4
+      vertex 42.8495 -51.315 0
+    endloop
+  endfacet
+  facet normal -0.966533 0.256541 0
+    outer loop
+      vertex 42.8495 -51.315 4
+      vertex 42.7897 -51.5403 0
+      vertex 42.7897 -51.5403 4
+    endloop
+  endfacet
+  facet normal -0.811437 -0.58444 0
+    outer loop
+      vertex 42.5199 -49.5274 0
+      vertex 42.3837 -49.3383 4
+      vertex 42.3837 -49.3383 0
+    endloop
+  endfacet
+  facet normal -0.811437 -0.58444 0
+    outer loop
+      vertex 42.3837 -49.3383 4
+      vertex 42.5199 -49.5274 0
+      vertex 42.5199 -49.5274 4
+    endloop
+  endfacet
+  facet normal 0.323425 -0.946254 0
+    outer loop
+      vertex 39.6488 -48.6123 0
+      vertex 39.8694 -48.5369 4
+      vertex 39.6488 -48.6123 4
+    endloop
+  endfacet
+  facet normal 0.323425 -0.946254 0
+    outer loop
+      vertex 39.8694 -48.5369 4
+      vertex 39.6488 -48.6123 0
+      vertex 39.8694 -48.5369 0
+    endloop
+  endfacet
+  facet normal -0.526059 -0.850448 0
+    outer loop
+      vertex 41.6757 -48.7404 0
+      vertex 41.8739 -48.863 4
+      vertex 41.6757 -48.7404 4
+    endloop
+  endfacet
+  facet normal -0.526059 -0.850448 -0
+    outer loop
+      vertex 41.8739 -48.863 4
+      vertex 41.6757 -48.7404 0
+      vertex 41.8739 -48.863 0
+    endloop
+  endfacet
+  facet normal 0.973288 0.229589 0
+    outer loop
+      vertex 38.2447 -51.4765 4
+      vertex 38.1912 -51.2497 0
+      vertex 38.1912 -51.2497 4
+    endloop
+  endfacet
+  facet normal 0.973288 0.229589 0
+    outer loop
+      vertex 38.1912 -51.2497 0
+      vertex 38.2447 -51.4765 4
+      vertex 38.2447 -51.4765 0
+    endloop
+  endfacet
+  facet normal 0.661295 -0.750126 0
+    outer loop
+      vertex 38.8712 -49.1163 0
+      vertex 39.046 -48.9622 4
+      vertex 38.8712 -49.1163 4
+    endloop
+  endfacet
+  facet normal 0.661295 -0.750126 0
+    outer loop
+      vertex 39.046 -48.9622 4
+      vertex 38.8712 -49.1163 0
+      vertex 39.046 -48.9622 0
+    endloop
+  endfacet
+  facet normal -0.132585 0.991172 0
+    outer loop
+      vertex 40.9575 -53.1547 0
+      vertex 40.7265 -53.1856 4
+      vertex 40.9575 -53.1547 4
+    endloop
+  endfacet
+  facet normal -0.132585 0.991172 0
+    outer loop
+      vertex 40.7265 -53.1856 4
+      vertex 40.9575 -53.1547 0
+      vertex 40.7265 -53.1856 0
+    endloop
+  endfacet
+  facet normal 0.160501 0.987036 -0
+    outer loop
+      vertex 40.2609 -53.1791 0
+      vertex 40.0309 -53.1417 4
+      vertex 40.2609 -53.1791 4
+    endloop
+  endfacet
+  facet normal 0.160501 0.987036 0
+    outer loop
+      vertex 40.0309 -53.1417 4
+      vertex 40.2609 -53.1791 0
+      vertex 40.0309 -53.1417 0
+    endloop
+  endfacet
+  facet normal -0.440164 -0.897917 0
+    outer loop
+      vertex 41.4664 -48.6378 0
+      vertex 41.6757 -48.7404 4
+      vertex 41.4664 -48.6378 4
+    endloop
+  endfacet
+  facet normal -0.440164 -0.897917 -0
+    outer loop
+      vertex 41.6757 -48.7404 4
+      vertex 41.4664 -48.6378 0
+      vertex 41.6757 -48.7404 0
+    endloop
+  endfacet
+  facet normal 0.811437 0.58444 0
+    outer loop
+      vertex 38.67 -52.2998 4
+      vertex 38.5338 -52.1107 0
+      vertex 38.5338 -52.1107 4
+    endloop
+  endfacet
+  facet normal 0.811437 0.58444 0
+    outer loop
+      vertex 38.5338 -52.1107 0
+      vertex 38.67 -52.2998 4
+      vertex 38.67 -52.2998 0
+    endloop
+  endfacet
+  facet normal -0.973288 -0.229589 0
+    outer loop
+      vertex 42.8625 -50.3884 0
+      vertex 42.809 -50.1616 4
+      vertex 42.809 -50.1616 0
+    endloop
+  endfacet
+  facet normal -0.973288 -0.229589 0
+    outer loop
+      vertex 42.809 -50.1616 4
+      vertex 42.8625 -50.3884 0
+      vertex 42.8625 -50.3884 4
     endloop
   endfacet
   facet normal -0.323425 0.946254 0
     outer loop
-      vertex 41.1843 -53.1012 7
+      vertex 41.4049 -53.0258 0
+      vertex 41.1843 -53.1012 4
+      vertex 41.4049 -53.0258 4
+    endloop
+  endfacet
+  facet normal -0.323425 0.946254 0
+    outer loop
+      vertex 41.1843 -53.1012 4
       vertex 41.4049 -53.0258 0
       vertex 41.1843 -53.1012 0
     endloop
   endfacet
-  facet normal 0.909822 0.414999 0
-    outer loop
-      vertex 38.4168 -51.9091 7
-      vertex 38.3201 -51.6971 0
-      vertex 38.3201 -51.6971 7
-    endloop
-  endfacet
-  facet normal 0.909822 0.414999 0
-    outer loop
-      vertex 38.3201 -51.6971 0
-      vertex 38.4168 -51.9091 7
-      vertex 38.4168 -51.9091 0
-    endloop
-  endfacet
-  facet normal 0.750313 0.661082 0
-    outer loop
-      vertex 38.8241 -52.4747 7
-      vertex 38.67 -52.2998 0
-      vertex 38.67 -52.2998 7
-    endloop
-  endfacet
-  facet normal 0.750313 0.661082 0
-    outer loop
-      vertex 38.67 -52.2998 0
-      vertex 38.8241 -52.4747 7
-      vertex 38.8241 -52.4747 0
-    endloop
-  endfacet
-  facet normal 0.850448 -0.526059 0
-    outer loop
-      vertex 38.4482 -49.6702 7
-      vertex 38.5708 -49.472 0
-      vertex 38.5708 -49.472 7
-    endloop
-  endfacet
-  facet normal 0.850448 -0.526059 0
-    outer loop
-      vertex 38.5708 -49.472 0
-      vertex 38.4482 -49.6702 7
-      vertex 38.4482 -49.6702 0
-    endloop
-  endfacet
-  facet normal 0.794821 -0.606845 0
-    outer loop
-      vertex 38.5708 -49.472 7
-      vertex 38.7122 -49.2868 0
-      vertex 38.7122 -49.2868 7
-    endloop
-  endfacet
-  facet normal 0.794821 -0.606845 0
-    outer loop
-      vertex 38.7122 -49.2868 0
-      vertex 38.5708 -49.472 7
-      vertex 38.5708 -49.472 0
-    endloop
-  endfacet
-  facet normal 0.897917 -0.440164 0
-    outer loop
-      vertex 38.3456 -49.8795 7
-      vertex 38.4482 -49.6702 0
-      vertex 38.4482 -49.6702 7
-    endloop
-  endfacet
-  facet normal 0.897917 -0.440164 0
-    outer loop
-      vertex 38.4482 -49.6702 0
-      vertex 38.3456 -49.8795 7
-      vertex 38.3456 -49.8795 0
-    endloop
-  endfacet
-  facet normal 0.936699 -0.350136 0
-    outer loop
-      vertex 38.264 -50.0978 7
-      vertex 38.3456 -49.8795 0
-      vertex 38.3456 -49.8795 7
-    endloop
-  endfacet
-  facet normal 0.936699 -0.350136 0
-    outer loop
-      vertex 38.3456 -49.8795 0
-      vertex 38.264 -50.0978 7
-      vertex 38.264 -50.0978 0
-    endloop
-  endfacet
-  facet normal 0.987036 -0.160501 0
-    outer loop
-      vertex 38.1668 -50.5531 7
-      vertex 38.2042 -50.3231 0
-      vertex 38.2042 -50.3231 7
-    endloop
-  endfacet
-  facet normal 0.987036 -0.160501 0
-    outer loop
-      vertex 38.2042 -50.3231 0
-      vertex 38.1668 -50.5531 7
-      vertex 38.1668 -50.5531 0
-    endloop
-  endfacet
-  facet normal 0.966533 -0.256541 0
-    outer loop
-      vertex 38.2042 -50.3231 7
-      vertex 38.264 -50.0978 0
-      vertex 38.264 -50.0978 7
-    endloop
-  endfacet
-  facet normal 0.966533 -0.256541 0
-    outer loop
-      vertex 38.264 -50.0978 0
-      vertex 38.2042 -50.3231 7
-      vertex 38.2042 -50.3231 0
-    endloop
-  endfacet
-  facet normal 0.998009 -0.0630728 0
-    outer loop
-      vertex 38.1521 -50.7857 7
-      vertex 38.1668 -50.5531 0
-      vertex 38.1668 -50.5531 7
-    endloop
-  endfacet
-  facet normal 0.998009 -0.0630728 0
-    outer loop
-      vertex 38.1668 -50.5531 0
-      vertex 38.1521 -50.7857 7
-      vertex 38.1521 -50.7857 0
-    endloop
-  endfacet
-  facet normal 0.999396 0.034743 0
-    outer loop
-      vertex 38.1602 -51.0187 7
-      vertex 38.1521 -50.7857 0
-      vertex 38.1521 -50.7857 7
-    endloop
-  endfacet
-  facet normal 0.999396 0.034743 0
-    outer loop
-      vertex 38.1521 -50.7857 0
-      vertex 38.1602 -51.0187 7
-      vertex 38.1602 -51.0187 0
-    endloop
-  endfacet
-  facet normal 0.973288 0.229589 0
-    outer loop
-      vertex 38.2447 -51.4765 7
-      vertex 38.1912 -51.2497 0
-      vertex 38.1912 -51.2497 7
-    endloop
-  endfacet
-  facet normal 0.973288 0.229589 0
-    outer loop
-      vertex 38.1912 -51.2497 0
-      vertex 38.2447 -51.4765 7
-      vertex 38.2447 -51.4765 0
-    endloop
-  endfacet
   facet normal 0.991115 0.133007 0
     outer loop
-      vertex 38.1912 -51.2497 7
+      vertex 38.1912 -51.2497 4
       vertex 38.1602 -51.0187 0
-      vertex 38.1602 -51.0187 7
+      vertex 38.1602 -51.0187 4
     endloop
   endfacet
   facet normal 0.991115 0.133007 0
     outer loop
       vertex 38.1602 -51.0187 0
-      vertex 38.1912 -51.2497 7
+      vertex 38.1912 -51.2497 4
       vertex 38.1912 -51.2497 0
     endloop
   endfacet
+  facet normal -0.850448 0.526059 0
+    outer loop
+      vertex 42.4829 -52.1661 0
+      vertex 42.6055 -51.9679 4
+      vertex 42.6055 -51.9679 0
+    endloop
+  endfacet
+  facet normal -0.850448 0.526059 0
+    outer loop
+      vertex 42.6055 -51.9679 4
+      vertex 42.4829 -52.1661 0
+      vertex 42.4829 -52.1661 4
+    endloop
+  endfacet
+  facet normal -0.160501 -0.987036 0
+    outer loop
+      vertex 40.7928 -48.459 0
+      vertex 41.0228 -48.4964 4
+      vertex 40.7928 -48.459 4
+    endloop
+  endfacet
+  facet normal -0.160501 -0.987036 -0
+    outer loop
+      vertex 41.0228 -48.4964 4
+      vertex 40.7928 -48.459 0
+      vertex 41.0228 -48.4964 0
+    endloop
+  endfacet
+  facet normal -0.501949 0.864897 0
+    outer loop
+      vertex 41.8185 -52.8121 0
+      vertex 41.6169 -52.9291 4
+      vertex 41.8185 -52.8121 4
+    endloop
+  endfacet
+  facet normal -0.501949 0.864897 0
+    outer loop
+      vertex 41.6169 -52.9291 4
+      vertex 41.8185 -52.8121 0
+      vertex 41.6169 -52.9291 0
+    endloop
+  endfacet
+  facet normal -0.897917 0.440164 0
+    outer loop
+      vertex 42.6055 -51.9679 0
+      vertex 42.7081 -51.7586 4
+      vertex 42.7081 -51.7586 0
+    endloop
+  endfacet
+  facet normal -0.897917 0.440164 0
+    outer loop
+      vertex 42.7081 -51.7586 4
+      vertex 42.6055 -51.9679 0
+      vertex 42.6055 -51.9679 4
+    endloop
+  endfacet
+  facet normal 0.987036 -0.160501 0
+    outer loop
+      vertex 38.1668 -50.5531 4
+      vertex 38.2042 -50.3231 0
+      vertex 38.2042 -50.3231 4
+    endloop
+  endfacet
+  facet normal 0.987036 -0.160501 0
+    outer loop
+      vertex 38.2042 -50.3231 0
+      vertex 38.1668 -50.5531 4
+      vertex 38.1668 -50.5531 0
+    endloop
+  endfacet
+  facet normal 0.0630728 0.998009 -0
+    outer loop
+      vertex 40.4935 -53.1938 0
+      vertex 40.2609 -53.1791 4
+      vertex 40.4935 -53.1938 4
+    endloop
+  endfacet
+  facet normal 0.0630728 0.998009 0
+    outer loop
+      vertex 40.2609 -53.1791 4
+      vertex 40.4935 -53.1938 0
+      vertex 40.2609 -53.1791 0
+    endloop
+  endfacet
+  facet normal -0.936699 0.350136 0
+    outer loop
+      vertex 42.7081 -51.7586 0
+      vertex 42.7897 -51.5403 4
+      vertex 42.7897 -51.5403 0
+    endloop
+  endfacet
+  facet normal -0.936699 0.350136 0
+    outer loop
+      vertex 42.7897 -51.5403 4
+      vertex 42.7081 -51.7586 0
+      vertex 42.7081 -51.7586 4
+    endloop
+  endfacet
+  facet normal 0.850448 -0.526059 0
+    outer loop
+      vertex 38.4482 -49.6702 4
+      vertex 38.5708 -49.472 0
+      vertex 38.5708 -49.472 4
+    endloop
+  endfacet
+  facet normal 0.850448 -0.526059 0
+    outer loop
+      vertex 38.5708 -49.472 0
+      vertex 38.4482 -49.6702 4
+      vertex 38.4482 -49.6702 0
+    endloop
+  endfacet
   facet normal 0.864897 0.501949 0
     outer loop
-      vertex 38.5338 -52.1107 7
+      vertex 38.5338 -52.1107 4
       vertex 38.4168 -51.9091 0
-      vertex 38.4168 -51.9091 7
+      vertex 38.4168 -51.9091 4
     endloop
   endfacet
   facet normal 0.864897 0.501949 0
     outer loop
       vertex 38.4168 -51.9091 0
-      vertex 38.5338 -52.1107 7
+      vertex 38.5338 -52.1107 4
       vertex 38.5338 -52.1107 0
     endloop
   endfacet
-  facet normal 0.946254 0.323425 0
+  facet normal 0.998009 -0.0630728 0
     outer loop
-      vertex 38.3201 -51.6971 7
-      vertex 38.2447 -51.4765 0
-      vertex 38.2447 -51.4765 7
+      vertex 38.1521 -50.7857 4
+      vertex 38.1668 -50.5531 0
+      vertex 38.1668 -50.5531 4
     endloop
   endfacet
-  facet normal 0.946254 0.323425 0
+  facet normal 0.998009 -0.0630728 0
     outer loop
-      vertex 38.2447 -51.4765 0
-      vertex 38.3201 -51.6971 7
+      vertex 38.1668 -50.5531 0
+      vertex 38.1521 -50.7857 4
+      vertex 38.1521 -50.7857 0
+    endloop
+  endfacet
+  facet normal -0.987036 0.160501 0
+    outer loop
+      vertex 42.8495 -51.315 0
+      vertex 42.8869 -51.085 4
+      vertex 42.8869 -51.085 0
+    endloop
+  endfacet
+  facet normal -0.987036 0.160501 0
+    outer loop
+      vertex 42.8869 -51.085 4
+      vertex 42.8495 -51.315 0
+      vertex 42.8495 -51.315 4
+    endloop
+  endfacet
+  facet normal -0.0630458 -0.998011 0
+    outer loop
+      vertex 40.5601 -48.4443 0
+      vertex 40.7928 -48.459 4
+      vertex 40.5601 -48.4443 4
+    endloop
+  endfacet
+  facet normal -0.0630458 -0.998011 -0
+    outer loop
+      vertex 40.7928 -48.459 4
+      vertex 40.5601 -48.4443 0
+      vertex 40.7928 -48.459 0
+    endloop
+  endfacet
+  facet normal 0.794821 -0.606845 0
+    outer loop
+      vertex 38.5708 -49.472 4
+      vertex 38.7122 -49.2868 0
+      vertex 38.7122 -49.2868 4
+    endloop
+  endfacet
+  facet normal 0.794821 -0.606845 0
+    outer loop
+      vertex 38.7122 -49.2868 0
+      vertex 38.5708 -49.472 4
+      vertex 38.5708 -49.472 0
+    endloop
+  endfacet
+  facet normal 0.256541 0.966533 -0
+    outer loop
+      vertex 40.0309 -53.1417 0
+      vertex 39.8056 -53.0819 4
+      vertex 40.0309 -53.1417 4
+    endloop
+  endfacet
+  facet normal 0.256541 0.966533 0
+    outer loop
+      vertex 39.8056 -53.0819 4
+      vertex 40.0309 -53.1417 0
+      vertex 39.8056 -53.0819 0
+    endloop
+  endfacet
+  facet normal 0.909822 0.414999 0
+    outer loop
+      vertex 38.4168 -51.9091 4
       vertex 38.3201 -51.6971 0
+      vertex 38.3201 -51.6971 4
+    endloop
+  endfacet
+  facet normal 0.909822 0.414999 0
+    outer loop
+      vertex 38.3201 -51.6971 0
+      vertex 38.4168 -51.9091 4
+      vertex 38.4168 -51.9091 0
+    endloop
+  endfacet
+  facet normal -0.998009 0.0630728 0
+    outer loop
+      vertex 42.8869 -51.085 0
+      vertex 42.9016 -50.8524 4
+      vertex 42.9016 -50.8524 0
+    endloop
+  endfacet
+  facet normal -0.998009 0.0630728 0
+    outer loop
+      vertex 42.9016 -50.8524 4
+      vertex 42.8869 -51.085 0
+      vertex 42.8869 -51.085 4
+    endloop
+  endfacet
+  facet normal 0.936699 -0.350136 0
+    outer loop
+      vertex 38.264 -50.0978 4
+      vertex 38.3456 -49.8795 0
+      vertex 38.3456 -49.8795 4
+    endloop
+  endfacet
+  facet normal 0.936699 -0.350136 0
+    outer loop
+      vertex 38.3456 -49.8795 0
+      vertex 38.264 -50.0978 4
+      vertex 38.264 -50.0978 0
+    endloop
+  endfacet
+  facet normal 0.414999 -0.909822 0
+    outer loop
+      vertex 39.4368 -48.709 0
+      vertex 39.6488 -48.6123 4
+      vertex 39.4368 -48.709 4
+    endloop
+  endfacet
+  facet normal 0.414999 -0.909822 0
+    outer loop
+      vertex 39.6488 -48.6123 4
+      vertex 39.4368 -48.709 0
+      vertex 39.6488 -48.6123 0
+    endloop
+  endfacet
+  facet normal 0.999396 0.034743 0
+    outer loop
+      vertex 38.1602 -51.0187 4
+      vertex 38.1521 -50.7857 0
+      vertex 38.1521 -50.7857 4
+    endloop
+  endfacet
+  facet normal 0.999396 0.034743 0
+    outer loop
+      vertex 38.1521 -50.7857 0
+      vertex 38.1602 -51.0187 4
+      vertex 38.1602 -51.0187 0
+    endloop
+  endfacet
+  facet normal -0.350136 -0.936699 0
+    outer loop
+      vertex 41.2481 -48.5562 0
+      vertex 41.4664 -48.6378 4
+      vertex 41.2481 -48.5562 4
+    endloop
+  endfacet
+  facet normal -0.350136 -0.936699 -0
+    outer loop
+      vertex 41.4664 -48.6378 4
+      vertex 41.2481 -48.5562 0
+      vertex 41.4664 -48.6378 0
+    endloop
+  endfacet
+  facet normal 0.607116 0.794614 -0
+    outer loop
+      vertex 39.1798 -52.7751 0
+      vertex 38.9946 -52.6336 4
+      vertex 39.1798 -52.7751 4
+    endloop
+  endfacet
+  facet normal 0.607116 0.794614 0
+    outer loop
+      vertex 38.9946 -52.6336 4
+      vertex 39.1798 -52.7751 0
+      vertex 38.9946 -52.6336 0
+    endloop
+  endfacet
+  facet normal 0.584237 -0.811583 0
+    outer loop
+      vertex 39.046 -48.9622 0
+      vertex 39.2352 -48.826 4
+      vertex 39.046 -48.9622 4
+    endloop
+  endfacet
+  facet normal 0.584237 -0.811583 0
+    outer loop
+      vertex 39.2352 -48.826 4
+      vertex 39.046 -48.9622 0
+      vertex 39.2352 -48.826 0
+    endloop
+  endfacet
+  facet normal 0.897917 -0.440164 0
+    outer loop
+      vertex 38.3456 -49.8795 4
+      vertex 38.4482 -49.6702 0
+      vertex 38.4482 -49.6702 4
+    endloop
+  endfacet
+  facet normal 0.897917 -0.440164 0
+    outer loop
+      vertex 38.4482 -49.6702 0
+      vertex 38.3456 -49.8795 4
+      vertex 38.3456 -49.8795 0
+    endloop
+  endfacet
+  facet normal 0.229589 -0.973288 0
+    outer loop
+      vertex 39.8694 -48.5369 0
+      vertex 40.0962 -48.4834 4
+      vertex 39.8694 -48.5369 4
+    endloop
+  endfacet
+  facet normal 0.229589 -0.973288 0
+    outer loop
+      vertex 40.0962 -48.4834 4
+      vertex 39.8694 -48.5369 0
+      vertex 40.0962 -48.4834 0
+    endloop
+  endfacet
+  facet normal -0.623491 0.781831 0
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 35.826 -60.9631 7
+      vertex 51.4626 -48.4933 7
+    endloop
+  endfacet
+  facet normal -0.623491 0.781831 0
+    outer loop
+      vertex 35.826 -60.9631 7
+      vertex 51.4626 -48.4933 4
+      vertex 35.826 -60.9631 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.8934 -50.6194 4
+      vertex 42.9016 -50.8524 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.8625 -50.3884 4
+      vertex 42.8934 -50.6194 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.809 -50.1616 4
+      vertex 42.8625 -50.3884 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.7336 -49.941 4
+      vertex 42.809 -50.1616 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.6369 -49.729 4
+      vertex 42.7336 -49.941 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.5199 -49.5274 4
+      vertex 42.6369 -49.729 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 42.3837 -49.3383 4
+      vertex 42.5199 -49.5274 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 42.2296 -49.1634 4
+      vertex 42.3837 -49.3383 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 42.0591 -49.0045 4
+      vertex 42.2296 -49.1634 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 41.8739 -48.863 4
+      vertex 42.0591 -49.0045 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 41.6757 -48.7404 4
+      vertex 41.8739 -48.863 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 41.4664 -48.6378 4
+      vertex 41.6757 -48.7404 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 41.2481 -48.5562 4
+      vertex 41.4664 -48.6378 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 41.0228 -48.4964 4
+      vertex 41.2481 -48.5562 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 40.7928 -48.459 4
+      vertex 41.0228 -48.4964 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 40.5601 -48.4443 4
+      vertex 40.7928 -48.459 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 40.3272 -48.4524 4
+      vertex 40.5601 -48.4443 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 40.0962 -48.4834 4
+      vertex 40.3272 -48.4524 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 39.8694 -48.5369 4
+      vertex 40.0962 -48.4834 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 39.6488 -48.6123 4
+      vertex 39.8694 -48.5369 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 39.4368 -48.709 4
+      vertex 39.6488 -48.6123 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 39.2352 -48.826 4
+      vertex 39.4368 -48.709 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 45.2277 -40.675 4
+      vertex 39.046 -48.9622 4
+      vertex 39.2352 -48.826 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 -53.1448 4
+      vertex 39.046 -48.9622 4
+      vertex 45.2277 -40.675 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.046 -48.9622 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.8712 -49.1163 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.8712 -49.1163 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.7122 -49.2868 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 -53.1448 4
+      vertex 38.1521 -50.7857 4
+      vertex 38.1668 -50.5531 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.5911 -53.1448 4
+      vertex 38.1668 -50.5531 4
+      vertex 38.2042 -50.3231 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1521 -50.7857 4
+      vertex 29.5911 -53.1448 4
+      vertex 35.826 -60.9631 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.264 -50.0978 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.2042 -50.3231 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.3456 -49.8795 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.264 -50.0978 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.4482 -49.6702 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.3456 -49.8795 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.5708 -49.472 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.4482 -49.6702 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.7122 -49.2868 4
+      vertex 29.5911 -53.1448 4
+      vertex 38.5708 -49.472 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.3837 -49.3383 4
+      vertex 51.4626 -48.4933 4
+      vertex 45.2277 -40.675 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.8869 -51.085 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.9016 -50.8524 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.8495 -51.315 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.8869 -51.085 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.7897 -51.5403 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.8495 -51.315 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.7081 -51.7586 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.7897 -51.5403 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.6055 -51.9679 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.7081 -51.7586 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.4829 -52.1661 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.6055 -51.9679 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.3414 -52.3513 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.4829 -52.1661 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.1825 -52.5218 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.3414 -52.3513 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 42.0076 -52.6759 4
+      vertex 51.4626 -48.4933 4
+      vertex 42.1825 -52.5218 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 -60.9631 4
+      vertex 42.0076 -52.6759 4
+      vertex 41.8185 -52.8121 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 -60.9631 4
+      vertex 41.8185 -52.8121 4
+      vertex 41.6169 -52.9291 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 -60.9631 4
+      vertex 41.6169 -52.9291 4
+      vertex 41.4049 -53.0258 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 42.0076 -52.6759 4
+      vertex 35.826 -60.9631 4
+      vertex 51.4626 -48.4933 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 41.1843 -53.1012 4
+      vertex 35.826 -60.9631 4
+      vertex 41.4049 -53.0258 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.9575 -53.1547 4
+      vertex 35.826 -60.9631 4
+      vertex 41.1843 -53.1012 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.7265 -53.1856 4
+      vertex 35.826 -60.9631 4
+      vertex 40.9575 -53.1547 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 40.4935 -53.1938 4
+      vertex 35.826 -60.9631 4
+      vertex 40.7265 -53.1856 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.2609 -53.1791 4
+      vertex 35.826 -60.9631 4
+      vertex 40.4935 -53.1938 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.0309 -53.1417 4
+      vertex 35.826 -60.9631 4
+      vertex 40.2609 -53.1791 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.8056 -53.0819 4
+      vertex 35.826 -60.9631 4
+      vertex 40.0309 -53.1417 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.5873 -53.0003 4
+      vertex 35.826 -60.9631 4
+      vertex 39.8056 -53.0819 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.378 -52.8977 4
+      vertex 35.826 -60.9631 4
+      vertex 39.5873 -53.0003 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 39.1798 -52.7751 4
+      vertex 35.826 -60.9631 4
+      vertex 39.378 -52.8977 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.9946 -52.6336 4
+      vertex 35.826 -60.9631 4
+      vertex 39.1798 -52.7751 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.8241 -52.4747 4
+      vertex 35.826 -60.9631 4
+      vertex 38.9946 -52.6336 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.67 -52.2998 4
+      vertex 35.826 -60.9631 4
+      vertex 38.8241 -52.4747 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.5338 -52.1107 4
+      vertex 35.826 -60.9631 4
+      vertex 38.67 -52.2998 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.4168 -51.9091 4
+      vertex 35.826 -60.9631 4
+      vertex 38.5338 -52.1107 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.3201 -51.6971 4
+      vertex 35.826 -60.9631 4
+      vertex 38.4168 -51.9091 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.2447 -51.4765 4
+      vertex 35.826 -60.9631 4
+      vertex 38.3201 -51.6971 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1912 -51.2497 4
+      vertex 35.826 -60.9631 4
+      vertex 38.2447 -51.4765 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1602 -51.0187 4
+      vertex 35.826 -60.9631 4
+      vertex 38.1912 -51.2497 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.826 -60.9631 4
+      vertex 38.1602 -51.0187 4
+      vertex 38.1521 -50.7857 4
+    endloop
+  endfacet
+  facet normal 0.623491 -0.781831 0
+    outer loop
+      vertex 29.5911 -53.1448 4
+      vertex 45.2277 -40.675 7
+      vertex 29.5911 -53.1448 7
+    endloop
+  endfacet
+  facet normal 0.623491 -0.781831 0
+    outer loop
+      vertex 45.2277 -40.675 7
+      vertex 29.5911 -53.1448 4
+      vertex 45.2277 -40.675 4
+    endloop
+  endfacet
+  facet normal -0.781831 -0.623491 0
+    outer loop
+      vertex 51.4626 -48.4933 4
+      vertex 45.2277 -40.675 7
+      vertex 45.2277 -40.675 4
+    endloop
+  endfacet
+  facet normal -0.781831 -0.623491 0
+    outer loop
+      vertex 45.2277 -40.675 7
+      vertex 51.4626 -48.4933 4
+      vertex 51.4626 -48.4933 7
+    endloop
+  endfacet
+  facet normal 0.781831 0.623491 0
+    outer loop
+      vertex 35.826 -60.9631 7
+      vertex 29.5911 -53.1448 4
+      vertex 29.5911 -53.1448 7
+    endloop
+  endfacet
+  facet normal 0.781831 0.623491 0
+    outer loop
+      vertex 29.5911 -53.1448 4
+      vertex 35.826 -60.9631 7
+      vertex 35.826 -60.9631 4
     endloop
   endfacet
   facet normal 1 -0 0
@@ -12487,900 +12739,1432 @@ solid OpenSCAD_Model
       vertex 53.625 -25.8244 3.5
     endloop
   endfacet
-  facet normal -0.85758 -0.514351 0
-    outer loop
-      vertex 67.0946 1.11957 0
-      vertex 66.9747 1.31948 7
-      vertex 66.9747 1.31948 0
-    endloop
-  endfacet
-  facet normal -0.85758 -0.514351 0
-    outer loop
-      vertex 66.9747 1.31948 7
-      vertex 67.0946 1.11957 0
-      vertex 67.0946 1.11957 7
-    endloop
-  endfacet
-  facet normal -0.33682 -0.941569 0
-    outer loop
-      vertex 65.6894 2.27273 0
-      vertex 65.9089 2.19421 7
-      vertex 65.6894 2.27273 7
-    endloop
-  endfacet
-  facet normal -0.33682 -0.941569 -0
-    outer loop
-      vertex 65.9089 2.19421 7
-      vertex 65.6894 2.27273 0
-      vertex 65.9089 2.19421 0
-    endloop
-  endfacet
-  facet normal 0.427542 -0.903995 0
-    outer loop
-      vertex 63.8804 2.09456 0
-      vertex 64.0911 2.19421 7
-      vertex 63.8804 2.09456 7
-    endloop
-  endfacet
-  facet normal 0.427542 -0.903995 0
-    outer loop
-      vertex 64.0911 2.19421 7
-      vertex 63.8804 2.09456 0
-      vertex 64.0911 2.19421 0
-    endloop
-  endfacet
-  facet normal 0.941571 -0.336815 0
-    outer loop
-      vertex 62.7273 0.689425 7
-      vertex 62.8058 0.908873 0
-      vertex 62.8058 0.908873 7
-    endloop
-  endfacet
-  facet normal 0.941571 -0.336815 0
-    outer loop
-      vertex 62.8058 0.908873 0
-      vertex 62.7273 0.689425 7
-      vertex 62.7273 0.689425 0
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489126 0
-    outer loop
-      vertex 67.3636 -0.23279 0
-      vertex 67.375 0 7
-      vertex 67.375 0 0
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489126 0
-    outer loop
-      vertex 67.375 0 7
-      vertex 67.3636 -0.23279 0
-      vertex 67.3636 -0.23279 7
-    endloop
-  endfacet
   facet normal -0.514117 -0.85772 0
     outer loop
       vertex 66.1196 2.09456 0
-      vertex 66.3195 1.97474 7
-      vertex 66.1196 2.09456 7
+      vertex 66.3195 1.97474 4
+      vertex 66.1196 2.09456 4
     endloop
   endfacet
   facet normal -0.514117 -0.85772 -0
     outer loop
-      vertex 66.3195 1.97474 7
+      vertex 66.3195 1.97474 4
       vertex 66.1196 2.09456 0
       vertex 66.3195 1.97474 0
-    endloop
-  endfacet
-  facet normal 0.803283 -0.595597 0
-    outer loop
-      vertex 63.0253 1.31948 7
-      vertex 63.1641 1.50668 0
-      vertex 63.1641 1.50668 7
-    endloop
-  endfacet
-  facet normal 0.803283 -0.595597 0
-    outer loop
-      vertex 63.1641 1.50668 0
-      vertex 63.0253 1.31948 7
-      vertex 63.0253 1.31948 0
-    endloop
-  endfacet
-  facet normal 0.24296 -0.970036 0
-    outer loop
-      vertex 64.3106 2.27273 0
-      vertex 64.5367 2.32936 7
-      vertex 64.3106 2.27273 7
-    endloop
-  endfacet
-  facet normal 0.24296 -0.970036 0
-    outer loop
-      vertex 64.5367 2.32936 7
-      vertex 64.3106 2.27273 0
-      vertex 64.5367 2.32936 0
     endloop
   endfacet
   facet normal -0.989176 -0.146736 0
     outer loop
       vertex 67.3636 0.23279 0
-      vertex 67.3294 0.463339 7
+      vertex 67.3294 0.463339 4
       vertex 67.3294 0.463339 0
     endloop
   endfacet
   facet normal -0.989176 -0.146736 0
     outer loop
-      vertex 67.3294 0.463339 7
+      vertex 67.3294 0.463339 4
       vertex 67.3636 0.23279 0
-      vertex 67.3636 0.23279 7
-    endloop
-  endfacet
-  facet normal -0.803283 -0.595597 0
-    outer loop
-      vertex 66.9747 1.31948 0
-      vertex 66.8359 1.50668 7
-      vertex 66.8359 1.50668 0
-    endloop
-  endfacet
-  facet normal -0.803283 -0.595597 0
-    outer loop
-      vertex 66.8359 1.50668 7
-      vertex 66.9747 1.31948 0
-      vertex 66.9747 1.31948 7
-    endloop
-  endfacet
-  facet normal -0.671544 -0.740964 0
-    outer loop
-      vertex 66.5067 1.8359 0
-      vertex 66.6794 1.67938 7
-      vertex 66.5067 1.8359 7
-    endloop
-  endfacet
-  facet normal -0.671544 -0.740964 -0
-    outer loop
-      vertex 66.6794 1.67938 7
-      vertex 66.5067 1.8359 0
-      vertex 66.6794 1.67938 0
-    endloop
-  endfacet
-  facet normal 0.0490817 -0.998795 0
-    outer loop
-      vertex 64.7672 2.36356 0
-      vertex 65 2.375 7
-      vertex 64.7672 2.36356 7
-    endloop
-  endfacet
-  facet normal 0.0490817 -0.998795 0
-    outer loop
-      vertex 65 2.375 7
-      vertex 64.7672 2.36356 0
-      vertex 65 2.375 0
-    endloop
-  endfacet
-  facet normal -0.24296 -0.970036 0
-    outer loop
-      vertex 65.4633 2.32936 0
-      vertex 65.6894 2.27273 7
-      vertex 65.4633 2.32936 7
-    endloop
-  endfacet
-  facet normal -0.24296 -0.970036 -0
-    outer loop
-      vertex 65.6894 2.27273 7
-      vertex 65.4633 2.32936 0
-      vertex 65.6894 2.27273 0
-    endloop
-  endfacet
-  facet normal -0.146766 -0.989171 0
-    outer loop
-      vertex 65.2328 2.36356 0
-      vertex 65.4633 2.32936 7
-      vertex 65.2328 2.36356 7
-    endloop
-  endfacet
-  facet normal -0.146766 -0.989171 -0
-    outer loop
-      vertex 65.4633 2.32936 7
-      vertex 65.2328 2.36356 0
-      vertex 65.4633 2.32936 0
-    endloop
-  endfacet
-  facet normal -0.427542 -0.903995 0
-    outer loop
-      vertex 65.9089 2.19421 0
-      vertex 66.1196 2.09456 7
-      vertex 65.9089 2.19421 7
-    endloop
-  endfacet
-  facet normal -0.427542 -0.903995 -0
-    outer loop
-      vertex 66.1196 2.09456 7
-      vertex 65.9089 2.19421 0
-      vertex 66.1196 2.09456 0
-    endloop
-  endfacet
-  facet normal -0.595708 -0.803201 0
-    outer loop
-      vertex 66.3195 1.97474 0
-      vertex 66.5067 1.8359 7
-      vertex 66.3195 1.97474 7
-    endloop
-  endfacet
-  facet normal -0.595708 -0.803201 -0
-    outer loop
-      vertex 66.5067 1.8359 7
-      vertex 66.3195 1.97474 0
-      vertex 66.5067 1.8359 0
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489126 0
-    outer loop
-      vertex 62.6364 -0.23279 7
-      vertex 62.625 0 0
-      vertex 62.625 0 7
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489126 0
-    outer loop
-      vertex 62.625 0 0
-      vertex 62.6364 -0.23279 7
-      vertex 62.6364 -0.23279 0
-    endloop
-  endfacet
-  facet normal 0.969962 -0.243256 0
-    outer loop
-      vertex 62.6706 0.463339 7
-      vertex 62.7273 0.689425 0
-      vertex 62.7273 0.689425 7
-    endloop
-  endfacet
-  facet normal 0.969962 -0.243256 0
-    outer loop
-      vertex 62.7273 0.689425 0
-      vertex 62.6706 0.463339 7
-      vertex 62.6706 0.463339 0
-    endloop
-  endfacet
-  facet normal 0.989176 -0.146736 0
-    outer loop
-      vertex 62.6364 0.23279 7
-      vertex 62.6706 0.463339 0
-      vertex 62.6706 0.463339 7
-    endloop
-  endfacet
-  facet normal 0.989176 -0.146736 0
-    outer loop
-      vertex 62.6706 0.463339 0
-      vertex 62.6364 0.23279 7
-      vertex 62.6364 0.23279 0
-    endloop
-  endfacet
-  facet normal 0.904076 -0.427372 0
-    outer loop
-      vertex 62.8058 0.908873 7
-      vertex 62.9054 1.11957 0
-      vertex 62.9054 1.11957 7
-    endloop
-  endfacet
-  facet normal 0.904076 -0.427372 0
-    outer loop
-      vertex 62.9054 1.11957 0
-      vertex 62.8058 0.908873 7
-      vertex 62.8058 0.908873 0
-    endloop
-  endfacet
-  facet normal 0.85758 -0.514351 0
-    outer loop
-      vertex 62.9054 1.11957 7
-      vertex 63.0253 1.31948 0
-      vertex 63.0253 1.31948 7
-    endloop
-  endfacet
-  facet normal 0.85758 -0.514351 0
-    outer loop
-      vertex 63.0253 1.31948 0
-      vertex 62.9054 1.11957 7
-      vertex 62.9054 1.11957 0
-    endloop
-  endfacet
-  facet normal 0.33682 -0.941569 0
-    outer loop
-      vertex 64.0911 2.19421 0
-      vertex 64.3106 2.27273 7
-      vertex 64.0911 2.19421 7
-    endloop
-  endfacet
-  facet normal 0.33682 -0.941569 0
-    outer loop
-      vertex 64.3106 2.27273 7
-      vertex 64.0911 2.19421 0
-      vertex 64.3106 2.27273 0
-    endloop
-  endfacet
-  facet normal 0.146766 -0.989171 0
-    outer loop
-      vertex 64.5367 2.32936 0
-      vertex 64.7672 2.36356 7
-      vertex 64.5367 2.32936 7
-    endloop
-  endfacet
-  facet normal 0.146766 -0.989171 0
-    outer loop
-      vertex 64.7672 2.36356 7
-      vertex 64.5367 2.32936 0
-      vertex 64.7672 2.36356 0
-    endloop
-  endfacet
-  facet normal 0.595708 -0.803201 0
-    outer loop
-      vertex 63.4933 1.8359 0
-      vertex 63.6805 1.97474 7
-      vertex 63.4933 1.8359 7
-    endloop
-  endfacet
-  facet normal 0.595708 -0.803201 0
-    outer loop
-      vertex 63.6805 1.97474 7
-      vertex 63.4933 1.8359 0
-      vertex 63.6805 1.97474 0
-    endloop
-  endfacet
-  facet normal 0.671544 -0.740964 0
-    outer loop
-      vertex 63.3206 1.67938 0
-      vertex 63.4933 1.8359 7
-      vertex 63.3206 1.67938 7
-    endloop
-  endfacet
-  facet normal 0.671544 -0.740964 0
-    outer loop
-      vertex 63.4933 1.8359 7
-      vertex 63.3206 1.67938 0
-      vertex 63.4933 1.8359 0
-    endloop
-  endfacet
-  facet normal 0.514117 -0.85772 0
-    outer loop
-      vertex 63.6805 1.97474 0
-      vertex 63.8804 2.09456 7
-      vertex 63.6805 1.97474 7
-    endloop
-  endfacet
-  facet normal 0.514117 -0.85772 0
-    outer loop
-      vertex 63.8804 2.09456 7
-      vertex 63.6805 1.97474 0
-      vertex 63.8804 2.09456 0
-    endloop
-  endfacet
-  facet normal 0.741007 -0.671497 0
-    outer loop
-      vertex 63.1641 1.50668 7
-      vertex 63.3206 1.67938 0
-      vertex 63.3206 1.67938 7
-    endloop
-  endfacet
-  facet normal 0.741007 -0.671497 0
-    outer loop
-      vertex 63.3206 1.67938 0
-      vertex 63.1641 1.50668 7
-      vertex 63.1641 1.50668 0
+      vertex 67.3636 0.23279 4
     endloop
   endfacet
   facet normal -0.998803 -0.0489126 0
     outer loop
       vertex 67.375 0 0
-      vertex 67.3636 0.23279 7
+      vertex 67.3636 0.23279 4
       vertex 67.3636 0.23279 0
     endloop
   endfacet
   facet normal -0.998803 -0.0489126 0
     outer loop
-      vertex 67.3636 0.23279 7
+      vertex 67.3636 0.23279 4
       vertex 67.375 0 0
-      vertex 67.375 0 7
-    endloop
-  endfacet
-  facet normal -0.969962 0.243256 0
-    outer loop
-      vertex 67.2727 -0.689425 0
-      vertex 67.3294 -0.463339 7
-      vertex 67.3294 -0.463339 0
-    endloop
-  endfacet
-  facet normal -0.969962 0.243256 0
-    outer loop
-      vertex 67.3294 -0.463339 7
-      vertex 67.2727 -0.689425 0
-      vertex 67.2727 -0.689425 7
-    endloop
-  endfacet
-  facet normal 0.989176 0.146736 0
-    outer loop
-      vertex 62.6706 -0.463339 7
-      vertex 62.6364 -0.23279 0
-      vertex 62.6364 -0.23279 7
-    endloop
-  endfacet
-  facet normal 0.989176 0.146736 0
-    outer loop
-      vertex 62.6364 -0.23279 0
-      vertex 62.6706 -0.463339 7
-      vertex 62.6706 -0.463339 0
-    endloop
-  endfacet
-  facet normal -0.146766 0.989171 0
-    outer loop
-      vertex 65.4633 -2.32936 0
-      vertex 65.2328 -2.36356 7
-      vertex 65.4633 -2.32936 7
-    endloop
-  endfacet
-  facet normal -0.146766 0.989171 0
-    outer loop
-      vertex 65.2328 -2.36356 7
-      vertex 65.4633 -2.32936 0
-      vertex 65.2328 -2.36356 0
-    endloop
-  endfacet
-  facet normal -0.427542 0.903995 0
-    outer loop
-      vertex 66.1196 -2.09456 0
-      vertex 65.9089 -2.19421 7
-      vertex 66.1196 -2.09456 7
-    endloop
-  endfacet
-  facet normal -0.427542 0.903995 0
-    outer loop
-      vertex 65.9089 -2.19421 7
-      vertex 66.1196 -2.09456 0
-      vertex 65.9089 -2.19421 0
-    endloop
-  endfacet
-  facet normal -0.904076 -0.427372 0
-    outer loop
-      vertex 67.1942 0.908873 0
-      vertex 67.0946 1.11957 7
-      vertex 67.0946 1.11957 0
-    endloop
-  endfacet
-  facet normal -0.904076 -0.427372 0
-    outer loop
-      vertex 67.0946 1.11957 7
-      vertex 67.1942 0.908873 0
-      vertex 67.1942 0.908873 7
-    endloop
-  endfacet
-  facet normal -0.941571 -0.336815 0
-    outer loop
-      vertex 67.2727 0.689425 0
-      vertex 67.1942 0.908873 7
-      vertex 67.1942 0.908873 0
-    endloop
-  endfacet
-  facet normal -0.941571 -0.336815 0
-    outer loop
-      vertex 67.1942 0.908873 7
-      vertex 67.2727 0.689425 0
-      vertex 67.2727 0.689425 7
-    endloop
-  endfacet
-  facet normal -0.741007 -0.671497 0
-    outer loop
-      vertex 66.8359 1.50668 0
-      vertex 66.6794 1.67938 7
-      vertex 66.6794 1.67938 0
-    endloop
-  endfacet
-  facet normal -0.741007 -0.671497 0
-    outer loop
-      vertex 66.6794 1.67938 7
-      vertex 66.8359 1.50668 0
-      vertex 66.8359 1.50668 7
-    endloop
-  endfacet
-  facet normal -0.0490817 -0.998795 0
-    outer loop
-      vertex 65 2.375 0
-      vertex 65.2328 2.36356 7
-      vertex 65 2.375 7
-    endloop
-  endfacet
-  facet normal -0.0490817 -0.998795 -0
-    outer loop
-      vertex 65.2328 2.36356 7
-      vertex 65 2.375 0
-      vertex 65.2328 2.36356 0
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489126 0
-    outer loop
-      vertex 62.625 0 7
-      vertex 62.6364 0.23279 0
-      vertex 62.6364 0.23279 7
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489126 0
-    outer loop
-      vertex 62.6364 0.23279 0
-      vertex 62.625 0 7
-      vertex 62.625 0 0
-    endloop
-  endfacet
-  facet normal -0.741007 0.671497 0
-    outer loop
-      vertex 66.6794 -1.67938 0
-      vertex 66.8359 -1.50668 7
-      vertex 66.8359 -1.50668 0
-    endloop
-  endfacet
-  facet normal -0.741007 0.671497 0
-    outer loop
-      vertex 66.8359 -1.50668 7
-      vertex 66.6794 -1.67938 0
-      vertex 66.6794 -1.67938 7
-    endloop
-  endfacet
-  facet normal -0.85758 0.514351 0
-    outer loop
-      vertex 66.9747 -1.31948 0
-      vertex 67.0946 -1.11957 7
-      vertex 67.0946 -1.11957 0
-    endloop
-  endfacet
-  facet normal -0.85758 0.514351 0
-    outer loop
-      vertex 67.0946 -1.11957 7
-      vertex 66.9747 -1.31948 0
-      vertex 66.9747 -1.31948 7
-    endloop
-  endfacet
-  facet normal -0.904076 0.427372 0
-    outer loop
-      vertex 67.0946 -1.11957 0
-      vertex 67.1942 -0.908873 7
-      vertex 67.1942 -0.908873 0
-    endloop
-  endfacet
-  facet normal -0.904076 0.427372 0
-    outer loop
-      vertex 67.1942 -0.908873 7
-      vertex 67.0946 -1.11957 0
-      vertex 67.0946 -1.11957 7
-    endloop
-  endfacet
-  facet normal 0.0490817 0.998795 -0
-    outer loop
-      vertex 65 -2.375 0
-      vertex 64.7672 -2.36356 7
-      vertex 65 -2.375 7
-    endloop
-  endfacet
-  facet normal 0.0490817 0.998795 0
-    outer loop
-      vertex 64.7672 -2.36356 7
-      vertex 65 -2.375 0
-      vertex 64.7672 -2.36356 0
-    endloop
-  endfacet
-  facet normal -0.24296 0.970036 0
-    outer loop
-      vertex 65.6894 -2.27273 0
-      vertex 65.4633 -2.32936 7
-      vertex 65.6894 -2.27273 7
-    endloop
-  endfacet
-  facet normal -0.24296 0.970036 0
-    outer loop
-      vertex 65.4633 -2.32936 7
-      vertex 65.6894 -2.27273 0
-      vertex 65.4633 -2.32936 0
-    endloop
-  endfacet
-  facet normal -0.33682 0.941569 0
-    outer loop
-      vertex 65.9089 -2.19421 0
-      vertex 65.6894 -2.27273 7
-      vertex 65.9089 -2.19421 7
-    endloop
-  endfacet
-  facet normal -0.33682 0.941569 0
-    outer loop
-      vertex 65.6894 -2.27273 7
-      vertex 65.9089 -2.19421 0
-      vertex 65.6894 -2.27273 0
+      vertex 67.375 0 4
     endloop
   endfacet
   facet normal -0.969962 -0.243256 0
     outer loop
       vertex 67.3294 0.463339 0
-      vertex 67.2727 0.689425 7
+      vertex 67.2727 0.689425 4
       vertex 67.2727 0.689425 0
     endloop
   endfacet
   facet normal -0.969962 -0.243256 0
     outer loop
-      vertex 67.2727 0.689425 7
+      vertex 67.2727 0.689425 4
       vertex 67.3294 0.463339 0
-      vertex 67.3294 0.463339 7
+      vertex 67.3294 0.463339 4
     endloop
   endfacet
-  facet normal -0.989176 0.146736 0
+  facet normal -0.33682 0.941569 0
     outer loop
-      vertex 67.3294 -0.463339 0
-      vertex 67.3636 -0.23279 7
-      vertex 67.3636 -0.23279 0
+      vertex 65.9089 -2.19421 0
+      vertex 65.6894 -2.27273 4
+      vertex 65.9089 -2.19421 4
     endloop
   endfacet
-  facet normal -0.989176 0.146736 0
+  facet normal -0.33682 0.941569 0
     outer loop
-      vertex 67.3636 -0.23279 7
-      vertex 67.3294 -0.463339 0
-      vertex 67.3294 -0.463339 7
-    endloop
-  endfacet
-  facet normal -0.671544 0.740964 0
-    outer loop
-      vertex 66.6794 -1.67938 0
-      vertex 66.5067 -1.8359 7
-      vertex 66.6794 -1.67938 7
-    endloop
-  endfacet
-  facet normal -0.671544 0.740964 0
-    outer loop
-      vertex 66.5067 -1.8359 7
-      vertex 66.6794 -1.67938 0
-      vertex 66.5067 -1.8359 0
-    endloop
-  endfacet
-  facet normal -0.595708 0.803201 0
-    outer loop
-      vertex 66.5067 -1.8359 0
-      vertex 66.3195 -1.97474 7
-      vertex 66.5067 -1.8359 7
-    endloop
-  endfacet
-  facet normal -0.595708 0.803201 0
-    outer loop
-      vertex 66.3195 -1.97474 7
-      vertex 66.5067 -1.8359 0
-      vertex 66.3195 -1.97474 0
-    endloop
-  endfacet
-  facet normal -0.514117 0.85772 0
-    outer loop
-      vertex 66.3195 -1.97474 0
-      vertex 66.1196 -2.09456 7
-      vertex 66.3195 -1.97474 7
-    endloop
-  endfacet
-  facet normal -0.514117 0.85772 0
-    outer loop
-      vertex 66.1196 -2.09456 7
-      vertex 66.3195 -1.97474 0
-      vertex 66.1196 -2.09456 0
-    endloop
-  endfacet
-  facet normal -0.803283 0.595597 0
-    outer loop
-      vertex 66.8359 -1.50668 0
-      vertex 66.9747 -1.31948 7
-      vertex 66.9747 -1.31948 0
-    endloop
-  endfacet
-  facet normal -0.803283 0.595597 0
-    outer loop
-      vertex 66.9747 -1.31948 7
-      vertex 66.8359 -1.50668 0
-      vertex 66.8359 -1.50668 7
-    endloop
-  endfacet
-  facet normal -0.941571 0.336815 0
-    outer loop
-      vertex 67.1942 -0.908873 0
-      vertex 67.2727 -0.689425 7
-      vertex 67.2727 -0.689425 0
-    endloop
-  endfacet
-  facet normal -0.941571 0.336815 0
-    outer loop
-      vertex 67.2727 -0.689425 7
-      vertex 67.1942 -0.908873 0
-      vertex 67.1942 -0.908873 7
-    endloop
-  endfacet
-  facet normal 0.24296 0.970036 -0
-    outer loop
-      vertex 64.5367 -2.32936 0
-      vertex 64.3106 -2.27273 7
-      vertex 64.5367 -2.32936 7
-    endloop
-  endfacet
-  facet normal 0.24296 0.970036 0
-    outer loop
-      vertex 64.3106 -2.27273 7
-      vertex 64.5367 -2.32936 0
-      vertex 64.3106 -2.27273 0
-    endloop
-  endfacet
-  facet normal -0.0490817 0.998795 0
-    outer loop
-      vertex 65.2328 -2.36356 0
-      vertex 65 -2.375 7
-      vertex 65.2328 -2.36356 7
-    endloop
-  endfacet
-  facet normal -0.0490817 0.998795 0
-    outer loop
-      vertex 65 -2.375 7
-      vertex 65.2328 -2.36356 0
-      vertex 65 -2.375 0
-    endloop
-  endfacet
-  facet normal 0.941571 0.336815 0
-    outer loop
-      vertex 62.8058 -0.908873 7
-      vertex 62.7273 -0.689425 0
-      vertex 62.7273 -0.689425 7
-    endloop
-  endfacet
-  facet normal 0.941571 0.336815 0
-    outer loop
-      vertex 62.7273 -0.689425 0
-      vertex 62.8058 -0.908873 7
-      vertex 62.8058 -0.908873 0
-    endloop
-  endfacet
-  facet normal 0.969962 0.243256 0
-    outer loop
-      vertex 62.7273 -0.689425 7
-      vertex 62.6706 -0.463339 0
-      vertex 62.6706 -0.463339 7
-    endloop
-  endfacet
-  facet normal 0.969962 0.243256 0
-    outer loop
-      vertex 62.6706 -0.463339 0
-      vertex 62.7273 -0.689425 7
-      vertex 62.7273 -0.689425 0
-    endloop
-  endfacet
-  facet normal 0.904076 0.427372 0
-    outer loop
-      vertex 62.9054 -1.11957 7
-      vertex 62.8058 -0.908873 0
-      vertex 62.8058 -0.908873 7
-    endloop
-  endfacet
-  facet normal 0.904076 0.427372 0
-    outer loop
-      vertex 62.8058 -0.908873 0
-      vertex 62.9054 -1.11957 7
-      vertex 62.9054 -1.11957 0
-    endloop
-  endfacet
-  facet normal 0.85758 0.514351 0
-    outer loop
-      vertex 63.0253 -1.31948 7
-      vertex 62.9054 -1.11957 0
-      vertex 62.9054 -1.11957 7
-    endloop
-  endfacet
-  facet normal 0.85758 0.514351 0
-    outer loop
-      vertex 62.9054 -1.11957 0
-      vertex 63.0253 -1.31948 7
-      vertex 63.0253 -1.31948 0
-    endloop
-  endfacet
-  facet normal 0.741007 0.671497 0
-    outer loop
-      vertex 63.3206 -1.67938 7
-      vertex 63.1641 -1.50668 0
-      vertex 63.1641 -1.50668 7
-    endloop
-  endfacet
-  facet normal 0.741007 0.671497 0
-    outer loop
-      vertex 63.1641 -1.50668 0
-      vertex 63.3206 -1.67938 7
-      vertex 63.3206 -1.67938 0
-    endloop
-  endfacet
-  facet normal 0.803283 0.595597 0
-    outer loop
-      vertex 63.1641 -1.50668 7
-      vertex 63.0253 -1.31948 0
-      vertex 63.0253 -1.31948 7
-    endloop
-  endfacet
-  facet normal 0.803283 0.595597 0
-    outer loop
-      vertex 63.0253 -1.31948 0
-      vertex 63.1641 -1.50668 7
-      vertex 63.1641 -1.50668 0
-    endloop
-  endfacet
-  facet normal 0.671544 0.740964 -0
-    outer loop
-      vertex 63.4933 -1.8359 0
-      vertex 63.3206 -1.67938 7
-      vertex 63.4933 -1.8359 7
-    endloop
-  endfacet
-  facet normal 0.671544 0.740964 0
-    outer loop
-      vertex 63.3206 -1.67938 7
-      vertex 63.4933 -1.8359 0
-      vertex 63.3206 -1.67938 0
-    endloop
-  endfacet
-  facet normal 0.595708 0.803201 -0
-    outer loop
-      vertex 63.6805 -1.97474 0
-      vertex 63.4933 -1.8359 7
-      vertex 63.6805 -1.97474 7
-    endloop
-  endfacet
-  facet normal 0.595708 0.803201 0
-    outer loop
-      vertex 63.4933 -1.8359 7
-      vertex 63.6805 -1.97474 0
-      vertex 63.4933 -1.8359 0
-    endloop
-  endfacet
-  facet normal 0.427542 0.903995 -0
-    outer loop
-      vertex 64.0911 -2.19421 0
-      vertex 63.8804 -2.09456 7
-      vertex 64.0911 -2.19421 7
-    endloop
-  endfacet
-  facet normal 0.427542 0.903995 0
-    outer loop
-      vertex 63.8804 -2.09456 7
-      vertex 64.0911 -2.19421 0
-      vertex 63.8804 -2.09456 0
-    endloop
-  endfacet
-  facet normal 0.514117 0.85772 -0
-    outer loop
-      vertex 63.8804 -2.09456 0
-      vertex 63.6805 -1.97474 7
-      vertex 63.8804 -2.09456 7
-    endloop
-  endfacet
-  facet normal 0.514117 0.85772 0
-    outer loop
-      vertex 63.6805 -1.97474 7
-      vertex 63.8804 -2.09456 0
-      vertex 63.6805 -1.97474 0
-    endloop
-  endfacet
-  facet normal 0.146766 0.989171 -0
-    outer loop
-      vertex 64.7672 -2.36356 0
-      vertex 64.5367 -2.32936 7
-      vertex 64.7672 -2.36356 7
-    endloop
-  endfacet
-  facet normal 0.146766 0.989171 0
-    outer loop
-      vertex 64.5367 -2.32936 7
-      vertex 64.7672 -2.36356 0
-      vertex 64.5367 -2.32936 0
+      vertex 65.6894 -2.27273 4
+      vertex 65.9089 -2.19421 0
+      vertex 65.6894 -2.27273 0
     endloop
   endfacet
   facet normal 0.33682 0.941569 -0
     outer loop
       vertex 64.3106 -2.27273 0
-      vertex 64.0911 -2.19421 7
-      vertex 64.3106 -2.27273 7
+      vertex 64.0911 -2.19421 4
+      vertex 64.3106 -2.27273 4
     endloop
   endfacet
   facet normal 0.33682 0.941569 0
     outer loop
-      vertex 64.0911 -2.19421 7
+      vertex 64.0911 -2.19421 4
       vertex 64.3106 -2.27273 0
       vertex 64.0911 -2.19421 0
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146736 0
+    outer loop
+      vertex 62.6364 0.23279 4
+      vertex 62.6706 0.463339 0
+      vertex 62.6706 0.463339 4
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146736 0
+    outer loop
+      vertex 62.6706 0.463339 0
+      vertex 62.6364 0.23279 4
+      vertex 62.6364 0.23279 0
+    endloop
+  endfacet
+  facet normal 0.0490817 -0.998795 0
+    outer loop
+      vertex 64.7672 2.36356 0
+      vertex 65 2.375 4
+      vertex 64.7672 2.36356 4
+    endloop
+  endfacet
+  facet normal 0.0490817 -0.998795 0
+    outer loop
+      vertex 65 2.375 4
+      vertex 64.7672 2.36356 0
+      vertex 65 2.375 0
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489126 0
+    outer loop
+      vertex 67.3636 -0.23279 0
+      vertex 67.375 0 4
+      vertex 67.375 0 0
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489126 0
+    outer loop
+      vertex 67.375 0 4
+      vertex 67.3636 -0.23279 0
+      vertex 67.3636 -0.23279 4
+    endloop
+  endfacet
+  facet normal -0.33682 -0.941569 0
+    outer loop
+      vertex 65.6894 2.27273 0
+      vertex 65.9089 2.19421 4
+      vertex 65.6894 2.27273 4
+    endloop
+  endfacet
+  facet normal -0.33682 -0.941569 -0
+    outer loop
+      vertex 65.9089 2.19421 4
+      vertex 65.6894 2.27273 0
+      vertex 65.9089 2.19421 0
+    endloop
+  endfacet
+  facet normal -0.0490817 0.998795 0
+    outer loop
+      vertex 65.2328 -2.36356 0
+      vertex 65 -2.375 4
+      vertex 65.2328 -2.36356 4
+    endloop
+  endfacet
+  facet normal -0.0490817 0.998795 0
+    outer loop
+      vertex 65 -2.375 4
+      vertex 65.2328 -2.36356 0
+      vertex 65 -2.375 0
+    endloop
+  endfacet
+  facet normal -0.514117 0.85772 0
+    outer loop
+      vertex 66.3195 -1.97474 0
+      vertex 66.1196 -2.09456 4
+      vertex 66.3195 -1.97474 4
+    endloop
+  endfacet
+  facet normal -0.514117 0.85772 0
+    outer loop
+      vertex 66.1196 -2.09456 4
+      vertex 66.3195 -1.97474 0
+      vertex 66.1196 -2.09456 0
+    endloop
+  endfacet
+  facet normal 0.803283 0.595597 0
+    outer loop
+      vertex 63.1641 -1.50668 4
+      vertex 63.0253 -1.31948 0
+      vertex 63.0253 -1.31948 4
+    endloop
+  endfacet
+  facet normal 0.803283 0.595597 0
+    outer loop
+      vertex 63.0253 -1.31948 0
+      vertex 63.1641 -1.50668 4
+      vertex 63.1641 -1.50668 0
+    endloop
+  endfacet
+  facet normal 0.595708 -0.803201 0
+    outer loop
+      vertex 63.4933 1.8359 0
+      vertex 63.6805 1.97474 4
+      vertex 63.4933 1.8359 4
+    endloop
+  endfacet
+  facet normal 0.595708 -0.803201 0
+    outer loop
+      vertex 63.6805 1.97474 4
+      vertex 63.4933 1.8359 0
+      vertex 63.6805 1.97474 0
+    endloop
+  endfacet
+  facet normal 0.146766 -0.989171 0
+    outer loop
+      vertex 64.5367 2.32936 0
+      vertex 64.7672 2.36356 4
+      vertex 64.5367 2.32936 4
+    endloop
+  endfacet
+  facet normal 0.146766 -0.989171 0
+    outer loop
+      vertex 64.7672 2.36356 4
+      vertex 64.5367 2.32936 0
+      vertex 64.7672 2.36356 0
+    endloop
+  endfacet
+  facet normal 0.24296 -0.970036 0
+    outer loop
+      vertex 64.3106 2.27273 0
+      vertex 64.5367 2.32936 4
+      vertex 64.3106 2.27273 4
+    endloop
+  endfacet
+  facet normal 0.24296 -0.970036 0
+    outer loop
+      vertex 64.5367 2.32936 4
+      vertex 64.3106 2.27273 0
+      vertex 64.5367 2.32936 0
+    endloop
+  endfacet
+  facet normal -0.427542 0.903995 0
+    outer loop
+      vertex 66.1196 -2.09456 0
+      vertex 65.9089 -2.19421 4
+      vertex 66.1196 -2.09456 4
+    endloop
+  endfacet
+  facet normal -0.427542 0.903995 0
+    outer loop
+      vertex 65.9089 -2.19421 4
+      vertex 66.1196 -2.09456 0
+      vertex 65.9089 -2.19421 0
+    endloop
+  endfacet
+  facet normal -0.24296 -0.970036 0
+    outer loop
+      vertex 65.4633 2.32936 0
+      vertex 65.6894 2.27273 4
+      vertex 65.4633 2.32936 4
+    endloop
+  endfacet
+  facet normal -0.24296 -0.970036 -0
+    outer loop
+      vertex 65.6894 2.27273 4
+      vertex 65.4633 2.32936 0
+      vertex 65.6894 2.27273 0
+    endloop
+  endfacet
+  facet normal -0.803283 0.595597 0
+    outer loop
+      vertex 66.8359 -1.50668 0
+      vertex 66.9747 -1.31948 4
+      vertex 66.9747 -1.31948 0
+    endloop
+  endfacet
+  facet normal -0.803283 0.595597 0
+    outer loop
+      vertex 66.9747 -1.31948 4
+      vertex 66.8359 -1.50668 0
+      vertex 66.8359 -1.50668 4
+    endloop
+  endfacet
+  facet normal 0.989176 0.146736 0
+    outer loop
+      vertex 62.6706 -0.463339 4
+      vertex 62.6364 -0.23279 0
+      vertex 62.6364 -0.23279 4
+    endloop
+  endfacet
+  facet normal 0.989176 0.146736 0
+    outer loop
+      vertex 62.6364 -0.23279 0
+      vertex 62.6706 -0.463339 4
+      vertex 62.6706 -0.463339 0
+    endloop
+  endfacet
+  facet normal 0.85758 -0.514351 0
+    outer loop
+      vertex 62.9054 1.11957 4
+      vertex 63.0253 1.31948 0
+      vertex 63.0253 1.31948 4
+    endloop
+  endfacet
+  facet normal 0.85758 -0.514351 0
+    outer loop
+      vertex 63.0253 1.31948 0
+      vertex 62.9054 1.11957 4
+      vertex 62.9054 1.11957 0
+    endloop
+  endfacet
+  facet normal -0.969962 0.243256 0
+    outer loop
+      vertex 67.2727 -0.689425 0
+      vertex 67.3294 -0.463339 4
+      vertex 67.3294 -0.463339 0
+    endloop
+  endfacet
+  facet normal -0.969962 0.243256 0
+    outer loop
+      vertex 67.3294 -0.463339 4
+      vertex 67.2727 -0.689425 0
+      vertex 67.2727 -0.689425 4
+    endloop
+  endfacet
+  facet normal 0.803283 -0.595597 0
+    outer loop
+      vertex 63.0253 1.31948 4
+      vertex 63.1641 1.50668 0
+      vertex 63.1641 1.50668 4
+    endloop
+  endfacet
+  facet normal 0.803283 -0.595597 0
+    outer loop
+      vertex 63.1641 1.50668 0
+      vertex 63.0253 1.31948 4
+      vertex 63.0253 1.31948 0
+    endloop
+  endfacet
+  facet normal -0.904076 0.427372 0
+    outer loop
+      vertex 67.0946 -1.11957 0
+      vertex 67.1942 -0.908873 4
+      vertex 67.1942 -0.908873 0
+    endloop
+  endfacet
+  facet normal -0.904076 0.427372 0
+    outer loop
+      vertex 67.1942 -0.908873 4
+      vertex 67.0946 -1.11957 0
+      vertex 67.0946 -1.11957 4
+    endloop
+  endfacet
+  facet normal -0.146766 -0.989171 0
+    outer loop
+      vertex 65.2328 2.36356 0
+      vertex 65.4633 2.32936 4
+      vertex 65.2328 2.36356 4
+    endloop
+  endfacet
+  facet normal -0.146766 -0.989171 -0
+    outer loop
+      vertex 65.4633 2.32936 4
+      vertex 65.2328 2.36356 0
+      vertex 65.4633 2.32936 0
+    endloop
+  endfacet
+  facet normal -0.146766 0.989171 0
+    outer loop
+      vertex 65.4633 -2.32936 0
+      vertex 65.2328 -2.36356 4
+      vertex 65.4633 -2.32936 4
+    endloop
+  endfacet
+  facet normal -0.146766 0.989171 0
+    outer loop
+      vertex 65.2328 -2.36356 4
+      vertex 65.4633 -2.32936 0
+      vertex 65.2328 -2.36356 0
+    endloop
+  endfacet
+  facet normal -0.595708 -0.803201 0
+    outer loop
+      vertex 66.3195 1.97474 0
+      vertex 66.5067 1.8359 4
+      vertex 66.3195 1.97474 4
+    endloop
+  endfacet
+  facet normal -0.595708 -0.803201 -0
+    outer loop
+      vertex 66.5067 1.8359 4
+      vertex 66.3195 1.97474 0
+      vertex 66.5067 1.8359 0
+    endloop
+  endfacet
+  facet normal -0.803283 -0.595597 0
+    outer loop
+      vertex 66.9747 1.31948 0
+      vertex 66.8359 1.50668 4
+      vertex 66.8359 1.50668 0
+    endloop
+  endfacet
+  facet normal -0.803283 -0.595597 0
+    outer loop
+      vertex 66.8359 1.50668 4
+      vertex 66.9747 1.31948 0
+      vertex 66.9747 1.31948 4
+    endloop
+  endfacet
+  facet normal -0.0490817 -0.998795 0
+    outer loop
+      vertex 65 2.375 0
+      vertex 65.2328 2.36356 4
+      vertex 65 2.375 4
+    endloop
+  endfacet
+  facet normal -0.0490817 -0.998795 -0
+    outer loop
+      vertex 65.2328 2.36356 4
+      vertex 65 2.375 0
+      vertex 65.2328 2.36356 0
+    endloop
+  endfacet
+  facet normal 0.941571 -0.336815 0
+    outer loop
+      vertex 62.7273 0.689425 4
+      vertex 62.8058 0.908873 0
+      vertex 62.8058 0.908873 4
+    endloop
+  endfacet
+  facet normal 0.941571 -0.336815 0
+    outer loop
+      vertex 62.8058 0.908873 0
+      vertex 62.7273 0.689425 4
+      vertex 62.7273 0.689425 0
+    endloop
+  endfacet
+  facet normal 0.33682 -0.941569 0
+    outer loop
+      vertex 64.0911 2.19421 0
+      vertex 64.3106 2.27273 4
+      vertex 64.0911 2.19421 4
+    endloop
+  endfacet
+  facet normal 0.33682 -0.941569 0
+    outer loop
+      vertex 64.3106 2.27273 4
+      vertex 64.0911 2.19421 0
+      vertex 64.3106 2.27273 0
+    endloop
+  endfacet
+  facet normal 0.427542 0.903995 -0
+    outer loop
+      vertex 64.0911 -2.19421 0
+      vertex 63.8804 -2.09456 4
+      vertex 64.0911 -2.19421 4
+    endloop
+  endfacet
+  facet normal 0.427542 0.903995 0
+    outer loop
+      vertex 63.8804 -2.09456 4
+      vertex 64.0911 -2.19421 0
+      vertex 63.8804 -2.09456 0
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489126 0
+    outer loop
+      vertex 62.6364 -0.23279 4
+      vertex 62.625 0 0
+      vertex 62.625 0 4
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489126 0
+    outer loop
+      vertex 62.625 0 0
+      vertex 62.6364 -0.23279 4
+      vertex 62.6364 -0.23279 0
+    endloop
+  endfacet
+  facet normal -0.85758 0.514351 0
+    outer loop
+      vertex 66.9747 -1.31948 0
+      vertex 67.0946 -1.11957 4
+      vertex 67.0946 -1.11957 0
+    endloop
+  endfacet
+  facet normal -0.85758 0.514351 0
+    outer loop
+      vertex 67.0946 -1.11957 4
+      vertex 66.9747 -1.31948 0
+      vertex 66.9747 -1.31948 4
+    endloop
+  endfacet
+  facet normal -0.671544 0.740964 0
+    outer loop
+      vertex 66.6794 -1.67938 0
+      vertex 66.5067 -1.8359 4
+      vertex 66.6794 -1.67938 4
+    endloop
+  endfacet
+  facet normal -0.671544 0.740964 0
+    outer loop
+      vertex 66.5067 -1.8359 4
+      vertex 66.6794 -1.67938 0
+      vertex 66.5067 -1.8359 0
+    endloop
+  endfacet
+  facet normal 0.427542 -0.903995 0
+    outer loop
+      vertex 63.8804 2.09456 0
+      vertex 64.0911 2.19421 4
+      vertex 63.8804 2.09456 4
+    endloop
+  endfacet
+  facet normal 0.427542 -0.903995 0
+    outer loop
+      vertex 64.0911 2.19421 4
+      vertex 63.8804 2.09456 0
+      vertex 64.0911 2.19421 0
+    endloop
+  endfacet
+  facet normal 0.0490817 0.998795 -0
+    outer loop
+      vertex 65 -2.375 0
+      vertex 64.7672 -2.36356 4
+      vertex 65 -2.375 4
+    endloop
+  endfacet
+  facet normal 0.0490817 0.998795 0
+    outer loop
+      vertex 64.7672 -2.36356 4
+      vertex 65 -2.375 0
+      vertex 64.7672 -2.36356 0
+    endloop
+  endfacet
+  facet normal -0.427542 -0.903995 0
+    outer loop
+      vertex 65.9089 2.19421 0
+      vertex 66.1196 2.09456 4
+      vertex 65.9089 2.19421 4
+    endloop
+  endfacet
+  facet normal -0.427542 -0.903995 -0
+    outer loop
+      vertex 66.1196 2.09456 4
+      vertex 65.9089 2.19421 0
+      vertex 66.1196 2.09456 0
+    endloop
+  endfacet
+  facet normal -0.941571 0.336815 0
+    outer loop
+      vertex 67.1942 -0.908873 0
+      vertex 67.2727 -0.689425 4
+      vertex 67.2727 -0.689425 0
+    endloop
+  endfacet
+  facet normal -0.941571 0.336815 0
+    outer loop
+      vertex 67.2727 -0.689425 4
+      vertex 67.1942 -0.908873 0
+      vertex 67.1942 -0.908873 4
+    endloop
+  endfacet
+  facet normal 0.514117 0.85772 -0
+    outer loop
+      vertex 63.8804 -2.09456 0
+      vertex 63.6805 -1.97474 4
+      vertex 63.8804 -2.09456 4
+    endloop
+  endfacet
+  facet normal 0.514117 0.85772 0
+    outer loop
+      vertex 63.6805 -1.97474 4
+      vertex 63.8804 -2.09456 0
+      vertex 63.6805 -1.97474 0
+    endloop
+  endfacet
+  facet normal -0.941571 -0.336815 0
+    outer loop
+      vertex 67.2727 0.689425 0
+      vertex 67.1942 0.908873 4
+      vertex 67.1942 0.908873 0
+    endloop
+  endfacet
+  facet normal -0.941571 -0.336815 0
+    outer loop
+      vertex 67.1942 0.908873 4
+      vertex 67.2727 0.689425 0
+      vertex 67.2727 0.689425 4
+    endloop
+  endfacet
+  facet normal 0.671544 -0.740964 0
+    outer loop
+      vertex 63.3206 1.67938 0
+      vertex 63.4933 1.8359 4
+      vertex 63.3206 1.67938 4
+    endloop
+  endfacet
+  facet normal 0.671544 -0.740964 0
+    outer loop
+      vertex 63.4933 1.8359 4
+      vertex 63.3206 1.67938 0
+      vertex 63.4933 1.8359 0
+    endloop
+  endfacet
+  facet normal -0.989176 0.146736 0
+    outer loop
+      vertex 67.3294 -0.463339 0
+      vertex 67.3636 -0.23279 4
+      vertex 67.3636 -0.23279 0
+    endloop
+  endfacet
+  facet normal -0.989176 0.146736 0
+    outer loop
+      vertex 67.3636 -0.23279 4
+      vertex 67.3294 -0.463339 0
+      vertex 67.3294 -0.463339 4
+    endloop
+  endfacet
+  facet normal -0.904076 -0.427372 0
+    outer loop
+      vertex 67.1942 0.908873 0
+      vertex 67.0946 1.11957 4
+      vertex 67.0946 1.11957 0
+    endloop
+  endfacet
+  facet normal -0.904076 -0.427372 0
+    outer loop
+      vertex 67.0946 1.11957 4
+      vertex 67.1942 0.908873 0
+      vertex 67.1942 0.908873 4
+    endloop
+  endfacet
+  facet normal 0.741007 0.671497 0
+    outer loop
+      vertex 63.3206 -1.67938 4
+      vertex 63.1641 -1.50668 0
+      vertex 63.1641 -1.50668 4
+    endloop
+  endfacet
+  facet normal 0.741007 0.671497 0
+    outer loop
+      vertex 63.1641 -1.50668 0
+      vertex 63.3206 -1.67938 4
+      vertex 63.3206 -1.67938 0
+    endloop
+  endfacet
+  facet normal -0.741007 0.671497 0
+    outer loop
+      vertex 66.6794 -1.67938 0
+      vertex 66.8359 -1.50668 4
+      vertex 66.8359 -1.50668 0
+    endloop
+  endfacet
+  facet normal -0.741007 0.671497 0
+    outer loop
+      vertex 66.8359 -1.50668 4
+      vertex 66.6794 -1.67938 0
+      vertex 66.6794 -1.67938 4
+    endloop
+  endfacet
+  facet normal -0.85758 -0.514351 0
+    outer loop
+      vertex 67.0946 1.11957 0
+      vertex 66.9747 1.31948 4
+      vertex 66.9747 1.31948 0
+    endloop
+  endfacet
+  facet normal -0.85758 -0.514351 0
+    outer loop
+      vertex 66.9747 1.31948 4
+      vertex 67.0946 1.11957 0
+      vertex 67.0946 1.11957 4
+    endloop
+  endfacet
+  facet normal 0.941571 0.336815 0
+    outer loop
+      vertex 62.8058 -0.908873 4
+      vertex 62.7273 -0.689425 0
+      vertex 62.7273 -0.689425 4
+    endloop
+  endfacet
+  facet normal 0.941571 0.336815 0
+    outer loop
+      vertex 62.7273 -0.689425 0
+      vertex 62.8058 -0.908873 4
+      vertex 62.8058 -0.908873 0
+    endloop
+  endfacet
+  facet normal 0.146766 0.989171 -0
+    outer loop
+      vertex 64.7672 -2.36356 0
+      vertex 64.5367 -2.32936 4
+      vertex 64.7672 -2.36356 4
+    endloop
+  endfacet
+  facet normal 0.146766 0.989171 0
+    outer loop
+      vertex 64.5367 -2.32936 4
+      vertex 64.7672 -2.36356 0
+      vertex 64.5367 -2.32936 0
+    endloop
+  endfacet
+  facet normal 0.671544 0.740964 -0
+    outer loop
+      vertex 63.4933 -1.8359 0
+      vertex 63.3206 -1.67938 4
+      vertex 63.4933 -1.8359 4
+    endloop
+  endfacet
+  facet normal 0.671544 0.740964 0
+    outer loop
+      vertex 63.3206 -1.67938 4
+      vertex 63.4933 -1.8359 0
+      vertex 63.3206 -1.67938 0
+    endloop
+  endfacet
+  facet normal -0.741007 -0.671497 0
+    outer loop
+      vertex 66.8359 1.50668 0
+      vertex 66.6794 1.67938 4
+      vertex 66.6794 1.67938 0
+    endloop
+  endfacet
+  facet normal -0.741007 -0.671497 0
+    outer loop
+      vertex 66.6794 1.67938 4
+      vertex 66.8359 1.50668 0
+      vertex 66.8359 1.50668 4
+    endloop
+  endfacet
+  facet normal 0.741007 -0.671497 0
+    outer loop
+      vertex 63.1641 1.50668 4
+      vertex 63.3206 1.67938 0
+      vertex 63.3206 1.67938 4
+    endloop
+  endfacet
+  facet normal 0.741007 -0.671497 0
+    outer loop
+      vertex 63.3206 1.67938 0
+      vertex 63.1641 1.50668 4
+      vertex 63.1641 1.50668 0
+    endloop
+  endfacet
+  facet normal 0.969962 0.243256 0
+    outer loop
+      vertex 62.7273 -0.689425 4
+      vertex 62.6706 -0.463339 0
+      vertex 62.6706 -0.463339 4
+    endloop
+  endfacet
+  facet normal 0.969962 0.243256 0
+    outer loop
+      vertex 62.6706 -0.463339 0
+      vertex 62.7273 -0.689425 4
+      vertex 62.7273 -0.689425 0
+    endloop
+  endfacet
+  facet normal -0.595708 0.803201 0
+    outer loop
+      vertex 66.5067 -1.8359 0
+      vertex 66.3195 -1.97474 4
+      vertex 66.5067 -1.8359 4
+    endloop
+  endfacet
+  facet normal -0.595708 0.803201 0
+    outer loop
+      vertex 66.3195 -1.97474 4
+      vertex 66.5067 -1.8359 0
+      vertex 66.3195 -1.97474 0
+    endloop
+  endfacet
+  facet normal 0.24296 0.970036 -0
+    outer loop
+      vertex 64.5367 -2.32936 0
+      vertex 64.3106 -2.27273 4
+      vertex 64.5367 -2.32936 4
+    endloop
+  endfacet
+  facet normal 0.24296 0.970036 0
+    outer loop
+      vertex 64.3106 -2.27273 4
+      vertex 64.5367 -2.32936 0
+      vertex 64.3106 -2.27273 0
+    endloop
+  endfacet
+  facet normal -0.671544 -0.740964 0
+    outer loop
+      vertex 66.5067 1.8359 0
+      vertex 66.6794 1.67938 4
+      vertex 66.5067 1.8359 4
+    endloop
+  endfacet
+  facet normal -0.671544 -0.740964 -0
+    outer loop
+      vertex 66.6794 1.67938 4
+      vertex 66.5067 1.8359 0
+      vertex 66.6794 1.67938 0
+    endloop
+  endfacet
+  facet normal 0.85758 0.514351 0
+    outer loop
+      vertex 63.0253 -1.31948 4
+      vertex 62.9054 -1.11957 0
+      vertex 62.9054 -1.11957 4
+    endloop
+  endfacet
+  facet normal 0.85758 0.514351 0
+    outer loop
+      vertex 62.9054 -1.11957 0
+      vertex 63.0253 -1.31948 4
+      vertex 63.0253 -1.31948 0
+    endloop
+  endfacet
+  facet normal 0.969962 -0.243256 0
+    outer loop
+      vertex 62.6706 0.463339 4
+      vertex 62.7273 0.689425 0
+      vertex 62.7273 0.689425 4
+    endloop
+  endfacet
+  facet normal 0.969962 -0.243256 0
+    outer loop
+      vertex 62.7273 0.689425 0
+      vertex 62.6706 0.463339 4
+      vertex 62.6706 0.463339 0
+    endloop
+  endfacet
+  facet normal 0.595708 0.803201 -0
+    outer loop
+      vertex 63.6805 -1.97474 0
+      vertex 63.4933 -1.8359 4
+      vertex 63.6805 -1.97474 4
+    endloop
+  endfacet
+  facet normal 0.595708 0.803201 0
+    outer loop
+      vertex 63.4933 -1.8359 4
+      vertex 63.6805 -1.97474 0
+      vertex 63.4933 -1.8359 0
+    endloop
+  endfacet
+  facet normal 0.514117 -0.85772 0
+    outer loop
+      vertex 63.6805 1.97474 0
+      vertex 63.8804 2.09456 4
+      vertex 63.6805 1.97474 4
+    endloop
+  endfacet
+  facet normal 0.514117 -0.85772 0
+    outer loop
+      vertex 63.8804 2.09456 4
+      vertex 63.6805 1.97474 0
+      vertex 63.8804 2.09456 0
+    endloop
+  endfacet
+  facet normal -0.24296 0.970036 0
+    outer loop
+      vertex 65.6894 -2.27273 0
+      vertex 65.4633 -2.32936 4
+      vertex 65.6894 -2.27273 4
+    endloop
+  endfacet
+  facet normal -0.24296 0.970036 0
+    outer loop
+      vertex 65.4633 -2.32936 4
+      vertex 65.6894 -2.27273 0
+      vertex 65.4633 -2.32936 0
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489126 0
+    outer loop
+      vertex 62.625 0 4
+      vertex 62.6364 0.23279 0
+      vertex 62.6364 0.23279 4
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489126 0
+    outer loop
+      vertex 62.6364 0.23279 0
+      vertex 62.625 0 4
+      vertex 62.625 0 0
+    endloop
+  endfacet
+  facet normal 0.904076 0.427372 0
+    outer loop
+      vertex 62.9054 -1.11957 4
+      vertex 62.8058 -0.908873 0
+      vertex 62.8058 -0.908873 4
+    endloop
+  endfacet
+  facet normal 0.904076 0.427372 0
+    outer loop
+      vertex 62.8058 -0.908873 0
+      vertex 62.9054 -1.11957 4
+      vertex 62.9054 -1.11957 0
+    endloop
+  endfacet
+  facet normal 0.904076 -0.427372 0
+    outer loop
+      vertex 62.8058 0.908873 4
+      vertex 62.9054 1.11957 0
+      vertex 62.9054 1.11957 4
+    endloop
+  endfacet
+  facet normal 0.904076 -0.427372 0
+    outer loop
+      vertex 62.9054 1.11957 0
+      vertex 62.8058 0.908873 4
+      vertex 62.8058 0.908873 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 70 -10 4
+      vertex 70 10 7
+      vertex 70 10 4
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 70 10 7
+      vertex 70 -10 4
+      vertex 70 -10 7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 67.375 0 4
+      vertex 70 -10 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 67.3636 0.23279 4
+      vertex 67.375 0 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 67.3294 0.463339 4
+      vertex 67.3636 0.23279 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 67.2727 0.689425 4
+      vertex 67.3294 0.463339 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 67.1942 0.908873 4
+      vertex 67.2727 0.689425 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 67.0946 1.11957 4
+      vertex 67.1942 0.908873 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 66.9747 1.31948 4
+      vertex 67.0946 1.11957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 66.8359 1.50668 4
+      vertex 66.9747 1.31948 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 66.6794 1.67938 4
+      vertex 66.8359 1.50668 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 66.5067 1.8359 4
+      vertex 66.6794 1.67938 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 66.3195 1.97474 4
+      vertex 66.5067 1.8359 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 66.1196 2.09456 4
+      vertex 66.3195 1.97474 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 65.9089 2.19421 4
+      vertex 66.1196 2.09456 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 65.6894 2.27273 4
+      vertex 65.9089 2.19421 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 65.4633 2.32936 4
+      vertex 65.6894 2.27273 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 65.2328 2.36356 4
+      vertex 65.4633 2.32936 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 70 10 4
+      vertex 65 2.375 4
+      vertex 65.2328 2.36356 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60 10 4
+      vertex 65 2.375 4
+      vertex 70 10 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65 2.375 4
+      vertex 60 10 4
+      vertex 64.7672 2.36356 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.7672 2.36356 4
+      vertex 60 10 4
+      vertex 64.5367 2.32936 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5367 2.32936 4
+      vertex 60 10 4
+      vertex 64.3106 2.27273 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.3106 2.27273 4
+      vertex 60 10 4
+      vertex 64.0911 2.19421 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.0911 2.19421 4
+      vertex 60 10 4
+      vertex 63.8804 2.09456 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.8804 2.09456 4
+      vertex 60 10 4
+      vertex 63.6805 1.97474 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6805 1.97474 4
+      vertex 60 10 4
+      vertex 63.4933 1.8359 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.4933 1.8359 4
+      vertex 60 10 4
+      vertex 63.3206 1.67938 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6364 0.23279 4
+      vertex 60 10 4
+      vertex 62.625 0 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6706 0.463339 4
+      vertex 60 10 4
+      vertex 62.6364 0.23279 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7273 0.689425 4
+      vertex 60 10 4
+      vertex 62.6706 0.463339 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8058 0.908873 4
+      vertex 60 10 4
+      vertex 62.7273 0.689425 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.9054 1.11957 4
+      vertex 60 10 4
+      vertex 62.8058 0.908873 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0253 1.31948 4
+      vertex 60 10 4
+      vertex 62.9054 1.11957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1641 1.50668 4
+      vertex 60 10 4
+      vertex 63.0253 1.31948 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.3206 1.67938 4
+      vertex 60 10 4
+      vertex 63.1641 1.50668 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 67.3636 -0.23279 4
+      vertex 70 -10 4
+      vertex 67.375 0 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 67.3294 -0.463339 4
+      vertex 70 -10 4
+      vertex 67.3636 -0.23279 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 67.2727 -0.689425 4
+      vertex 70 -10 4
+      vertex 67.3294 -0.463339 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 67.1942 -0.908873 4
+      vertex 70 -10 4
+      vertex 67.2727 -0.689425 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 67.0946 -1.11957 4
+      vertex 70 -10 4
+      vertex 67.1942 -0.908873 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.9747 -1.31948 4
+      vertex 70 -10 4
+      vertex 67.0946 -1.11957 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.8359 -1.50668 4
+      vertex 70 -10 4
+      vertex 66.9747 -1.31948 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.6794 -1.67938 4
+      vertex 70 -10 4
+      vertex 66.8359 -1.50668 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.5067 -1.8359 4
+      vertex 70 -10 4
+      vertex 66.6794 -1.67938 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.3195 -1.97474 4
+      vertex 70 -10 4
+      vertex 66.5067 -1.8359 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 66.1196 -2.09456 4
+      vertex 70 -10 4
+      vertex 66.3195 -1.97474 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.9089 -2.19421 4
+      vertex 70 -10 4
+      vertex 66.1196 -2.09456 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.6894 -2.27273 4
+      vertex 70 -10 4
+      vertex 65.9089 -2.19421 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.4633 -2.32936 4
+      vertex 70 -10 4
+      vertex 65.6894 -2.27273 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65.2328 -2.36356 4
+      vertex 70 -10 4
+      vertex 65.4633 -2.32936 4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 65 -2.375 4
+      vertex 70 -10 4
+      vertex 65.2328 -2.36356 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 65 -2.375 4
+      vertex 64.7672 -2.36356 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 64.7672 -2.36356 4
+      vertex 64.5367 -2.32936 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 64.5367 -2.32936 4
+      vertex 64.3106 -2.27273 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 64.3106 -2.27273 4
+      vertex 64.0911 -2.19421 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 64.0911 -2.19421 4
+      vertex 63.8804 -2.09456 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 63.8804 -2.09456 4
+      vertex 63.6805 -1.97474 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 63.6805 -1.97474 4
+      vertex 63.4933 -1.8359 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 63.4933 -1.8359 4
+      vertex 63.3206 -1.67938 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 63.3206 -1.67938 4
+      vertex 63.1641 -1.50668 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60 -10 4
+      vertex 62.625 0 4
+      vertex 60 10 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.625 0 4
+      vertex 60 -10 4
+      vertex 62.6364 -0.23279 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6364 -0.23279 4
+      vertex 60 -10 4
+      vertex 62.6706 -0.463339 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 65 -2.375 4
+      vertex 60 -10 4
+      vertex 70 -10 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.0253 -1.31948 4
+      vertex 60 -10 4
+      vertex 63.1641 -1.50668 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.9054 -1.11957 4
+      vertex 60 -10 4
+      vertex 63.0253 -1.31948 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8058 -0.908873 4
+      vertex 60 -10 4
+      vertex 62.9054 -1.11957 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7273 -0.689425 4
+      vertex 60 -10 4
+      vertex 62.8058 -0.908873 4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6706 -0.463339 4
+      vertex 60 -10 4
+      vertex 62.7273 -0.689425 4
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 60 -10 7
+      vertex 60 10 4
+      vertex 60 10 7
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 60 10 4
+      vertex 60 -10 7
+      vertex 60 -10 4
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 60 10 4
+      vertex 70 10 7
+      vertex 60 10 7
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 70 10 7
+      vertex 60 10 4
+      vertex 70 10 4
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 70 -10 4
+      vertex 60 -10 7
+      vertex 70 -10 7
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 60 -10 7
+      vertex 70 -10 4
+      vertex 60 -10 4
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
I just guessed randomly at the dimensions of the camera base, but the parameters should be easy to adjust to get a nice snug indent so that the base sits happily in the edge and can't rotate. I'm not taking thickness of the extruded filament into account here, so you'll have to compensate (presumably by making the hole wider by a fraction of a millimeter to account for the thickness of the bead). 

I also don't know if the mounting bolt hole is in the center of the base or not. I've assumed that it's in the center of the width, but added a parameter to adjust it if it's not in the center of the thickness.

