### PR TITLE
Fix permission issues with appending to config.txt

### DIFF
--- a/provisioning/child_pi_setup.sh
+++ b/provisioning/child_pi_setup.sh
@@ -32,8 +32,11 @@ fi
 
 echo "************************************"
 echo Now you should have a $model set up as Child for an ODM360 rig.
+echo 'About to reboot to enable camera... (15s)'
 echo "************************************"
 echo
+
+sleep 15s
 
 # Reboot to enable camera
 sudo reboot

--- a/provisioning/child_pi_setup.sh
+++ b/provisioning/child_pi_setup.sh
@@ -26,8 +26,10 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev
 
 # Set up pi camera
 if [[ "$onpi" ]]; then
-    echo "start_x=1             # Enables camera" | sudo tee --append /boot/config.txt
-    echo "gpu_mem=256           # Sets GPU memory" | sudo tee --append /boot/config.txt
+    echo "" | sudo tee --append /boot/config.txt # Add blank line before camera setup in config
+    echo "# Enable camera and set GPU memory to allow for maximum resolution." | sudo tee --append /boot/config.txt
+    echo "start_x=1             # Enable camera" | sudo tee --append /boot/config.txt
+    echo "gpu_mem=256           # Set GPU memory" | sudo tee --append /boot/config.txt
 fi
 
 echo "************************************"

--- a/provisioning/child_pi_setup.sh
+++ b/provisioning/child_pi_setup.sh
@@ -26,8 +26,8 @@ sudo apt install -y postgresql postgresql-contrib libpq-dev
 
 # Set up pi camera
 if [[ "$onpi" ]]; then
-    echo "start_x=1             # Enables camera" >> /boot/config.txt
-    echo "gpu_mem=256           # Sets GPU memory" >> /boot/config.txt
+    echo "start_x=1             # Enables camera" | sudo tee --append /boot/config.txt
+    echo "gpu_mem=256           # Sets GPU memory" | sudo tee --append /boot/config.txt
 fi
 
 echo "************************************"


### PR DESCRIPTION
Fixing my bug in pull request https://github.com/OpenDroneMap/odm360/pull/79, specifically that we can't write to `/boot/` without a `sudo tee`.