### PR TITLE
Nut seats for camera mount

### DIFF
--- a/hardware/cam/cam_case.scad
+++ b/hardware/cam/cam_case.scad
@@ -6,6 +6,8 @@ screw_hole_radius = 1.25;
 screw_hole_offset = 3.5;
 pad_diameter = 7;
 pad_height = 6;
+nut_diameter = 4;
+nut_seat_depth = 1;
 
 
 // Don't touch
@@ -16,59 +18,83 @@ pin = pad_height * 2 + 2;
 // This is not inches. No need to fix.
 difference(){
     union() {
-        cube([length_cam_case,width_cam_case,thickness], center = true);
-        translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,0]) {
-            cylinder( r = pad_diameter/2, h = pad_height, $fn = 64);
-        }
-        mirror([1,0,0]) {    
-            translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,0]) {
-                cylinder( r = pad_diameter/2, h = pad_height, $fn = 64);
-            }
-        }
-        mirror([0,1,0]) {    
-            translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,0]) {
-                cylinder( r = pad_diameter/2, h = pad_height, $fn = 64);
-            }
-        }
+        cube([length_cam_case,width_cam_case, 
+              thickness], center = true);
+        translate([length_cam_case/2 - 
+                   screw_hole_offset, width_cam_case/2 - 
+                   screw_hole_offset,0]) {
+                       cylinder(r = pad_diameter/2, 
+                                h = pad_height, $fn = 64);
+                   }
+        mirror([1,0,0]) {
+            translate([length_cam_case/2 - 
+                      screw_hole_offset, width_cam_case/2 - 
+                      screw_hole_offset,0]) {
+                          cylinder(r = pad_diameter/2, 
+                                   h = pad_height, $fn = 64);
+                      }
+                  }
+                      
+        mirror([0,1,0]) {  
+            translate([length_cam_case/2 - 
+                       screw_hole_offset, width_cam_case/2 - 
+                       screw_hole_offset,0]) {
+                           cylinder(r = pad_diameter/2, 
+                                    h = pad_height, $fn = 64);
+                       }
+                   }
         mirror([1,0,0]) {
             mirror([0,1,0]) {    
-                translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,0]) {
-                    cylinder( r = pad_diameter/2, h = pad_height, $fn = 64);
-                }
-            }
-        }    
-    }
+                translate([length_cam_case/2 - 
+                           screw_hole_offset, width_cam_case/2 - 
+                           screw_hole_offset,0]) {
+                               cylinder(r = pad_diameter/2, 
+                                        h = pad_height, $fn = 64);
+                           }
+                       }
+                   }
+               }
 
-    translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,-2]) {
-            cylinder(r = screw_hole_radius, h = pin, $fn=64);
-    }
+    translate([length_cam_case/2 - screw_hole_offset, 
+               width_cam_case/2 - screw_hole_offset,-2]) {
+                   cylinder(r = screw_hole_radius, h = pin, $fn=64);
+               }
 
     mirror([1,0,0]) {    
-        translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,-2]) {
-            cylinder(r = screw_hole_radius, h = pin, $fn=64);
+        translate([length_cam_case/2 - 
+        screw_hole_offset, width_cam_case/2 - screw_hole_offset,-2]) {
+            cylinder(r = screw_hole_radius, 
+            h = pin, $fn=64);
         }
     }
-
+    
     mirror([0,1,0]) {    
-        translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 - screw_hole_offset,-2]) {
-            cylinder(r = screw_hole_radius, h = pin, $fn=64);
+        translate([length_cam_case/2 - 
+        screw_hole_offset, width_cam_case/2 - screw_hole_offset,-2]) {
+            cylinder(r = screw_hole_radius, 
+            h = pin, $fn=64);
         }
     }
 
     mirror([1,0,0]) {
         mirror([0,1,0]) {    
             translate([length_cam_case/2 - screw_hole_offset, width_cam_case/2 -  screw_hole_offset,-2]) {
-                cylinder(r = screw_hole_radius, h = pin, $fn=64);
+                cylinder(r = screw_hole_radius, 
+                h = pin, $fn=64);
             }
         }
     }
-    translate([width_cam_case/4, 0 ,-2]) {
+    translate([width_cam_case/4, 0, -2]) {
         cylinder(r = screw_hole_radius, h = pin, $fn=64);
+        cylinder(r = nut_diameter/2, 
+        h = nut_seat_depth + 1, $fn = 6);
     }
 
     mirror([1,0,0]) {    
-        translate([width_cam_case/4, 0 ,-2]) {
+        translate([width_cam_case/4, 0, -2]) {
             cylinder(r = screw_hole_radius, h = pin, $fn=64);
+            cylinder(r = nut_diameter/2, 
+            h = nut_seat_depth + 1, $fn = 6);
         }
     }    
 }

--- a/hardware/cam/cam_case.stl
+++ b/hardware/cam/cam_case.stl
@@ -1,4 +1,4736 @@
 solid OpenSCAD_Model
+  facet normal 1 -0 0
+    outer loop
+      vertex 18.5 15 1
+      vertex 18.5 18.5 -1
+      vertex 18.5 18.5 1
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 18.5 -15 1
+      vertex 18.5 18.5 -1
+      vertex 18.5 15 1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 18.5 -15 1
+      vertex 18.5 -18.5 1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 18.5 -15 1
+      vertex 18.5 -18.5 -1
+      vertex 18.5 18.5 -1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -15.3431 18.4831 1
+      vertex -15 18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -15.6828 18.4327 1
+      vertex -15.3431 18.4831 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -16.016 18.3493 1
+      vertex -15.6828 18.4327 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -16.3394 18.2336 1
+      vertex -16.016 18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -16.6499 18.0867 1
+      vertex -16.3394 18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -16.9445 17.9101 1
+      vertex -16.6499 18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -17.2204 17.7055 1
+      vertex -16.9445 17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -17.4749 17.4749 1
+      vertex -17.2204 17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -17.7055 17.2204 1
+      vertex -17.4749 17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -17.9101 16.9445 1
+      vertex -17.7055 17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -18.0867 16.6499 1
+      vertex -17.9101 16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -18.2336 16.3394 1
+      vertex -18.0867 16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -18.3493 16.016 1
+      vertex -18.2336 16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -18.4327 15.6828 1
+      vertex -18.3493 16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 18.5 1
+      vertex -18.4831 15.3431 1
+      vertex -18.4327 15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 15.3431 1
+      vertex -18.5 18.5 1
+      vertex -18.5 15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 18.4831 15.3431 1
+      vertex 18.5 15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 18.4327 15.6828 1
+      vertex 18.4831 15.3431 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 18.3493 16.016 1
+      vertex 18.4327 15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 18.2336 16.3394 1
+      vertex 18.3493 16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 18.0867 16.6499 1
+      vertex 18.2336 16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 17.9101 16.9445 1
+      vertex 18.0867 16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 17.7055 17.2204 1
+      vertex 17.9101 16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 17.4749 17.4749 1
+      vertex 17.7055 17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 17.2204 17.7055 1
+      vertex 17.4749 17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 16.9445 17.9101 1
+      vertex 17.2204 17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 16.6499 18.0867 1
+      vertex 16.9445 17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 16.3394 18.2336 1
+      vertex 16.6499 18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 16.016 18.3493 1
+      vertex 16.3394 18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 15.6828 18.4327 1
+      vertex 16.016 18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 18.5 1
+      vertex 15.3431 18.4831 1
+      vertex 15.6828 18.4327 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 15.3431 18.4831 1
+      vertex 18.5 18.5 1
+      vertex 15 18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3431 -18.4831 1
+      vertex -18.5 -18.5 1
+      vertex -15 -18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6828 -18.4327 1
+      vertex -18.5 -18.5 1
+      vertex -15.3431 -18.4831 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.016 -18.3493 1
+      vertex -18.5 -18.5 1
+      vertex -15.6828 -18.4327 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3394 -18.2336 1
+      vertex -18.5 -18.5 1
+      vertex -16.016 -18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6499 -18.0867 1
+      vertex -18.5 -18.5 1
+      vertex -16.3394 -18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9445 -17.9101 1
+      vertex -18.5 -18.5 1
+      vertex -16.6499 -18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2204 -17.7055 1
+      vertex -18.5 -18.5 1
+      vertex -16.9445 -17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4749 -17.4749 1
+      vertex -18.5 -18.5 1
+      vertex -17.2204 -17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.7055 -17.2204 1
+      vertex -18.5 -18.5 1
+      vertex -17.4749 -17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9101 -16.9445 1
+      vertex -18.5 -18.5 1
+      vertex -17.7055 -17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0867 -16.6499 1
+      vertex -18.5 -18.5 1
+      vertex -17.9101 -16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2336 -16.3394 1
+      vertex -18.5 -18.5 1
+      vertex -18.0867 -16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3493 -16.016 1
+      vertex -18.5 -18.5 1
+      vertex -18.2336 -16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4327 -15.6828 1
+      vertex -18.5 -18.5 1
+      vertex -18.3493 -16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 -15.3431 1
+      vertex -18.5 -18.5 1
+      vertex -18.4327 -15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 -18.5 1
+      vertex -18.4831 -15.3431 1
+      vertex -18.5 -15 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.4831 -15.3431 1
+      vertex 18.5 -18.5 1
+      vertex 18.5 -15 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.4327 -15.6828 1
+      vertex 18.5 -18.5 1
+      vertex 18.4831 -15.3431 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.3493 -16.016 1
+      vertex 18.5 -18.5 1
+      vertex 18.4327 -15.6828 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2336 -16.3394 1
+      vertex 18.5 -18.5 1
+      vertex 18.3493 -16.016 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0867 -16.6499 1
+      vertex 18.5 -18.5 1
+      vertex 18.2336 -16.3394 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.9101 -16.9445 1
+      vertex 18.5 -18.5 1
+      vertex 18.0867 -16.6499 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.7055 -17.2204 1
+      vertex 18.5 -18.5 1
+      vertex 17.9101 -16.9445 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.4749 -17.4749 1
+      vertex 18.5 -18.5 1
+      vertex 17.7055 -17.2204 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.2204 -17.7055 1
+      vertex 18.5 -18.5 1
+      vertex 17.4749 -17.4749 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.9445 -17.9101 1
+      vertex 18.5 -18.5 1
+      vertex 17.2204 -17.7055 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.6499 -18.0867 1
+      vertex 18.5 -18.5 1
+      vertex 16.9445 -17.9101 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.3394 -18.2336 1
+      vertex 18.5 -18.5 1
+      vertex 16.6499 -18.0867 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.016 -18.3493 1
+      vertex 18.5 -18.5 1
+      vertex 16.3394 -18.2336 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.6828 -18.4327 1
+      vertex 18.5 -18.5 1
+      vertex 16.016 -18.3493 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.3431 -18.4831 1
+      vertex 18.5 -18.5 1
+      vertex 15.6828 -18.4327 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 -18.5 1
+      vertex 15.3431 -18.4831 1
+      vertex 15 -18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.72835 1.15485 1
+      vertex -13.984 11.6507 1
+      vertex -9.83925 1.1024 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -11.5169 -14.6569 1
+      vertex -11.5 -15 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.3172 11.5673 1
+      vertex -9.83925 1.1024 1
+      vertex -13.984 11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -11.5673 -14.3172 1
+      vertex -11.5169 -14.6569 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.83925 1.1024 1
+      vertex -14.3172 11.5673 1
+      vertex -9.94446 1.03934 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -11.6507 -13.984 1
+      vertex -11.5673 -14.3172 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.94446 1.03934 1
+      vertex -14.3172 11.5673 1
+      vertex -10.043 0.966263 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -11.7664 -13.6606 1
+      vertex -11.6507 -13.984 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.6569 11.5169 1
+      vertex -10.043 0.966263 1
+      vertex -14.3172 11.5673 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -11.9133 -13.3501 1
+      vertex -11.7664 -13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.043 0.966263 1
+      vertex -14.6569 11.5169 1
+      vertex -10.1339 0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -12.0899 -13.0555 1
+      vertex -11.9133 -13.3501 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15 11.5 1
+      vertex -10.1339 0.883883 1
+      vertex -14.6569 11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -12.2945 -12.7796 1
+      vertex -12.0899 -13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.1339 0.883883 1
+      vertex -15 11.5 1
+      vertex -10.2163 0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -12.5251 -12.5251 1
+      vertex -12.2945 -12.7796 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3431 11.5169 1
+      vertex -10.2163 0.792991 1
+      vertex -15 11.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -12.7796 -12.2945 1
+      vertex -12.5251 -12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.2163 0.792991 1
+      vertex -15.3431 11.5169 1
+      vertex -10.2893 0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -13.0555 -12.0899 1
+      vertex -12.7796 -12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.2893 0.694463 1
+      vertex -15.3431 11.5169 1
+      vertex -10.3524 0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -13.3501 -11.9133 1
+      vertex -13.0555 -12.0899 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6828 11.5673 1
+      vertex -10.3524 0.589246 1
+      vertex -15.3431 11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -13.6606 -11.7664 1
+      vertex -13.3501 -11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.3524 0.589246 1
+      vertex -15.6828 11.5673 1
+      vertex -10.4048 0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -13.984 -11.6507 1
+      vertex -13.6606 -11.7664 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.016 11.6507 1
+      vertex -10.4048 0.478354 1
+      vertex -15.6828 11.5673 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -14.3172 -11.5673 1
+      vertex -13.984 -11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.4048 0.478354 1
+      vertex -16.016 11.6507 1
+      vertex -10.4462 0.362855 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -14.6569 -11.5169 1
+      vertex -14.3172 -11.5673 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3394 11.7664 1
+      vertex -10.4462 0.362855 1
+      vertex -16.016 11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -15 -11.5 1
+      vertex -14.6569 -11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.4462 0.362855 1
+      vertex -16.3394 11.7664 1
+      vertex -10.476 0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -15.3431 -11.5169 1
+      vertex -15 -11.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6499 11.9133 1
+      vertex -10.476 0.243862 1
+      vertex -16.3394 11.7664 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -15.6828 -11.5673 1
+      vertex -15.3431 -11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.476 0.243862 1
+      vertex -16.6499 11.9133 1
+      vertex -10.494 0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -16.016 -11.6507 1
+      vertex -15.6828 -11.5673 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9445 12.0899 1
+      vertex -10.494 0.122521 1
+      vertex -16.6499 11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -16.3394 -11.7664 1
+      vertex -16.016 -11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.494 0.122521 1
+      vertex -16.9445 12.0899 1
+      vertex -10.5 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -16.6499 -11.9133 1
+      vertex -16.3394 -11.7664 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9445 -12.0899 1
+      vertex -10.5 0 1
+      vertex -16.9445 12.0899 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -16.9445 -12.0899 1
+      vertex -16.6499 -11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2204 12.2945 1
+      vertex -16.9445 -12.0899 1
+      vertex -16.9445 12.0899 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2204 12.2945 1
+      vertex -17.2204 -12.2945 1
+      vertex -16.9445 -12.0899 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4749 12.5251 1
+      vertex -17.2204 -12.2945 1
+      vertex -17.2204 12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4749 12.5251 1
+      vertex -17.4749 -12.5251 1
+      vertex -17.2204 -12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.7055 12.7796 1
+      vertex -17.4749 -12.5251 1
+      vertex -17.4749 12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.7055 12.7796 1
+      vertex -17.7055 -12.7796 1
+      vertex -17.4749 -12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9101 13.0555 1
+      vertex -17.7055 -12.7796 1
+      vertex -17.7055 12.7796 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9101 13.0555 1
+      vertex -17.9101 -13.0555 1
+      vertex -17.7055 -12.7796 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0867 13.3501 1
+      vertex -17.9101 -13.0555 1
+      vertex -17.9101 13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0867 13.3501 1
+      vertex -18.0867 -13.3501 1
+      vertex -17.9101 -13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2336 13.6606 1
+      vertex -18.0867 -13.3501 1
+      vertex -18.0867 13.3501 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2336 13.6606 1
+      vertex -18.2336 -13.6606 1
+      vertex -18.0867 -13.3501 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3493 13.984 1
+      vertex -18.2336 -13.6606 1
+      vertex -18.2336 13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3493 13.984 1
+      vertex -18.3493 -13.984 1
+      vertex -18.2336 -13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4327 14.3172 1
+      vertex -18.3493 -13.984 1
+      vertex -18.3493 13.984 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4327 14.3172 1
+      vertex -18.4327 -14.3172 1
+      vertex -18.3493 -13.984 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 14.6569 1
+      vertex -18.4327 -14.3172 1
+      vertex -18.4327 14.3172 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 14.6569 1
+      vertex -18.4831 -14.6569 1
+      vertex -18.4327 -14.3172 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 15 1
+      vertex -18.4831 -14.6569 1
+      vertex -18.4831 14.6569 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 -14.6569 1
+      vertex -18.5 15 1
+      vertex -18.5 -15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.984 -11.6507 1
+      vertex 9.72835 -1.15485 1
+      vertex 13.6606 -11.7664 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 15 1
+      vertex 11.5 15 1
+      vertex 11.5169 15.3431 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.494 0.122521 1
+      vertex 10.5 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.476 0.243862 1
+      vertex 10.494 0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.4462 0.362855 1
+      vertex 10.476 0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.4048 0.478354 1
+      vertex 10.4462 0.362855 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.3524 0.589246 1
+      vertex 10.4048 0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.2893 0.694463 1
+      vertex 10.3524 0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.2163 0.792991 1
+      vertex 10.2893 0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.1339 0.883883 1
+      vertex 10.2163 0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 10.043 0.966263 1
+      vertex 10.1339 0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.94446 1.03934 1
+      vertex 10.043 0.966263 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.83925 1.1024 1
+      vertex 9.94446 1.03934 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.72835 1.15485 1
+      vertex 9.83925 1.1024 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.61285 1.19617 1
+      vertex 9.72835 1.15485 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.49386 1.22598 1
+      vertex 9.61285 1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.37252 1.24398 1
+      vertex 9.49386 1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5169 15.3431 1
+      vertex 11.5169 15.3431 1
+      vertex 11.5673 15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.25 1.25 1
+      vertex 9.37252 1.24398 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.12748 1.24398 1
+      vertex 9.25 1.25 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 9.00614 1.22598 1
+      vertex 9.12748 1.24398 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 8.88715 1.19617 1
+      vertex 9.00614 1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 8.77165 1.15485 1
+      vertex 8.88715 1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 8.66075 1.1024 1
+      vertex 8.77165 1.15485 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 8.55554 1.03934 1
+      vertex 8.66075 1.1024 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 8.45701 0.966263 1
+      vertex 8.55554 1.03934 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5169 14.6569 1
+      vertex 11.5169 14.6569 1
+      vertex -11.5 15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 8.36612 0.883883 1
+      vertex 8.45701 0.966263 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5673 14.3172 1
+      vertex 11.5169 14.6569 1
+      vertex -11.5169 14.6569 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.36612 0.883883 1
+      vertex -8.36612 0.883883 1
+      vertex 8.28374 0.792991 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -8.28374 0.792991 1
+      vertex 8.28374 0.792991 1
+      vertex -8.36612 0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.28374 0.792991 1
+      vertex -8.28374 0.792991 1
+      vertex 8.21066 0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.21066 0.694463 1
+      vertex -8.21066 0.694463 1
+      vertex 8.1476 0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.00602 0.122521 1
+      vertex -8 0 1
+      vertex 8 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.00602 0.122521 1
+      vertex 8.00602 0.122521 1
+      vertex 8.02402 0.243862 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -8.1476 0.589246 1
+      vertex 8.1476 0.589246 1
+      vertex -8.21066 0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5673 15.6828 1
+      vertex 11.5673 15.6828 1
+      vertex 11.6507 16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6507 16.016 1
+      vertex 11.6507 16.016 1
+      vertex 11.7664 16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7664 16.3394 1
+      vertex 11.7664 16.3394 1
+      vertex 11.9133 16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9133 16.6499 1
+      vertex 11.9133 16.6499 1
+      vertex 12.0899 16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0899 16.9445 1
+      vertex 12.0899 16.9445 1
+      vertex 12.2945 17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2945 17.2204 1
+      vertex 12.2945 17.2204 1
+      vertex 12.5251 17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5251 17.4749 1
+      vertex 12.5251 17.4749 1
+      vertex 12.7796 17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.00602 0.122521 1
+      vertex -8.00602 0.122521 1
+      vertex -8 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.02402 0.243862 1
+      vertex -8.02402 0.243862 1
+      vertex -8.00602 0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.02402 0.243862 1
+      vertex -8.05383 0.362855 1
+      vertex -8.02402 0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.05383 0.362855 1
+      vertex -8.05383 0.362855 1
+      vertex 8.02402 0.243862 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -8.05383 0.362855 1
+      vertex 8.05383 0.362855 1
+      vertex -8.09515 0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.09515 0.478354 1
+      vertex -8.09515 0.478354 1
+      vertex 8.05383 0.362855 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -8.09515 0.478354 1
+      vertex 8.09515 0.478354 1
+      vertex -8.1476 0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.1476 0.589246 1
+      vertex -8.1476 0.589246 1
+      vertex 8.09515 0.478354 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -8.21066 0.694463 1
+      vertex 8.21066 0.694463 1
+      vertex -8.28374 0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6507 13.984 1
+      vertex 11.5169 14.6569 1
+      vertex -11.5673 14.3172 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex -11.6507 13.984 1
+      vertex 8.36612 0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.36612 0.883883 1
+      vertex -11.6507 13.984 1
+      vertex -8.36612 0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.36612 0.883883 1
+      vertex -11.6507 13.984 1
+      vertex -8.45701 0.966263 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.7664 13.6606 1
+      vertex -8.45701 0.966263 1
+      vertex -11.6507 13.984 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.45701 0.966263 1
+      vertex -11.7664 13.6606 1
+      vertex -8.55554 1.03934 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.9133 13.3501 1
+      vertex -8.55554 1.03934 1
+      vertex -11.7664 13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.55554 1.03934 1
+      vertex -11.9133 13.3501 1
+      vertex -8.66075 1.1024 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.0899 13.0555 1
+      vertex -8.66075 1.1024 1
+      vertex -11.9133 13.3501 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.7796 17.7055 1
+      vertex 12.7796 17.7055 1
+      vertex 13.0555 17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.66075 1.1024 1
+      vertex -12.0899 13.0555 1
+      vertex -8.77165 1.15485 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.2945 12.7796 1
+      vertex -8.77165 1.15485 1
+      vertex -12.0899 13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.77165 1.15485 1
+      vertex -12.2945 12.7796 1
+      vertex -8.88715 1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.88715 1.19617 1
+      vertex -12.2945 12.7796 1
+      vertex -9.00614 1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.61285 1.19617 1
+      vertex -13.6606 11.7664 1
+      vertex -9.72835 1.15485 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.6606 11.7664 1
+      vertex -9.61285 1.19617 1
+      vertex -13.3501 11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.49386 1.22598 1
+      vertex -13.3501 11.9133 1
+      vertex -9.61285 1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.37252 1.24398 1
+      vertex -13.3501 11.9133 1
+      vertex -9.49386 1.22598 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.3501 11.9133 1
+      vertex -9.37252 1.24398 1
+      vertex -13.0555 12.0899 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.25 1.25 1
+      vertex -13.0555 12.0899 1
+      vertex -9.37252 1.24398 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.0555 12.0899 1
+      vertex -9.25 1.25 1
+      vertex -12.7796 12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.12748 1.24398 1
+      vertex -12.7796 12.2945 1
+      vertex -9.25 1.25 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.7796 12.2945 1
+      vertex -9.12748 1.24398 1
+      vertex -12.5251 12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.00614 1.22598 1
+      vertex -12.5251 12.5251 1
+      vertex -9.12748 1.24398 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.5251 12.5251 1
+      vertex -9.00614 1.22598 1
+      vertex -12.2945 12.7796 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0555 17.9101 1
+      vertex 13.0555 17.9101 1
+      vertex 13.3501 18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3501 18.0867 1
+      vertex 13.3501 18.0867 1
+      vertex 13.6606 18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6606 18.2336 1
+      vertex 13.6606 18.2336 1
+      vertex 13.984 18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.984 18.3493 1
+      vertex 13.984 18.3493 1
+      vertex 14.3172 18.4327 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3172 18.4327 1
+      vertex 14.3172 18.4327 1
+      vertex 14.6569 18.4831 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 15.3431 1
+      vertex -11.5169 15.3431 1
+      vertex -11.5 15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5673 15.6828 1
+      vertex -11.5673 15.6828 1
+      vertex -11.5169 15.3431 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6507 16.016 1
+      vertex -11.6507 16.016 1
+      vertex -11.5673 15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7664 16.3394 1
+      vertex -11.7664 16.3394 1
+      vertex -11.6507 16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9133 16.6499 1
+      vertex -11.9133 16.6499 1
+      vertex -11.7664 16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0899 16.9445 1
+      vertex -12.0899 16.9445 1
+      vertex -11.9133 16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2945 17.2204 1
+      vertex -12.2945 17.2204 1
+      vertex -12.0899 16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6569 18.4831 1
+      vertex 14.6569 18.4831 1
+      vertex 15 18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5251 17.4749 1
+      vertex -12.5251 17.4749 1
+      vertex -12.2945 17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7796 17.7055 1
+      vertex -12.7796 17.7055 1
+      vertex -12.5251 17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0555 17.9101 1
+      vertex -13.0555 17.9101 1
+      vertex -12.7796 17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3501 18.0867 1
+      vertex -13.3501 18.0867 1
+      vertex -13.0555 17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6606 18.2336 1
+      vertex -13.6606 18.2336 1
+      vertex -13.3501 18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.984 18.3493 1
+      vertex -13.984 18.3493 1
+      vertex -13.6606 18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3172 18.4327 1
+      vertex -14.3172 18.4327 1
+      vertex -13.984 18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6569 18.4831 1
+      vertex -14.6569 18.4831 1
+      vertex -14.3172 18.4327 1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -14.6569 18.4831 1
+      vertex 15 18.5 1
+      vertex -15 18.5 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.4831 14.6569 1
+      vertex 18.5 -15 1
+      vertex 18.5 15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4831 14.6569 1
+      vertex 18.4831 -14.6569 1
+      vertex 18.5 -15 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.4327 14.3172 1
+      vertex 18.4831 -14.6569 1
+      vertex 18.4831 14.6569 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4327 14.3172 1
+      vertex 18.4327 -14.3172 1
+      vertex 18.4831 -14.6569 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.3493 13.984 1
+      vertex 18.4327 -14.3172 1
+      vertex 18.4327 14.3172 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3493 13.984 1
+      vertex 18.3493 -13.984 1
+      vertex 18.4327 -14.3172 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.2336 13.6606 1
+      vertex 18.3493 -13.984 1
+      vertex 18.3493 13.984 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2336 13.6606 1
+      vertex 18.2336 -13.6606 1
+      vertex 18.3493 -13.984 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.0867 13.3501 1
+      vertex 18.2336 -13.6606 1
+      vertex 18.2336 13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0867 13.3501 1
+      vertex 18.0867 -13.3501 1
+      vertex 18.2336 -13.6606 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.9101 13.0555 1
+      vertex 18.0867 -13.3501 1
+      vertex 18.0867 13.3501 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9101 13.0555 1
+      vertex 17.9101 -13.0555 1
+      vertex 18.0867 -13.3501 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.7055 12.7796 1
+      vertex 17.9101 -13.0555 1
+      vertex 17.9101 13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7055 12.7796 1
+      vertex 17.7055 -12.7796 1
+      vertex 17.9101 -13.0555 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.4749 12.5251 1
+      vertex 17.7055 -12.7796 1
+      vertex 17.7055 12.7796 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4749 12.5251 1
+      vertex 17.4749 -12.5251 1
+      vertex 17.7055 -12.7796 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 17.2204 12.2945 1
+      vertex 17.4749 -12.5251 1
+      vertex 17.4749 12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2204 12.2945 1
+      vertex 17.2204 -12.2945 1
+      vertex 17.4749 -12.5251 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.9445 12.0899 1
+      vertex 17.2204 -12.2945 1
+      vertex 17.2204 12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 12.0899 1
+      vertex 16.9445 -12.0899 1
+      vertex 17.2204 -12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 16.9445 12.0899 1
+      vertex 16.6499 11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 12.0899 1
+      vertex 10.5 0 1
+      vertex 16.9445 -12.0899 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 16.6499 11.9133 1
+      vertex 16.3394 11.7664 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.494 -0.122521 1
+      vertex 16.9445 -12.0899 1
+      vertex 10.5 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 16.3394 11.7664 1
+      vertex 16.016 11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 -12.0899 1
+      vertex 10.494 -0.122521 1
+      vertex 16.6499 -11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 16.016 11.6507 1
+      vertex 15.6828 11.5673 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.476 -0.243862 1
+      vertex 16.6499 -11.9133 1
+      vertex 10.494 -0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 15.6828 11.5673 1
+      vertex 15.3431 11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6499 -11.9133 1
+      vertex 10.476 -0.243862 1
+      vertex 16.3394 -11.7664 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 15.3431 11.5169 1
+      vertex 15 11.5 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.4462 -0.362855 1
+      vertex 16.3394 -11.7664 1
+      vertex 10.476 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 15 11.5 1
+      vertex 14.6569 11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3394 -11.7664 1
+      vertex 10.4462 -0.362855 1
+      vertex 16.016 -11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 14.6569 11.5169 1
+      vertex 14.3172 11.5673 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.4048 -0.478354 1
+      vertex 16.016 -11.6507 1
+      vertex 10.4462 -0.362855 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 14.3172 11.5673 1
+      vertex 13.984 11.6507 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.016 -11.6507 1
+      vertex 10.4048 -0.478354 1
+      vertex 15.6828 -11.5673 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 13.984 11.6507 1
+      vertex 13.6606 11.7664 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.3524 -0.589246 1
+      vertex 15.6828 -11.5673 1
+      vertex 10.4048 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 13.6606 11.7664 1
+      vertex 13.3501 11.9133 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6828 -11.5673 1
+      vertex 10.3524 -0.589246 1
+      vertex 15.3431 -11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 13.3501 11.9133 1
+      vertex 13.0555 12.0899 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.2893 -0.694463 1
+      vertex 15.3431 -11.5169 1
+      vertex 10.3524 -0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 13.0555 12.0899 1
+      vertex 12.7796 12.2945 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.2163 -0.792991 1
+      vertex 15.3431 -11.5169 1
+      vertex 10.2893 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 12.7796 12.2945 1
+      vertex 12.5251 12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3431 -11.5169 1
+      vertex 10.2163 -0.792991 1
+      vertex 15 -11.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 12.5251 12.5251 1
+      vertex 12.2945 12.7796 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.1339 -0.883883 1
+      vertex 15 -11.5 1
+      vertex 10.2163 -0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 12.2945 12.7796 1
+      vertex 12.0899 13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 -11.5 1
+      vertex 10.1339 -0.883883 1
+      vertex 14.6569 -11.5169 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 12.0899 13.0555 1
+      vertex 11.9133 13.3501 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.043 -0.966263 1
+      vertex 14.6569 -11.5169 1
+      vertex 10.1339 -0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 11.9133 13.3501 1
+      vertex 11.7664 13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6569 -11.5169 1
+      vertex 10.043 -0.966263 1
+      vertex 14.3172 -11.5673 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 11.7664 13.6606 1
+      vertex 11.6507 13.984 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.94446 -1.03934 1
+      vertex 14.3172 -11.5673 1
+      vertex 10.043 -0.966263 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 11.6507 13.984 1
+      vertex 11.5673 14.3172 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.83925 -1.1024 1
+      vertex 14.3172 -11.5673 1
+      vertex 9.94446 -1.03934 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 0 1
+      vertex 11.5673 14.3172 1
+      vertex 11.5169 14.6569 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3172 -11.5673 1
+      vertex 9.83925 -1.1024 1
+      vertex 13.984 -11.6507 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.5 15 1
+      vertex 11.5169 14.6569 1
+      vertex 11.5 15 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.72835 -1.15485 1
+      vertex 13.984 -11.6507 1
+      vertex 9.83925 -1.1024 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.61285 -1.19617 1
+      vertex 13.6606 -11.7664 1
+      vertex 9.72835 -1.15485 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6606 -11.7664 1
+      vertex 9.61285 -1.19617 1
+      vertex 13.3501 -11.9133 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.49386 -1.22598 1
+      vertex 13.3501 -11.9133 1
+      vertex 9.61285 -1.19617 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.37252 -1.24398 1
+      vertex 13.3501 -11.9133 1
+      vertex 9.49386 -1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3501 -11.9133 1
+      vertex 9.37252 -1.24398 1
+      vertex 13.0555 -12.0899 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.25 -1.25 1
+      vertex 13.0555 -12.0899 1
+      vertex 9.37252 -1.24398 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0555 -12.0899 1
+      vertex 9.25 -1.25 1
+      vertex 12.7796 -12.2945 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.12748 -1.24398 1
+      vertex 12.7796 -12.2945 1
+      vertex 9.25 -1.25 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7796 -12.2945 1
+      vertex 9.12748 -1.24398 1
+      vertex 12.5251 -12.5251 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.00614 -1.22598 1
+      vertex 12.5251 -12.5251 1
+      vertex 9.12748 -1.24398 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5251 -12.5251 1
+      vertex 9.00614 -1.22598 1
+      vertex 12.2945 -12.7796 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.88715 -1.19617 1
+      vertex 12.2945 -12.7796 1
+      vertex 9.00614 -1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.77165 -1.15485 1
+      vertex 12.2945 -12.7796 1
+      vertex 8.88715 -1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2945 -12.7796 1
+      vertex 8.77165 -1.15485 1
+      vertex 12.0899 -13.0555 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.66075 -1.1024 1
+      vertex 12.0899 -13.0555 1
+      vertex 8.77165 -1.15485 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0899 -13.0555 1
+      vertex 8.66075 -1.1024 1
+      vertex 11.9133 -13.3501 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.55554 -1.03934 1
+      vertex 11.9133 -13.3501 1
+      vertex 8.66075 -1.1024 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9133 -13.3501 1
+      vertex 8.55554 -1.03934 1
+      vertex 11.7664 -13.6606 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.45701 -0.966263 1
+      vertex 11.7664 -13.6606 1
+      vertex 8.55554 -1.03934 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7664 -13.6606 1
+      vertex 8.45701 -0.966263 1
+      vertex 11.6507 -13.984 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.36612 -0.883883 1
+      vertex 11.6507 -13.984 1
+      vertex 8.45701 -0.966263 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8.36612 -0.883883 1
+      vertex 11.6507 -13.984 1
+      vertex 8.36612 -0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex 11.6507 -13.984 1
+      vertex -8.36612 -0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 -14.6569 1
+      vertex -11.5 -15 1
+      vertex 11.5 -15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5 -15 1
+      vertex -11.5 -15 1
+      vertex 11.5169 -15.3431 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5673 -14.3172 1
+      vertex -11.5 -15 1
+      vertex 11.5169 -14.6569 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.36612 -0.883883 1
+      vertex 8.36612 -0.883883 1
+      vertex 8.28374 -0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.28374 -0.792991 1
+      vertex 8.28374 -0.792991 1
+      vertex 8.21066 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.21066 -0.694463 1
+      vertex 8.21066 -0.694463 1
+      vertex 8.1476 -0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.1476 -0.589246 1
+      vertex 8.1476 -0.589246 1
+      vertex 8.09515 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.09515 -0.478354 1
+      vertex 8.09515 -0.478354 1
+      vertex 8.05383 -0.362855 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.05383 -0.362855 1
+      vertex 8.05383 -0.362855 1
+      vertex 8.02402 -0.243862 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -8 0 1
+      vertex 8.00602 -0.122521 1
+      vertex 8 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.00602 -0.122521 1
+      vertex 8.00602 -0.122521 1
+      vertex -8 0 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.00602 -0.122521 1
+      vertex -8.00602 -0.122521 1
+      vertex 8.02402 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.02402 -0.243862 1
+      vertex 8.02402 -0.243862 1
+      vertex -8.00602 -0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.05383 -0.362855 1
+      vertex 8.02402 -0.243862 1
+      vertex -8.02402 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.05383 -0.362855 1
+      vertex -8.05383 -0.362855 1
+      vertex -8.09515 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.09515 -0.478354 1
+      vertex -8.09515 -0.478354 1
+      vertex -8.1476 -0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.1476 -0.589246 1
+      vertex -8.1476 -0.589246 1
+      vertex -8.21066 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.21066 -0.694463 1
+      vertex -8.21066 -0.694463 1
+      vertex -8.28374 -0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.28374 -0.792991 1
+      vertex -8.28374 -0.792991 1
+      vertex -8.36612 -0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6507 -13.984 1
+      vertex -11.5 -15 1
+      vertex 11.5673 -14.3172 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5169 -15.3431 1
+      vertex 11.5169 -15.3431 1
+      vertex -11.5 -15 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5169 -15.3431 1
+      vertex -11.5169 -15.3431 1
+      vertex 11.5673 -15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5673 -15.6828 1
+      vertex 11.5673 -15.6828 1
+      vertex -11.5169 -15.3431 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5673 -15.6828 1
+      vertex -11.5673 -15.6828 1
+      vertex 11.6507 -16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6507 -16.016 1
+      vertex 11.6507 -16.016 1
+      vertex -11.5673 -15.6828 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6507 -16.016 1
+      vertex -11.6507 -16.016 1
+      vertex 11.7664 -16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7664 -16.3394 1
+      vertex 11.7664 -16.3394 1
+      vertex -11.6507 -16.016 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -8.36612 -0.883883 1
+      vertex -8.45701 -0.966263 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -8.45701 -0.966263 1
+      vertex -8.55554 -1.03934 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -8.55554 -1.03934 1
+      vertex -8.66075 -1.1024 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -8.66075 -1.1024 1
+      vertex -8.77165 -1.15485 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -8.77165 -1.15485 1
+      vertex -8.88715 -1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -8.88715 -1.19617 1
+      vertex -9.00614 -1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.00614 -1.22598 1
+      vertex -9.12748 -1.24398 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.12748 -1.24398 1
+      vertex -9.25 -1.25 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.25 -1.25 1
+      vertex -9.37252 -1.24398 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.37252 -1.24398 1
+      vertex -9.49386 -1.22598 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7664 -16.3394 1
+      vertex -11.7664 -16.3394 1
+      vertex 11.9133 -16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.49386 -1.22598 1
+      vertex -9.61285 -1.19617 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.61285 -1.19617 1
+      vertex -9.72835 -1.15485 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.72835 -1.15485 1
+      vertex -9.83925 -1.1024 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.83925 -1.1024 1
+      vertex -9.94446 -1.03934 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.984 11.6507 1
+      vertex -9.72835 1.15485 1
+      vertex -13.6606 11.7664 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.5 0 1
+      vertex -11.5 -15 1
+      vertex -10.494 -0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.476 -0.243862 1
+      vertex -10.494 -0.122521 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.4462 -0.362855 1
+      vertex -10.476 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.4048 -0.478354 1
+      vertex -10.4462 -0.362855 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.3524 -0.589246 1
+      vertex -10.4048 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.2893 -0.694463 1
+      vertex -10.3524 -0.589246 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.2163 -0.792991 1
+      vertex -10.2893 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.1339 -0.883883 1
+      vertex -10.2163 -0.792991 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -10.043 -0.966263 1
+      vertex -10.1339 -0.883883 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 1
+      vertex -9.94446 -1.03934 1
+      vertex -10.043 -0.966263 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9133 -16.6499 1
+      vertex 11.9133 -16.6499 1
+      vertex -11.7664 -16.3394 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9133 -16.6499 1
+      vertex -11.9133 -16.6499 1
+      vertex 12.0899 -16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0899 -16.9445 1
+      vertex 12.0899 -16.9445 1
+      vertex -11.9133 -16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0899 -16.9445 1
+      vertex -12.0899 -16.9445 1
+      vertex 12.2945 -17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2945 -17.2204 1
+      vertex 12.2945 -17.2204 1
+      vertex -12.0899 -16.9445 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2945 -17.2204 1
+      vertex -12.2945 -17.2204 1
+      vertex 12.5251 -17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5251 -17.4749 1
+      vertex 12.5251 -17.4749 1
+      vertex -12.2945 -17.2204 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5251 -17.4749 1
+      vertex -12.5251 -17.4749 1
+      vertex 12.7796 -17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.7796 -17.7055 1
+      vertex 12.7796 -17.7055 1
+      vertex -12.5251 -17.4749 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7796 -17.7055 1
+      vertex -12.7796 -17.7055 1
+      vertex 13.0555 -17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0555 -17.9101 1
+      vertex 13.0555 -17.9101 1
+      vertex -12.7796 -17.7055 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0555 -17.9101 1
+      vertex -13.0555 -17.9101 1
+      vertex 13.3501 -18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3501 -18.0867 1
+      vertex 13.3501 -18.0867 1
+      vertex -13.0555 -17.9101 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3501 -18.0867 1
+      vertex -13.3501 -18.0867 1
+      vertex 13.6606 -18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6606 -18.2336 1
+      vertex 13.6606 -18.2336 1
+      vertex -13.3501 -18.0867 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6606 -18.2336 1
+      vertex -13.6606 -18.2336 1
+      vertex 13.984 -18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.984 -18.3493 1
+      vertex 13.984 -18.3493 1
+      vertex -13.6606 -18.2336 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.984 -18.3493 1
+      vertex -13.984 -18.3493 1
+      vertex 14.3172 -18.4327 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3172 -18.4327 1
+      vertex 14.3172 -18.4327 1
+      vertex -13.984 -18.3493 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3172 -18.4327 1
+      vertex -14.3172 -18.4327 1
+      vertex 14.6569 -18.4831 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6569 -18.4831 1
+      vertex 14.6569 -18.4831 1
+      vertex -14.3172 -18.4327 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6569 -18.4831 1
+      vertex -14.6569 -18.4831 1
+      vertex 15 -18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 -18.5 1
+      vertex -14.6569 -18.4831 1
+      vertex -15 -18.5 1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8451 -14.5216 -1
+      vertex -8.25 -1.73205 -1
+      vertex -13.8038 -14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -13.756 14.8775 -1
+      vertex -13.75 15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8976 -14.4108 -1
+      vertex -8.25 -1.73205 -1
+      vertex -13.8451 -14.5216 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -13.774 14.7561 -1
+      vertex -13.756 14.8775 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9607 -14.3055 -1
+      vertex -8.25 -1.73205 -1
+      vertex -13.8976 -14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -13.8038 14.6371 -1
+      vertex -13.774 14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0337 -14.207 -1
+      vertex -8.25 -1.73205 -1
+      vertex -13.9607 -14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -13.8451 14.5216 -1
+      vertex -13.8038 14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1161 -14.1161 -1
+      vertex -8.25 -1.73205 -1
+      vertex -14.0337 -14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -13.8976 14.4108 -1
+      vertex -13.8451 14.5216 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 -1
+      vertex -14.1161 -14.1161 -1
+      vertex -10.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -13.9607 14.3055 -1
+      vertex -13.8976 14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.207 -14.0337 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.1161 -14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.0337 14.207 -1
+      vertex -13.9607 14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3055 -13.9607 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.207 -14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.1161 14.1161 -1
+      vertex -14.0337 14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4108 -13.8976 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.3055 -13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.207 14.0337 -1
+      vertex -14.1161 14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5216 -13.8451 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.4108 -13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.3055 13.9607 -1
+      vertex -14.207 14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.6371 -13.8038 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.5216 -13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.4108 13.8976 -1
+      vertex -14.3055 13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7561 -13.774 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.6371 -13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.5216 13.8451 -1
+      vertex -14.4108 13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8775 -13.756 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.7561 -13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.6371 13.8038 -1
+      vertex -14.5216 13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15 -13.75 -1
+      vertex -10.25 -1.73205 -1
+      vertex -14.8775 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.7561 13.774 -1
+      vertex -14.6371 13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.1225 -13.756 -1
+      vertex -10.25 -1.73205 -1
+      vertex -15 -13.75 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -14.8775 13.756 -1
+      vertex -14.7561 13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.2439 -13.774 -1
+      vertex -10.25 -1.73205 -1
+      vertex -15.1225 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15 13.75 -1
+      vertex -14.8775 13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.3629 -13.8038 -1
+      vertex -10.25 -1.73205 -1
+      vertex -15.2439 -13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.1225 13.756 -1
+      vertex -15 13.75 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 -1
+      vertex -15.3629 -13.8038 -1
+      vertex -11.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.2439 13.774 -1
+      vertex -15.1225 13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4784 -13.8451 -1
+      vertex -11.25 0 -1
+      vertex -15.3629 -13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.3629 13.8038 -1
+      vertex -15.2439 13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.5892 -13.8976 -1
+      vertex -11.25 0 -1
+      vertex -15.4784 -13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.4784 13.8451 -1
+      vertex -15.3629 13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.6945 -13.9607 -1
+      vertex -11.25 0 -1
+      vertex -15.5892 -13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.5892 13.8976 -1
+      vertex -15.4784 13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.793 -14.0337 -1
+      vertex -11.25 0 -1
+      vertex -15.6945 -13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.6945 13.9607 -1
+      vertex -15.5892 13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8839 -14.1161 -1
+      vertex -11.25 0 -1
+      vertex -15.793 -14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.793 14.0337 -1
+      vertex -15.6945 13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9663 -14.207 -1
+      vertex -11.25 0 -1
+      vertex -15.8839 -14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.8839 14.1161 -1
+      vertex -15.793 14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9663 14.207 -1
+      vertex -11.25 0 -1
+      vertex -15.9663 -14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 -1
+      vertex -15.9663 14.207 -1
+      vertex -15.8839 14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0393 -14.3055 -1
+      vertex -15.9663 14.207 -1
+      vertex -15.9663 -14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0393 -14.3055 -1
+      vertex -16.0393 14.3055 -1
+      vertex -15.9663 14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1024 -14.4108 -1
+      vertex -16.0393 14.3055 -1
+      vertex -16.0393 -14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1024 -14.4108 -1
+      vertex -16.1024 14.4108 -1
+      vertex -16.0393 14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 -18.5 -1
+      vertex -16.1024 -14.4108 -1
+      vertex -16.1549 -14.5216 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.1024 -14.4108 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.1024 14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 -18.5 -1
+      vertex -16.1549 -14.5216 -1
+      vertex -16.1962 -14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -16.1024 14.4108 -1
+      vertex -18.5 -18.5 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 -18.5 -1
+      vertex -16.1962 -14.6371 -1
+      vertex -16.226 -14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1024 14.4108 -1
+      vertex -18.5 18.5 -1
+      vertex -16.1549 14.5216 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 -18.5 -1
+      vertex -16.226 -14.7561 -1
+      vertex -16.244 -14.8775 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1549 14.5216 -1
+      vertex -18.5 18.5 -1
+      vertex -16.1962 14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 -18.5 -1
+      vertex -16.244 -14.8775 -1
+      vertex -16.25 -15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1962 14.6371 -1
+      vertex -18.5 18.5 -1
+      vertex -16.226 14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1962 -14.6371 -1
+      vertex 18.5 -18.5 -1
+      vertex 16.226 -14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 18.5 -1
+      vertex 16.244 14.8775 -1
+      vertex 16.25 15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1549 -14.5216 -1
+      vertex 18.5 -18.5 -1
+      vertex 16.1962 -14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 18.5 -1
+      vertex 16.226 14.7561 -1
+      vertex 16.244 14.8775 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1024 -14.4108 -1
+      vertex 18.5 -18.5 -1
+      vertex 16.1549 -14.5216 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 18.5 -1
+      vertex 16.1962 14.6371 -1
+      vertex 16.226 14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.1024 -14.4108 -1
+      vertex 18.5 18.5 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 18.5 -1
+      vertex 16.1549 14.5216 -1
+      vertex 16.1962 14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1024 14.4108 -1
+      vertex 18.5 18.5 -1
+      vertex 16.1024 -14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 18.5 -1
+      vertex 16.1024 14.4108 -1
+      vertex 16.1549 14.5216 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.0393 -14.3055 -1
+      vertex 16.1024 14.4108 -1
+      vertex 16.1024 -14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.0393 -14.3055 -1
+      vertex 16.0393 14.3055 -1
+      vertex 16.1024 14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9663 -14.207 -1
+      vertex 16.0393 14.3055 -1
+      vertex 16.0393 -14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9663 -14.207 -1
+      vertex 15.9663 14.207 -1
+      vertex 16.0393 14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 -1
+      vertex 15.9663 -14.207 -1
+      vertex 15.8839 -14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9663 -14.207 -1
+      vertex 11.25 0 -1
+      vertex 15.9663 14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 -1
+      vertex 15.8839 -14.1161 -1
+      vertex 15.793 -14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9663 14.207 -1
+      vertex 11.25 0 -1
+      vertex 15.8839 14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 -1
+      vertex 15.793 -14.0337 -1
+      vertex 15.6945 -13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8839 14.1161 -1
+      vertex 11.25 0 -1
+      vertex 15.793 14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 -1
+      vertex 15.6945 -13.9607 -1
+      vertex 15.5892 -13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.793 14.0337 -1
+      vertex 11.25 0 -1
+      vertex 15.6945 13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 -1
+      vertex 15.5892 -13.8976 -1
+      vertex 15.4784 -13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.6945 13.9607 -1
+      vertex 11.25 0 -1
+      vertex 15.5892 13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 -1
+      vertex 15.4784 -13.8451 -1
+      vertex 15.3629 -13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.5892 13.8976 -1
+      vertex 11.25 0 -1
+      vertex 15.4784 13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 15.3629 -13.8038 -1
+      vertex 15.2439 -13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4784 13.8451 -1
+      vertex 11.25 0 -1
+      vertex 15.3629 13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 15.2439 -13.774 -1
+      vertex 15.1225 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 1.73205 -1
+      vertex 15.3629 13.8038 -1
+      vertex 11.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 15.1225 -13.756 -1
+      vertex 15 -13.75 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3629 13.8038 -1
+      vertex 10.25 1.73205 -1
+      vertex 15.2439 13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 15 -13.75 -1
+      vertex 14.8775 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.2439 13.774 -1
+      vertex 10.25 1.73205 -1
+      vertex 15.1225 13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.8775 -13.756 -1
+      vertex 14.7561 -13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.1225 13.756 -1
+      vertex 10.25 1.73205 -1
+      vertex 15 13.75 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.7561 -13.774 -1
+      vertex 14.6371 -13.8038 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15 13.75 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.8775 13.756 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.6371 -13.8038 -1
+      vertex 14.5216 -13.8451 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.8775 13.756 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.7561 13.774 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.5216 -13.8451 -1
+      vertex 14.4108 -13.8976 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.7561 13.774 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.6371 13.8038 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.4108 -13.8976 -1
+      vertex 14.3055 -13.9607 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.6371 13.8038 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.5216 13.8451 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.3055 -13.9607 -1
+      vertex 14.207 -14.0337 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.5216 13.8451 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.4108 13.8976 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 14.207 -14.0337 -1
+      vertex 14.1161 -14.1161 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.4108 13.8976 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.3055 13.9607 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 14.1161 -14.1161 -1
+      vertex 14.0337 -14.207 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.3055 13.9607 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.207 14.0337 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 14.0337 -14.207 -1
+      vertex 13.9607 -14.3055 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.207 14.0337 -1
+      vertex 10.25 1.73205 -1
+      vertex 14.1161 14.1161 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 13.9607 -14.3055 -1
+      vertex 13.8976 -14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 1.73205 -1
+      vertex 14.1161 14.1161 -1
+      vertex 10.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 13.8976 -14.4108 -1
+      vertex 13.8451 -14.5216 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.1161 14.1161 -1
+      vertex 8.25 1.73205 -1
+      vertex 14.0337 14.207 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 13.8451 -14.5216 -1
+      vertex 13.8038 -14.6371 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.0337 14.207 -1
+      vertex 8.25 1.73205 -1
+      vertex 13.9607 14.3055 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 13.8038 -14.6371 -1
+      vertex 13.774 -14.7561 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.9607 14.3055 -1
+      vertex 8.25 1.73205 -1
+      vertex 13.8976 14.4108 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex 13.774 -14.7561 -1
+      vertex 13.756 -14.8775 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.8976 14.4108 -1
+      vertex 8.25 1.73205 -1
+      vertex 13.8451 14.5216 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.75 -15 -1
+      vertex 13.756 -14.8775 -1
+      vertex 13.75 -15 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.8451 14.5216 -1
+      vertex 8.25 1.73205 -1
+      vertex 13.8038 14.6371 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.244 -14.8775 -1
+      vertex 18.5 -18.5 -1
+      vertex 16.25 -15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.244 -15.1225 -1
+      vertex 16.25 -15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.226 -15.2439 -1
+      vertex 16.244 -15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.1962 -15.3629 -1
+      vertex 16.226 -15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.1549 -15.4784 -1
+      vertex 16.1962 -15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.1024 -15.5892 -1
+      vertex 16.1549 -15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 16.0393 -15.6945 -1
+      vertex 16.1024 -15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.9663 -15.793 -1
+      vertex 16.0393 -15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.8839 -15.8839 -1
+      vertex 15.9663 -15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.793 -15.9663 -1
+      vertex 15.8839 -15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.6945 -16.0393 -1
+      vertex 15.793 -15.9663 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.5892 -16.1024 -1
+      vertex 15.6945 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.4784 -16.1549 -1
+      vertex 15.5892 -16.1024 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.3629 -16.1962 -1
+      vertex 15.4784 -16.1549 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.2439 -16.226 -1
+      vertex 15.3629 -16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15.1225 -16.244 -1
+      vertex 15.2439 -16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 15 -16.25 -1
+      vertex 15.1225 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 14.8775 -16.244 -1
+      vertex 15 -16.25 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 14.7561 -16.226 -1
+      vertex 14.8775 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 14.6371 -16.1962 -1
+      vertex 14.7561 -16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 14.5216 -16.1549 -1
+      vertex 14.6371 -16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.5 -18.5 -1
+      vertex 14.4108 -16.1024 -1
+      vertex 14.5216 -16.1549 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.8038 14.6371 -1
+      vertex 8.25 1.73205 -1
+      vertex 13.774 14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.75 -15 -1
+      vertex 13.75 -15 -1
+      vertex 13.756 -15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.756 -15.1225 -1
+      vertex 13.756 -15.1225 -1
+      vertex 13.774 -15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3629 -13.8038 -1
+      vertex 10.25 -1.73205 -1
+      vertex 11.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.774 -15.2439 -1
+      vertex 13.774 -15.2439 -1
+      vertex 13.8038 -15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1161 -14.1161 -1
+      vertex 8.25 -1.73205 -1
+      vertex 10.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8038 -15.3629 -1
+      vertex 13.8038 -15.3629 -1
+      vertex 13.8451 -15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.756 -14.8775 -1
+      vertex 13.756 -14.8775 -1
+      vertex -13.75 -15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex -8.25 -1.73205 -1
+      vertex 7.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8451 -15.4784 -1
+      vertex 13.8451 -15.4784 -1
+      vertex 13.8976 -15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8976 -15.5892 -1
+      vertex 13.8976 -15.5892 -1
+      vertex 13.9607 -15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9607 -15.6945 -1
+      vertex 13.9607 -15.6945 -1
+      vertex 14.0337 -15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0337 -15.793 -1
+      vertex 14.0337 -15.793 -1
+      vertex 14.1161 -15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1161 -15.8839 -1
+      vertex 14.1161 -15.8839 -1
+      vertex 14.207 -15.9663 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 7.25 0 -1
+      vertex -8.25 -1.73205 -1
+      vertex -7.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.207 -15.9663 -1
+      vertex 14.207 -15.9663 -1
+      vertex 14.3055 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.756 -14.8775 -1
+      vertex -13.756 -14.8775 -1
+      vertex 8.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3055 -16.0393 -1
+      vertex 14.3055 -16.0393 -1
+      vertex 14.4108 -16.1024 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4108 -16.1024 -1
+      vertex 14.4108 -16.1024 -1
+      vertex 18.5 -18.5 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.774 -14.7561 -1
+      vertex -8.25 -1.73205 -1
+      vertex -13.756 -14.8775 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 -1
+      vertex -13.756 -14.8775 -1
+      vertex -8.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.756 -15.1225 -1
+      vertex -13.756 -15.1225 -1
+      vertex -13.75 -15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.774 -15.2439 -1
+      vertex -13.774 -15.2439 -1
+      vertex -13.756 -15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8038 -15.3629 -1
+      vertex -13.8038 -15.3629 -1
+      vertex -13.774 -15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8451 -15.4784 -1
+      vertex -13.8451 -15.4784 -1
+      vertex -13.8038 -15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8976 -15.5892 -1
+      vertex -13.8976 -15.5892 -1
+      vertex -13.8451 -15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.9607 -15.6945 -1
+      vertex -13.9607 -15.6945 -1
+      vertex -13.8976 -15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0337 -15.793 -1
+      vertex -14.0337 -15.793 -1
+      vertex -13.9607 -15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1161 -15.8839 -1
+      vertex -14.1161 -15.8839 -1
+      vertex -14.0337 -15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.207 -15.9663 -1
+      vertex -14.207 -15.9663 -1
+      vertex -14.1161 -15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3055 -16.0393 -1
+      vertex -14.3055 -16.0393 -1
+      vertex -14.207 -15.9663 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.4108 -16.1024 -1
+      vertex -14.4108 -16.1024 -1
+      vertex -14.3055 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 -18.5 -1
+      vertex -14.4108 -16.1024 -1
+      vertex 18.5 -18.5 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4108 -16.1024 -1
+      vertex -18.5 -18.5 -1
+      vertex -14.5216 -16.1549 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5216 -16.1549 -1
+      vertex -18.5 -18.5 -1
+      vertex -14.6371 -16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.6371 -16.1962 -1
+      vertex -18.5 -18.5 -1
+      vertex -14.7561 -16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.7561 -16.226 -1
+      vertex -18.5 -18.5 -1
+      vertex -14.8775 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.8775 -16.244 -1
+      vertex -18.5 -18.5 -1
+      vertex -15 -16.25 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.226 14.7561 -1
+      vertex -18.5 18.5 -1
+      vertex -16.244 14.8775 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.244 -15.1225 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.25 -15 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.226 -15.2439 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.244 -15.1225 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.1962 -15.3629 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.226 -15.2439 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.1549 -15.4784 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.1962 -15.3629 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.1024 -15.5892 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.1549 -15.4784 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.0393 -15.6945 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.1024 -15.5892 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.9663 -15.793 -1
+      vertex -18.5 -18.5 -1
+      vertex -16.0393 -15.6945 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8839 -15.8839 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.9663 -15.793 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.793 -15.9663 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.8839 -15.8839 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.6945 -16.0393 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.793 -15.9663 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.5892 -16.1024 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.6945 -16.0393 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.4784 -16.1549 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.5892 -16.1024 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.3629 -16.1962 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.4784 -16.1549 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.2439 -16.226 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.3629 -16.1962 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.1225 -16.244 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.2439 -16.226 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15 -16.25 -1
+      vertex -18.5 -18.5 -1
+      vertex -15.1225 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.226 -14.7561 -1
+      vertex 18.5 -18.5 -1
+      vertex 16.244 -14.8775 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.244 15.1225 -1
+      vertex 18.5 18.5 -1
+      vertex 16.25 15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.226 15.2439 -1
+      vertex 18.5 18.5 -1
+      vertex 16.244 15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1962 15.3629 -1
+      vertex 18.5 18.5 -1
+      vertex 16.226 15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1549 15.4784 -1
+      vertex 18.5 18.5 -1
+      vertex 16.1962 15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1024 15.5892 -1
+      vertex 18.5 18.5 -1
+      vertex 16.1549 15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.0393 15.6945 -1
+      vertex 18.5 18.5 -1
+      vertex 16.1024 15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.9663 15.793 -1
+      vertex 18.5 18.5 -1
+      vertex 16.0393 15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8839 15.8839 -1
+      vertex 18.5 18.5 -1
+      vertex 15.9663 15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.793 15.9663 -1
+      vertex 18.5 18.5 -1
+      vertex 15.8839 15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.6945 16.0393 -1
+      vertex 18.5 18.5 -1
+      vertex 15.793 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.5892 16.1024 -1
+      vertex 18.5 18.5 -1
+      vertex 15.6945 16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4784 16.1549 -1
+      vertex 18.5 18.5 -1
+      vertex 15.5892 16.1024 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3629 16.1962 -1
+      vertex 18.5 18.5 -1
+      vertex 15.4784 16.1549 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.2439 16.226 -1
+      vertex 18.5 18.5 -1
+      vertex 15.3629 16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.1225 16.244 -1
+      vertex 18.5 18.5 -1
+      vertex 15.2439 16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15 16.25 -1
+      vertex 18.5 18.5 -1
+      vertex 15.1225 16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.8775 16.244 -1
+      vertex 18.5 18.5 -1
+      vertex 15 16.25 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.7561 16.226 -1
+      vertex 18.5 18.5 -1
+      vertex 14.8775 16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.6371 16.1962 -1
+      vertex 18.5 18.5 -1
+      vertex 14.7561 16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.5216 16.1549 -1
+      vertex 18.5 18.5 -1
+      vertex 14.6371 16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.4108 16.1024 -1
+      vertex 18.5 18.5 -1
+      vertex 14.5216 16.1549 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.774 14.7561 -1
+      vertex 8.25 1.73205 -1
+      vertex 13.756 14.8775 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.75 15 -1
+      vertex 13.756 14.8775 -1
+      vertex 8.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.756 14.8775 -1
+      vertex -13.75 15 -1
+      vertex 13.75 15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.75 15 -1
+      vertex -13.75 15 -1
+      vertex 13.756 15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.756 15.1225 -1
+      vertex 13.756 15.1225 -1
+      vertex -13.75 15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.756 15.1225 -1
+      vertex -13.756 15.1225 -1
+      vertex 13.774 15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 1.73205 -1
+      vertex 8.25 1.73205 -1
+      vertex 7.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 1.73205 -1
+      vertex 7.25 0 -1
+      vertex -7.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.75 15 -1
+      vertex 8.25 1.73205 -1
+      vertex -8.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.774 15.2439 -1
+      vertex 13.774 15.2439 -1
+      vertex -13.756 15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.774 15.2439 -1
+      vertex -13.774 15.2439 -1
+      vertex 13.8038 15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8038 15.3629 -1
+      vertex 13.8038 15.3629 -1
+      vertex -13.774 15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8038 15.3629 -1
+      vertex -13.8038 15.3629 -1
+      vertex 13.8451 15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8451 15.4784 -1
+      vertex 13.8451 15.4784 -1
+      vertex -13.8038 15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8451 15.4784 -1
+      vertex -13.8451 15.4784 -1
+      vertex 13.8976 15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.75 15 -1
+      vertex -8.25 1.73205 -1
+      vertex -10.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8976 15.5892 -1
+      vertex 13.8976 15.5892 -1
+      vertex -13.8451 15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8976 15.5892 -1
+      vertex -13.8976 15.5892 -1
+      vertex 13.9607 15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8038 -14.6371 -1
+      vertex -8.25 -1.73205 -1
+      vertex -13.774 -14.7561 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.75 15 -1
+      vertex -10.25 1.73205 -1
+      vertex -11.25 0 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.9607 15.6945 -1
+      vertex 13.9607 15.6945 -1
+      vertex -13.8976 15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.9607 15.6945 -1
+      vertex -13.9607 15.6945 -1
+      vertex 14.0337 15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0337 15.793 -1
+      vertex 14.0337 15.793 -1
+      vertex -13.9607 15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0337 15.793 -1
+      vertex -14.0337 15.793 -1
+      vertex 14.1161 15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.1161 15.8839 -1
+      vertex 14.1161 15.8839 -1
+      vertex -14.0337 15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1161 15.8839 -1
+      vertex -14.1161 15.8839 -1
+      vertex 14.207 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.207 15.9663 -1
+      vertex 14.207 15.9663 -1
+      vertex -14.1161 15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.207 15.9663 -1
+      vertex -14.207 15.9663 -1
+      vertex 14.3055 16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3055 16.0393 -1
+      vertex 14.3055 16.0393 -1
+      vertex -14.207 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.3055 16.0393 -1
+      vertex -14.3055 16.0393 -1
+      vertex 14.4108 16.1024 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4108 16.1024 -1
+      vertex 14.4108 16.1024 -1
+      vertex -14.3055 16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.4108 16.1024 -1
+      vertex -14.4108 16.1024 -1
+      vertex 18.5 18.5 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -14.4108 16.1024 -1
+      vertex -14.5216 16.1549 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -14.5216 16.1549 -1
+      vertex -14.6371 16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -14.6371 16.1962 -1
+      vertex -14.7561 16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -14.7561 16.226 -1
+      vertex -14.8775 16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -14.8775 16.244 -1
+      vertex -15 16.25 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5 18.5 -1
+      vertex -15 16.25 -1
+      vertex -15.1225 16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.244 14.8775 -1
+      vertex -18.5 18.5 -1
+      vertex -16.25 15 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4108 16.1024 -1
+      vertex -18.5 18.5 -1
+      vertex 18.5 18.5 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.2439 16.226 -1
+      vertex -18.5 18.5 -1
+      vertex -15.1225 16.244 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.3629 16.1962 -1
+      vertex -18.5 18.5 -1
+      vertex -15.2439 16.226 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.4784 16.1549 -1
+      vertex -18.5 18.5 -1
+      vertex -15.3629 16.1962 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.5892 16.1024 -1
+      vertex -18.5 18.5 -1
+      vertex -15.4784 16.1549 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.6945 16.0393 -1
+      vertex -18.5 18.5 -1
+      vertex -15.5892 16.1024 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.793 15.9663 -1
+      vertex -18.5 18.5 -1
+      vertex -15.6945 16.0393 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8839 15.8839 -1
+      vertex -18.5 18.5 -1
+      vertex -15.793 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.9663 15.793 -1
+      vertex -18.5 18.5 -1
+      vertex -15.8839 15.8839 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.0393 15.6945 -1
+      vertex -18.5 18.5 -1
+      vertex -15.9663 15.793 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1024 15.5892 -1
+      vertex -18.5 18.5 -1
+      vertex -16.0393 15.6945 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1549 15.4784 -1
+      vertex -18.5 18.5 -1
+      vertex -16.1024 15.5892 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1962 15.3629 -1
+      vertex -18.5 18.5 -1
+      vertex -16.1549 15.4784 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.226 15.2439 -1
+      vertex -18.5 18.5 -1
+      vertex -16.1962 15.3629 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.244 15.1225 -1
+      vertex -18.5 18.5 -1
+      vertex -16.226 15.2439 -1
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.25 15 -1
+      vertex -18.5 18.5 -1
+      vertex -16.244 15.1225 -1
+    endloop
+  endfacet
   facet normal -1 0 0
     outer loop
       vertex -18.5 18.5 -1
@@ -25,5578 +4757,6 @@ solid OpenSCAD_Model
       vertex -18.5 -15 1
       vertex -18.5 -18.5 -1
       vertex -18.5 -18.5 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.4831 -15.3431 1
-      vertex 18.5 -18.5 1
-      vertex 18.5 -15 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.4327 -15.6828 1
-      vertex 18.5 -18.5 1
-      vertex 18.4831 -15.3431 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.3493 -16.016 1
-      vertex 18.5 -18.5 1
-      vertex 18.4327 -15.6828 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.2336 -16.3394 1
-      vertex 18.5 -18.5 1
-      vertex 18.3493 -16.016 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.0867 -16.6499 1
-      vertex 18.5 -18.5 1
-      vertex 18.2336 -16.3394 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.9101 -16.9445 1
-      vertex 18.5 -18.5 1
-      vertex 18.0867 -16.6499 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.7055 -17.2204 1
-      vertex 18.5 -18.5 1
-      vertex 17.9101 -16.9445 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.4749 -17.4749 1
-      vertex 18.5 -18.5 1
-      vertex 17.7055 -17.2204 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.2204 -17.7055 1
-      vertex 18.5 -18.5 1
-      vertex 17.4749 -17.4749 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.9445 -17.9101 1
-      vertex 18.5 -18.5 1
-      vertex 17.2204 -17.7055 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.6499 -18.0867 1
-      vertex 18.5 -18.5 1
-      vertex 16.9445 -17.9101 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.3394 -18.2336 1
-      vertex 18.5 -18.5 1
-      vertex 16.6499 -18.0867 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.016 -18.3493 1
-      vertex 18.5 -18.5 1
-      vertex 16.3394 -18.2336 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.6828 -18.4327 1
-      vertex 18.5 -18.5 1
-      vertex 16.016 -18.3493 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.3431 -18.4831 1
-      vertex 18.5 -18.5 1
-      vertex 15.6828 -18.4327 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 -18.5 1
-      vertex 15.3431 -18.4831 1
-      vertex 15 -18.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3431 -18.4831 1
-      vertex -18.5 -18.5 1
-      vertex -15 -18.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6828 -18.4327 1
-      vertex -18.5 -18.5 1
-      vertex -15.3431 -18.4831 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.016 -18.3493 1
-      vertex -18.5 -18.5 1
-      vertex -15.6828 -18.4327 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.3394 -18.2336 1
-      vertex -18.5 -18.5 1
-      vertex -16.016 -18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6499 -18.0867 1
-      vertex -18.5 -18.5 1
-      vertex -16.3394 -18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.9445 -17.9101 1
-      vertex -18.5 -18.5 1
-      vertex -16.6499 -18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.2204 -17.7055 1
-      vertex -18.5 -18.5 1
-      vertex -16.9445 -17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.4749 -17.4749 1
-      vertex -18.5 -18.5 1
-      vertex -17.2204 -17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.7055 -17.2204 1
-      vertex -18.5 -18.5 1
-      vertex -17.4749 -17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9101 -16.9445 1
-      vertex -18.5 -18.5 1
-      vertex -17.7055 -17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0867 -16.6499 1
-      vertex -18.5 -18.5 1
-      vertex -17.9101 -16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2336 -16.3394 1
-      vertex -18.5 -18.5 1
-      vertex -18.0867 -16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3493 -16.016 1
-      vertex -18.5 -18.5 1
-      vertex -18.2336 -16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4327 -15.6828 1
-      vertex -18.5 -18.5 1
-      vertex -18.3493 -16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 -15.3431 1
-      vertex -18.5 -18.5 1
-      vertex -18.4327 -15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 -18.5 1
-      vertex -18.4831 -15.3431 1
-      vertex -18.5 -15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 18.4831 15.3431 1
-      vertex 18.5 15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 18.4327 15.6828 1
-      vertex 18.4831 15.3431 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 18.3493 16.016 1
-      vertex 18.4327 15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 18.2336 16.3394 1
-      vertex 18.3493 16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 18.0867 16.6499 1
-      vertex 18.2336 16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 17.9101 16.9445 1
-      vertex 18.0867 16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 17.7055 17.2204 1
-      vertex 17.9101 16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 17.4749 17.4749 1
-      vertex 17.7055 17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 17.2204 17.7055 1
-      vertex 17.4749 17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 16.9445 17.9101 1
-      vertex 17.2204 17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 16.6499 18.0867 1
-      vertex 16.9445 17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 16.3394 18.2336 1
-      vertex 16.6499 18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 16.016 18.3493 1
-      vertex 16.3394 18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 15.6828 18.4327 1
-      vertex 16.016 18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 18.5 1
-      vertex 15.3431 18.4831 1
-      vertex 15.6828 18.4327 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 15.3431 18.4831 1
-      vertex 18.5 18.5 1
-      vertex 15 18.5 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -15.3431 18.4831 1
-      vertex -15 18.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -15.6828 18.4327 1
-      vertex -15.3431 18.4831 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -16.016 18.3493 1
-      vertex -15.6828 18.4327 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -16.3394 18.2336 1
-      vertex -16.016 18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -16.6499 18.0867 1
-      vertex -16.3394 18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -16.9445 17.9101 1
-      vertex -16.6499 18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -17.2204 17.7055 1
-      vertex -16.9445 17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -17.4749 17.4749 1
-      vertex -17.2204 17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -17.7055 17.2204 1
-      vertex -17.4749 17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -17.9101 16.9445 1
-      vertex -17.7055 17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -18.0867 16.6499 1
-      vertex -17.9101 16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -18.2336 16.3394 1
-      vertex -18.0867 16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -18.3493 16.016 1
-      vertex -18.2336 16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -18.4327 15.6828 1
-      vertex -18.3493 16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 18.5 1
-      vertex -18.4831 15.3431 1
-      vertex -18.4327 15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 15.3431 1
-      vertex -18.5 18.5 1
-      vertex -18.5 15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.72835 1.15485 1
-      vertex -13.984 11.6507 1
-      vertex -9.83925 1.1024 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -11.5169 -14.6569 1
-      vertex -11.5 -15 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.3172 11.5673 1
-      vertex -9.83925 1.1024 1
-      vertex -13.984 11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -11.5673 -14.3172 1
-      vertex -11.5169 -14.6569 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.83925 1.1024 1
-      vertex -14.3172 11.5673 1
-      vertex -9.94446 1.03934 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -11.6507 -13.984 1
-      vertex -11.5673 -14.3172 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.94446 1.03934 1
-      vertex -14.3172 11.5673 1
-      vertex -10.043 0.966263 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -11.7664 -13.6606 1
-      vertex -11.6507 -13.984 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.6569 11.5169 1
-      vertex -10.043 0.966263 1
-      vertex -14.3172 11.5673 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -11.9133 -13.3501 1
-      vertex -11.7664 -13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.043 0.966263 1
-      vertex -14.6569 11.5169 1
-      vertex -10.1339 0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -12.0899 -13.0555 1
-      vertex -11.9133 -13.3501 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15 11.5 1
-      vertex -10.1339 0.883883 1
-      vertex -14.6569 11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -12.2945 -12.7796 1
-      vertex -12.0899 -13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.1339 0.883883 1
-      vertex -15 11.5 1
-      vertex -10.2163 0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -12.5251 -12.5251 1
-      vertex -12.2945 -12.7796 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3431 11.5169 1
-      vertex -10.2163 0.792991 1
-      vertex -15 11.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -12.7796 -12.2945 1
-      vertex -12.5251 -12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.2163 0.792991 1
-      vertex -15.3431 11.5169 1
-      vertex -10.2893 0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -13.0555 -12.0899 1
-      vertex -12.7796 -12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.2893 0.694463 1
-      vertex -15.3431 11.5169 1
-      vertex -10.3524 0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -13.3501 -11.9133 1
-      vertex -13.0555 -12.0899 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6828 11.5673 1
-      vertex -10.3524 0.589246 1
-      vertex -15.3431 11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -13.6606 -11.7664 1
-      vertex -13.3501 -11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.3524 0.589246 1
-      vertex -15.6828 11.5673 1
-      vertex -10.4048 0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -13.984 -11.6507 1
-      vertex -13.6606 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.016 11.6507 1
-      vertex -10.4048 0.478354 1
-      vertex -15.6828 11.5673 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -14.3172 -11.5673 1
-      vertex -13.984 -11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.4048 0.478354 1
-      vertex -16.016 11.6507 1
-      vertex -10.4462 0.362855 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -14.6569 -11.5169 1
-      vertex -14.3172 -11.5673 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.3394 11.7664 1
-      vertex -10.4462 0.362855 1
-      vertex -16.016 11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -15 -11.5 1
-      vertex -14.6569 -11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.4462 0.362855 1
-      vertex -16.3394 11.7664 1
-      vertex -10.476 0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -15.3431 -11.5169 1
-      vertex -15 -11.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6499 11.9133 1
-      vertex -10.476 0.243862 1
-      vertex -16.3394 11.7664 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -15.6828 -11.5673 1
-      vertex -15.3431 -11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.476 0.243862 1
-      vertex -16.6499 11.9133 1
-      vertex -10.494 0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -16.016 -11.6507 1
-      vertex -15.6828 -11.5673 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.9445 12.0899 1
-      vertex -10.494 0.122521 1
-      vertex -16.6499 11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -16.3394 -11.7664 1
-      vertex -16.016 -11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.494 0.122521 1
-      vertex -16.9445 12.0899 1
-      vertex -10.5 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -16.6499 -11.9133 1
-      vertex -16.3394 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.9445 -12.0899 1
-      vertex -10.5 0 1
-      vertex -16.9445 12.0899 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -16.9445 -12.0899 1
-      vertex -16.6499 -11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.2204 12.2945 1
-      vertex -16.9445 -12.0899 1
-      vertex -16.9445 12.0899 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.2204 12.2945 1
-      vertex -17.2204 -12.2945 1
-      vertex -16.9445 -12.0899 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.4749 12.5251 1
-      vertex -17.2204 -12.2945 1
-      vertex -17.2204 12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.4749 12.5251 1
-      vertex -17.4749 -12.5251 1
-      vertex -17.2204 -12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.7055 12.7796 1
-      vertex -17.4749 -12.5251 1
-      vertex -17.4749 12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.7055 12.7796 1
-      vertex -17.7055 -12.7796 1
-      vertex -17.4749 -12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9101 13.0555 1
-      vertex -17.7055 -12.7796 1
-      vertex -17.7055 12.7796 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9101 13.0555 1
-      vertex -17.9101 -13.0555 1
-      vertex -17.7055 -12.7796 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0867 13.3501 1
-      vertex -17.9101 -13.0555 1
-      vertex -17.9101 13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0867 13.3501 1
-      vertex -18.0867 -13.3501 1
-      vertex -17.9101 -13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2336 13.6606 1
-      vertex -18.0867 -13.3501 1
-      vertex -18.0867 13.3501 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2336 13.6606 1
-      vertex -18.2336 -13.6606 1
-      vertex -18.0867 -13.3501 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3493 13.984 1
-      vertex -18.2336 -13.6606 1
-      vertex -18.2336 13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3493 13.984 1
-      vertex -18.3493 -13.984 1
-      vertex -18.2336 -13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4327 14.3172 1
-      vertex -18.3493 -13.984 1
-      vertex -18.3493 13.984 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4327 14.3172 1
-      vertex -18.4327 -14.3172 1
-      vertex -18.3493 -13.984 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 14.6569 1
-      vertex -18.4327 -14.3172 1
-      vertex -18.4327 14.3172 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 14.6569 1
-      vertex -18.4831 -14.6569 1
-      vertex -18.4327 -14.3172 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 15 1
-      vertex -18.4831 -14.6569 1
-      vertex -18.4831 14.6569 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 -14.6569 1
-      vertex -18.5 15 1
-      vertex -18.5 -15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.984 -11.6507 1
-      vertex 9.72835 -1.15485 1
-      vertex 13.6606 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 15 1
-      vertex 11.5 15 1
-      vertex 11.5169 15.3431 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.494 0.122521 1
-      vertex 10.5 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.476 0.243862 1
-      vertex 10.494 0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.4462 0.362855 1
-      vertex 10.476 0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.4048 0.478354 1
-      vertex 10.4462 0.362855 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.3524 0.589246 1
-      vertex 10.4048 0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.2893 0.694463 1
-      vertex 10.3524 0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.2163 0.792991 1
-      vertex 10.2893 0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.1339 0.883883 1
-      vertex 10.2163 0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 10.043 0.966263 1
-      vertex 10.1339 0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.94446 1.03934 1
-      vertex 10.043 0.966263 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.83925 1.1024 1
-      vertex 9.94446 1.03934 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.72835 1.15485 1
-      vertex 9.83925 1.1024 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.61285 1.19617 1
-      vertex 9.72835 1.15485 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.49386 1.22598 1
-      vertex 9.61285 1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.37252 1.24398 1
-      vertex 9.49386 1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 15.3431 1
-      vertex 11.5169 15.3431 1
-      vertex 11.5673 15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.25 1.25 1
-      vertex 9.37252 1.24398 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.12748 1.24398 1
-      vertex 9.25 1.25 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 9.00614 1.22598 1
-      vertex 9.12748 1.24398 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 8.88714 1.19617 1
-      vertex 9.00614 1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 8.77165 1.15485 1
-      vertex 8.88714 1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 8.66075 1.1024 1
-      vertex 8.77165 1.15485 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 8.55554 1.03934 1
-      vertex 8.66075 1.1024 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 8.45701 0.966263 1
-      vertex 8.55554 1.03934 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 14.6569 1
-      vertex 11.5169 14.6569 1
-      vertex -11.5 15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex 8.36612 0.883883 1
-      vertex 8.45701 0.966263 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 14.3172 1
-      vertex 11.5169 14.6569 1
-      vertex -11.5169 14.6569 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.36612 0.883883 1
-      vertex -8.36612 0.883883 1
-      vertex 8.28374 0.792991 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -8.28374 0.792991 1
-      vertex 8.28374 0.792991 1
-      vertex -8.36612 0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.28374 0.792991 1
-      vertex -8.28374 0.792991 1
-      vertex 8.21066 0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.21066 0.694463 1
-      vertex -8.21066 0.694463 1
-      vertex 8.1476 0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.00602 0.122521 1
-      vertex -8 0 1
-      vertex 8 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.00602 0.122521 1
-      vertex 8.00602 0.122521 1
-      vertex 8.02402 0.243862 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -8.1476 0.589246 1
-      vertex 8.1476 0.589246 1
-      vertex -8.21066 0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 15.6828 1
-      vertex 11.5673 15.6828 1
-      vertex 11.6507 16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 16.016 1
-      vertex 11.6507 16.016 1
-      vertex 11.7664 16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7664 16.3394 1
-      vertex 11.7664 16.3394 1
-      vertex 11.9133 16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.9133 16.6499 1
-      vertex 11.9133 16.6499 1
-      vertex 12.0899 16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0899 16.9445 1
-      vertex 12.0899 16.9445 1
-      vertex 12.2945 17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2945 17.2204 1
-      vertex 12.2945 17.2204 1
-      vertex 12.5251 17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5251 17.4749 1
-      vertex 12.5251 17.4749 1
-      vertex 12.7796 17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.00602 0.122521 1
-      vertex -8.00602 0.122521 1
-      vertex -8 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.02402 0.243862 1
-      vertex -8.02402 0.243862 1
-      vertex -8.00602 0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.02402 0.243862 1
-      vertex -8.05382 0.362855 1
-      vertex -8.02402 0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.05382 0.362855 1
-      vertex -8.05382 0.362855 1
-      vertex 8.02402 0.243862 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -8.05382 0.362855 1
-      vertex 8.05382 0.362855 1
-      vertex -8.09515 0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.09515 0.478354 1
-      vertex -8.09515 0.478354 1
-      vertex 8.05382 0.362855 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -8.09515 0.478354 1
-      vertex 8.09515 0.478354 1
-      vertex -8.1476 0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.1476 0.589246 1
-      vertex -8.1476 0.589246 1
-      vertex 8.09515 0.478354 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -8.21066 0.694463 1
-      vertex 8.21066 0.694463 1
-      vertex -8.28374 0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 13.984 1
-      vertex 11.5169 14.6569 1
-      vertex -11.5673 14.3172 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 1
-      vertex -11.6507 13.984 1
-      vertex 8.36612 0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.36612 0.883883 1
-      vertex -11.6507 13.984 1
-      vertex -8.36612 0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.36612 0.883883 1
-      vertex -11.6507 13.984 1
-      vertex -8.45701 0.966263 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.7664 13.6606 1
-      vertex -8.45701 0.966263 1
-      vertex -11.6507 13.984 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.45701 0.966263 1
-      vertex -11.7664 13.6606 1
-      vertex -8.55554 1.03934 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.9133 13.3501 1
-      vertex -8.55554 1.03934 1
-      vertex -11.7664 13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.55554 1.03934 1
-      vertex -11.9133 13.3501 1
-      vertex -8.66075 1.1024 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.0899 13.0555 1
-      vertex -8.66075 1.1024 1
-      vertex -11.9133 13.3501 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.7796 17.7055 1
-      vertex 12.7796 17.7055 1
-      vertex 13.0555 17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.66075 1.1024 1
-      vertex -12.0899 13.0555 1
-      vertex -8.77165 1.15485 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.2945 12.7796 1
-      vertex -8.77165 1.15485 1
-      vertex -12.0899 13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.77165 1.15485 1
-      vertex -12.2945 12.7796 1
-      vertex -8.88714 1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.88714 1.19617 1
-      vertex -12.2945 12.7796 1
-      vertex -9.00614 1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.61285 1.19617 1
-      vertex -13.6606 11.7664 1
-      vertex -9.72835 1.15485 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.6606 11.7664 1
-      vertex -9.61285 1.19617 1
-      vertex -13.3501 11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.49386 1.22598 1
-      vertex -13.3501 11.9133 1
-      vertex -9.61285 1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.37252 1.24398 1
-      vertex -13.3501 11.9133 1
-      vertex -9.49386 1.22598 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.3501 11.9133 1
-      vertex -9.37252 1.24398 1
-      vertex -13.0555 12.0899 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.25 1.25 1
-      vertex -13.0555 12.0899 1
-      vertex -9.37252 1.24398 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.0555 12.0899 1
-      vertex -9.25 1.25 1
-      vertex -12.7796 12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.12748 1.24398 1
-      vertex -12.7796 12.2945 1
-      vertex -9.25 1.25 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.7796 12.2945 1
-      vertex -9.12748 1.24398 1
-      vertex -12.5251 12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -9.00614 1.22598 1
-      vertex -12.5251 12.5251 1
-      vertex -9.12748 1.24398 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -12.5251 12.5251 1
-      vertex -9.00614 1.22598 1
-      vertex -12.2945 12.7796 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0555 17.9101 1
-      vertex 13.0555 17.9101 1
-      vertex 13.3501 18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.3501 18.0867 1
-      vertex 13.3501 18.0867 1
-      vertex 13.6606 18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.6606 18.2336 1
-      vertex 13.6606 18.2336 1
-      vertex 13.984 18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.984 18.3493 1
-      vertex 13.984 18.3493 1
-      vertex 14.3172 18.4327 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3172 18.4327 1
-      vertex 14.3172 18.4327 1
-      vertex 14.6569 18.4831 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 15.3431 1
-      vertex -11.5169 15.3431 1
-      vertex -11.5 15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5673 15.6828 1
-      vertex -11.5673 15.6828 1
-      vertex -11.5169 15.3431 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6507 16.016 1
-      vertex -11.6507 16.016 1
-      vertex -11.5673 15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7664 16.3394 1
-      vertex -11.7664 16.3394 1
-      vertex -11.6507 16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.9133 16.6499 1
-      vertex -11.9133 16.6499 1
-      vertex -11.7664 16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0899 16.9445 1
-      vertex -12.0899 16.9445 1
-      vertex -11.9133 16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2945 17.2204 1
-      vertex -12.2945 17.2204 1
-      vertex -12.0899 16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6569 18.4831 1
-      vertex 14.6569 18.4831 1
-      vertex 15 18.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5251 17.4749 1
-      vertex -12.5251 17.4749 1
-      vertex -12.2945 17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7796 17.7055 1
-      vertex -12.7796 17.7055 1
-      vertex -12.5251 17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0555 17.9101 1
-      vertex -13.0555 17.9101 1
-      vertex -12.7796 17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.3501 18.0867 1
-      vertex -13.3501 18.0867 1
-      vertex -13.0555 17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6606 18.2336 1
-      vertex -13.6606 18.2336 1
-      vertex -13.3501 18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.984 18.3493 1
-      vertex -13.984 18.3493 1
-      vertex -13.6606 18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3172 18.4327 1
-      vertex -14.3172 18.4327 1
-      vertex -13.984 18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6569 18.4831 1
-      vertex -14.6569 18.4831 1
-      vertex -14.3172 18.4327 1
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex -14.6569 18.4831 1
-      vertex 15 18.5 1
-      vertex -15 18.5 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.4831 14.6569 1
-      vertex 18.5 -15 1
-      vertex 18.5 15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4831 14.6569 1
-      vertex 18.4831 -14.6569 1
-      vertex 18.5 -15 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.4327 14.3172 1
-      vertex 18.4831 -14.6569 1
-      vertex 18.4831 14.6569 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4327 14.3172 1
-      vertex 18.4327 -14.3172 1
-      vertex 18.4831 -14.6569 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.3493 13.984 1
-      vertex 18.4327 -14.3172 1
-      vertex 18.4327 14.3172 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3493 13.984 1
-      vertex 18.3493 -13.984 1
-      vertex 18.4327 -14.3172 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.2336 13.6606 1
-      vertex 18.3493 -13.984 1
-      vertex 18.3493 13.984 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2336 13.6606 1
-      vertex 18.2336 -13.6606 1
-      vertex 18.3493 -13.984 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.0867 13.3501 1
-      vertex 18.2336 -13.6606 1
-      vertex 18.2336 13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0867 13.3501 1
-      vertex 18.0867 -13.3501 1
-      vertex 18.2336 -13.6606 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.9101 13.0555 1
-      vertex 18.0867 -13.3501 1
-      vertex 18.0867 13.3501 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9101 13.0555 1
-      vertex 17.9101 -13.0555 1
-      vertex 18.0867 -13.3501 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.7055 12.7796 1
-      vertex 17.9101 -13.0555 1
-      vertex 17.9101 13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7055 12.7796 1
-      vertex 17.7055 -12.7796 1
-      vertex 17.9101 -13.0555 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.4749 12.5251 1
-      vertex 17.7055 -12.7796 1
-      vertex 17.7055 12.7796 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.4749 12.5251 1
-      vertex 17.4749 -12.5251 1
-      vertex 17.7055 -12.7796 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.2204 12.2945 1
-      vertex 17.4749 -12.5251 1
-      vertex 17.4749 12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.2204 12.2945 1
-      vertex 17.2204 -12.2945 1
-      vertex 17.4749 -12.5251 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.9445 12.0899 1
-      vertex 17.2204 -12.2945 1
-      vertex 17.2204 12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 12.0899 1
-      vertex 16.9445 -12.0899 1
-      vertex 17.2204 -12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 16.9445 12.0899 1
-      vertex 16.6499 11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 12.0899 1
-      vertex 10.5 0 1
-      vertex 16.9445 -12.0899 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 16.6499 11.9133 1
-      vertex 16.3394 11.7664 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.494 -0.122521 1
-      vertex 16.9445 -12.0899 1
-      vertex 10.5 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 16.3394 11.7664 1
-      vertex 16.016 11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 -12.0899 1
-      vertex 10.494 -0.122521 1
-      vertex 16.6499 -11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 16.016 11.6507 1
-      vertex 15.6828 11.5673 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.476 -0.243862 1
-      vertex 16.6499 -11.9133 1
-      vertex 10.494 -0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 15.6828 11.5673 1
-      vertex 15.3431 11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6499 -11.9133 1
-      vertex 10.476 -0.243862 1
-      vertex 16.3394 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 15.3431 11.5169 1
-      vertex 15 11.5 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.4462 -0.362855 1
-      vertex 16.3394 -11.7664 1
-      vertex 10.476 -0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 15 11.5 1
-      vertex 14.6569 11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3394 -11.7664 1
-      vertex 10.4462 -0.362855 1
-      vertex 16.016 -11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 14.6569 11.5169 1
-      vertex 14.3172 11.5673 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.4048 -0.478354 1
-      vertex 16.016 -11.6507 1
-      vertex 10.4462 -0.362855 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 14.3172 11.5673 1
-      vertex 13.984 11.6507 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.016 -11.6507 1
-      vertex 10.4048 -0.478354 1
-      vertex 15.6828 -11.5673 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 13.984 11.6507 1
-      vertex 13.6606 11.7664 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.3524 -0.589246 1
-      vertex 15.6828 -11.5673 1
-      vertex 10.4048 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 13.6606 11.7664 1
-      vertex 13.3501 11.9133 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6828 -11.5673 1
-      vertex 10.3524 -0.589246 1
-      vertex 15.3431 -11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 13.3501 11.9133 1
-      vertex 13.0555 12.0899 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.2893 -0.694463 1
-      vertex 15.3431 -11.5169 1
-      vertex 10.3524 -0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 13.0555 12.0899 1
-      vertex 12.7796 12.2945 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.2163 -0.792991 1
-      vertex 15.3431 -11.5169 1
-      vertex 10.2893 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 12.7796 12.2945 1
-      vertex 12.5251 12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.3431 -11.5169 1
-      vertex 10.2163 -0.792991 1
-      vertex 15 -11.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 12.5251 12.5251 1
-      vertex 12.2945 12.7796 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.1339 -0.883883 1
-      vertex 15 -11.5 1
-      vertex 10.2163 -0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 12.2945 12.7796 1
-      vertex 12.0899 13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 -11.5 1
-      vertex 10.1339 -0.883883 1
-      vertex 14.6569 -11.5169 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 12.0899 13.0555 1
-      vertex 11.9133 13.3501 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.043 -0.966263 1
-      vertex 14.6569 -11.5169 1
-      vertex 10.1339 -0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 11.9133 13.3501 1
-      vertex 11.7664 13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6569 -11.5169 1
-      vertex 10.043 -0.966263 1
-      vertex 14.3172 -11.5673 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 11.7664 13.6606 1
-      vertex 11.6507 13.984 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.94446 -1.03934 1
-      vertex 14.3172 -11.5673 1
-      vertex 10.043 -0.966263 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 11.6507 13.984 1
-      vertex 11.5673 14.3172 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.83925 -1.1024 1
-      vertex 14.3172 -11.5673 1
-      vertex 9.94446 -1.03934 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 0 1
-      vertex 11.5673 14.3172 1
-      vertex 11.5169 14.6569 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3172 -11.5673 1
-      vertex 9.83925 -1.1024 1
-      vertex 13.984 -11.6507 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.5 15 1
-      vertex 11.5169 14.6569 1
-      vertex 11.5 15 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.72835 -1.15485 1
-      vertex 13.984 -11.6507 1
-      vertex 9.83925 -1.1024 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.61285 -1.19617 1
-      vertex 13.6606 -11.7664 1
-      vertex 9.72835 -1.15485 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6606 -11.7664 1
-      vertex 9.61285 -1.19617 1
-      vertex 13.3501 -11.9133 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.49386 -1.22598 1
-      vertex 13.3501 -11.9133 1
-      vertex 9.61285 -1.19617 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.37252 -1.24398 1
-      vertex 13.3501 -11.9133 1
-      vertex 9.49386 -1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.3501 -11.9133 1
-      vertex 9.37252 -1.24398 1
-      vertex 13.0555 -12.0899 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.25 -1.25 1
-      vertex 13.0555 -12.0899 1
-      vertex 9.37252 -1.24398 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0555 -12.0899 1
-      vertex 9.25 -1.25 1
-      vertex 12.7796 -12.2945 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.12748 -1.24398 1
-      vertex 12.7796 -12.2945 1
-      vertex 9.25 -1.25 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7796 -12.2945 1
-      vertex 9.12748 -1.24398 1
-      vertex 12.5251 -12.5251 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.00614 -1.22598 1
-      vertex 12.5251 -12.5251 1
-      vertex 9.12748 -1.24398 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5251 -12.5251 1
-      vertex 9.00614 -1.22598 1
-      vertex 12.2945 -12.7796 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.88714 -1.19617 1
-      vertex 12.2945 -12.7796 1
-      vertex 9.00614 -1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.77165 -1.15485 1
-      vertex 12.2945 -12.7796 1
-      vertex 8.88714 -1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2945 -12.7796 1
-      vertex 8.77165 -1.15485 1
-      vertex 12.0899 -13.0555 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.66075 -1.1024 1
-      vertex 12.0899 -13.0555 1
-      vertex 8.77165 -1.15485 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0899 -13.0555 1
-      vertex 8.66075 -1.1024 1
-      vertex 11.9133 -13.3501 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.55554 -1.03934 1
-      vertex 11.9133 -13.3501 1
-      vertex 8.66075 -1.1024 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.9133 -13.3501 1
-      vertex 8.55554 -1.03934 1
-      vertex 11.7664 -13.6606 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.45701 -0.966263 1
-      vertex 11.7664 -13.6606 1
-      vertex 8.55554 -1.03934 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7664 -13.6606 1
-      vertex 8.45701 -0.966263 1
-      vertex 11.6507 -13.984 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.36612 -0.883883 1
-      vertex 11.6507 -13.984 1
-      vertex 8.45701 -0.966263 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -8.36612 -0.883883 1
-      vertex 11.6507 -13.984 1
-      vertex 8.36612 -0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex 11.6507 -13.984 1
-      vertex -8.36612 -0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 -14.6569 1
-      vertex -11.5 -15 1
-      vertex 11.5 -15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5 -15 1
-      vertex -11.5 -15 1
-      vertex 11.5169 -15.3431 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5673 -14.3172 1
-      vertex -11.5 -15 1
-      vertex 11.5169 -14.6569 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.36612 -0.883883 1
-      vertex 8.36612 -0.883883 1
-      vertex 8.28374 -0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.28374 -0.792991 1
-      vertex 8.28374 -0.792991 1
-      vertex 8.21066 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.21066 -0.694463 1
-      vertex 8.21066 -0.694463 1
-      vertex 8.1476 -0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.1476 -0.589246 1
-      vertex 8.1476 -0.589246 1
-      vertex 8.09515 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.09515 -0.478354 1
-      vertex 8.09515 -0.478354 1
-      vertex 8.05382 -0.362855 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.05382 -0.362855 1
-      vertex 8.05382 -0.362855 1
-      vertex 8.02402 -0.243862 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -8 0 1
-      vertex 8.00602 -0.122521 1
-      vertex 8 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.00602 -0.122521 1
-      vertex 8.00602 -0.122521 1
-      vertex -8 0 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.00602 -0.122521 1
-      vertex -8.00602 -0.122521 1
-      vertex 8.02402 -0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.02402 -0.243862 1
-      vertex 8.02402 -0.243862 1
-      vertex -8.00602 -0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -8.05382 -0.362855 1
-      vertex 8.02402 -0.243862 1
-      vertex -8.02402 -0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.05382 -0.362855 1
-      vertex -8.05382 -0.362855 1
-      vertex -8.09515 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.09515 -0.478354 1
-      vertex -8.09515 -0.478354 1
-      vertex -8.1476 -0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.1476 -0.589246 1
-      vertex -8.1476 -0.589246 1
-      vertex -8.21066 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.21066 -0.694463 1
-      vertex -8.21066 -0.694463 1
-      vertex -8.28374 -0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.28374 -0.792991 1
-      vertex -8.28374 -0.792991 1
-      vertex -8.36612 -0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6507 -13.984 1
-      vertex -11.5 -15 1
-      vertex 11.5673 -14.3172 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 -15.3431 1
-      vertex 11.5169 -15.3431 1
-      vertex -11.5 -15 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 -15.3431 1
-      vertex -11.5169 -15.3431 1
-      vertex 11.5673 -15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 -15.6828 1
-      vertex 11.5673 -15.6828 1
-      vertex -11.5169 -15.3431 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5673 -15.6828 1
-      vertex -11.5673 -15.6828 1
-      vertex 11.6507 -16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 -16.016 1
-      vertex 11.6507 -16.016 1
-      vertex -11.5673 -15.6828 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6507 -16.016 1
-      vertex -11.6507 -16.016 1
-      vertex 11.7664 -16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7664 -16.3394 1
-      vertex 11.7664 -16.3394 1
-      vertex -11.6507 -16.016 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -8.36612 -0.883883 1
-      vertex -8.45701 -0.966263 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -8.45701 -0.966263 1
-      vertex -8.55554 -1.03934 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -8.55554 -1.03934 1
-      vertex -8.66075 -1.1024 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -8.66075 -1.1024 1
-      vertex -8.77165 -1.15485 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -8.77165 -1.15485 1
-      vertex -8.88714 -1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -8.88714 -1.19617 1
-      vertex -9.00614 -1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.00614 -1.22598 1
-      vertex -9.12748 -1.24398 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.12748 -1.24398 1
-      vertex -9.25 -1.25 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.25 -1.25 1
-      vertex -9.37252 -1.24398 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.37252 -1.24398 1
-      vertex -9.49386 -1.22598 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7664 -16.3394 1
-      vertex -11.7664 -16.3394 1
-      vertex 11.9133 -16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.49386 -1.22598 1
-      vertex -9.61285 -1.19617 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.61285 -1.19617 1
-      vertex -9.72835 -1.15485 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.72835 -1.15485 1
-      vertex -9.83925 -1.1024 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.83925 -1.1024 1
-      vertex -9.94446 -1.03934 1
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.984 11.6507 1
-      vertex -9.72835 1.15485 1
-      vertex -13.6606 11.7664 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.5 0 1
-      vertex -11.5 -15 1
-      vertex -10.494 -0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.476 -0.243862 1
-      vertex -10.494 -0.122521 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.4462 -0.362855 1
-      vertex -10.476 -0.243862 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.4048 -0.478354 1
-      vertex -10.4462 -0.362855 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.3524 -0.589246 1
-      vertex -10.4048 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.2893 -0.694463 1
-      vertex -10.3524 -0.589246 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.2163 -0.792991 1
-      vertex -10.2893 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.1339 -0.883883 1
-      vertex -10.2163 -0.792991 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -10.043 -0.966263 1
-      vertex -10.1339 -0.883883 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 1
-      vertex -9.94446 -1.03934 1
-      vertex -10.043 -0.966263 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.9133 -16.6499 1
-      vertex 11.9133 -16.6499 1
-      vertex -11.7664 -16.3394 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.9133 -16.6499 1
-      vertex -11.9133 -16.6499 1
-      vertex 12.0899 -16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0899 -16.9445 1
-      vertex 12.0899 -16.9445 1
-      vertex -11.9133 -16.6499 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0899 -16.9445 1
-      vertex -12.0899 -16.9445 1
-      vertex 12.2945 -17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2945 -17.2204 1
-      vertex 12.2945 -17.2204 1
-      vertex -12.0899 -16.9445 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2945 -17.2204 1
-      vertex -12.2945 -17.2204 1
-      vertex 12.5251 -17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5251 -17.4749 1
-      vertex 12.5251 -17.4749 1
-      vertex -12.2945 -17.2204 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5251 -17.4749 1
-      vertex -12.5251 -17.4749 1
-      vertex 12.7796 -17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.7796 -17.7055 1
-      vertex 12.7796 -17.7055 1
-      vertex -12.5251 -17.4749 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7796 -17.7055 1
-      vertex -12.7796 -17.7055 1
-      vertex 13.0555 -17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0555 -17.9101 1
-      vertex 13.0555 -17.9101 1
-      vertex -12.7796 -17.7055 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0555 -17.9101 1
-      vertex -13.0555 -17.9101 1
-      vertex 13.3501 -18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.3501 -18.0867 1
-      vertex 13.3501 -18.0867 1
-      vertex -13.0555 -17.9101 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.3501 -18.0867 1
-      vertex -13.3501 -18.0867 1
-      vertex 13.6606 -18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.6606 -18.2336 1
-      vertex 13.6606 -18.2336 1
-      vertex -13.3501 -18.0867 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6606 -18.2336 1
-      vertex -13.6606 -18.2336 1
-      vertex 13.984 -18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.984 -18.3493 1
-      vertex 13.984 -18.3493 1
-      vertex -13.6606 -18.2336 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.984 -18.3493 1
-      vertex -13.984 -18.3493 1
-      vertex 14.3172 -18.4327 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3172 -18.4327 1
-      vertex 14.3172 -18.4327 1
-      vertex -13.984 -18.3493 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3172 -18.4327 1
-      vertex -14.3172 -18.4327 1
-      vertex 14.6569 -18.4831 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6569 -18.4831 1
-      vertex 14.6569 -18.4831 1
-      vertex -14.3172 -18.4327 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6569 -18.4831 1
-      vertex -14.6569 -18.4831 1
-      vertex 15 -18.5 1
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 -18.5 1
-      vertex -14.6569 -18.4831 1
-      vertex -15 -18.5 1
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 18.5 15 1
-      vertex 18.5 18.5 -1
-      vertex 18.5 18.5 1
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 18.5 -15 1
-      vertex 18.5 18.5 -1
-      vertex 18.5 15 1
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 18.5 -15 1
-      vertex 18.5 -18.5 1
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 18.5 -15 1
-      vertex 18.5 -18.5 -1
-      vertex 18.5 18.5 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.72835 -1.15485 -1
-      vertex -14.6371 -13.8038 -1
-      vertex -9.83925 -1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.756 14.8775 -1
-      vertex -13.75 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.7561 -13.774 -1
-      vertex -9.83925 -1.1024 -1
-      vertex -14.6371 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.774 14.7561 -1
-      vertex -13.756 14.8775 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.83925 -1.1024 -1
-      vertex -14.7561 -13.774 -1
-      vertex -9.94446 -1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.8038 14.6371 -1
-      vertex -13.774 14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8775 -13.756 -1
-      vertex -9.94446 -1.03934 -1
-      vertex -14.7561 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.8451 14.5216 -1
-      vertex -13.8038 14.6371 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.94446 -1.03934 -1
-      vertex -14.8775 -13.756 -1
-      vertex -10.043 -0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.8976 14.4108 -1
-      vertex -13.8451 14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15 -13.75 -1
-      vertex -10.043 -0.966263 -1
-      vertex -14.8775 -13.756 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.9607 14.3055 -1
-      vertex -13.8976 14.4108 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.043 -0.966263 -1
-      vertex -15 -13.75 -1
-      vertex -10.1339 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.0337 14.207 -1
-      vertex -13.9607 14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.1225 -13.756 -1
-      vertex -10.1339 -0.883883 -1
-      vertex -15 -13.75 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.1161 14.1161 -1
-      vertex -14.0337 14.207 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.1339 -0.883883 -1
-      vertex -15.1225 -13.756 -1
-      vertex -10.2163 -0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.207 14.0337 -1
-      vertex -14.1161 14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.2439 -13.774 -1
-      vertex -10.2163 -0.792991 -1
-      vertex -15.1225 -13.756 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.3055 13.9607 -1
-      vertex -14.207 14.0337 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.2163 -0.792991 -1
-      vertex -15.2439 -13.774 -1
-      vertex -10.2893 -0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.4108 13.8976 -1
-      vertex -14.3055 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.3629 -13.8038 -1
-      vertex -10.2893 -0.694463 -1
-      vertex -15.2439 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.5216 13.8451 -1
-      vertex -14.4108 13.8976 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.2893 -0.694463 -1
-      vertex -15.3629 -13.8038 -1
-      vertex -10.3524 -0.589246 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.6371 13.8038 -1
-      vertex -14.5216 13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.4784 -13.8451 -1
-      vertex -10.3524 -0.589246 -1
-      vertex -15.3629 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.7561 13.774 -1
-      vertex -14.6371 13.8038 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.3524 -0.589246 -1
-      vertex -15.4784 -13.8451 -1
-      vertex -10.4048 -0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -14.8775 13.756 -1
-      vertex -14.7561 13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.5892 -13.8976 -1
-      vertex -10.4048 -0.478354 -1
-      vertex -15.4784 -13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15 13.75 -1
-      vertex -14.8775 13.756 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.4048 -0.478354 -1
-      vertex -15.5892 -13.8976 -1
-      vertex -10.4462 -0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.1225 13.756 -1
-      vertex -15 13.75 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.6945 -13.9607 -1
-      vertex -10.4462 -0.362855 -1
-      vertex -15.5892 -13.8976 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.2439 13.774 -1
-      vertex -15.1225 13.756 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.4462 -0.362855 -1
-      vertex -15.6945 -13.9607 -1
-      vertex -10.476 -0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.3629 13.8038 -1
-      vertex -15.2439 13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.793 -14.0337 -1
-      vertex -10.476 -0.243862 -1
-      vertex -15.6945 -13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.4784 13.8451 -1
-      vertex -15.3629 13.8038 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.476 -0.243862 -1
-      vertex -15.793 -14.0337 -1
-      vertex -10.494 -0.122521 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.5892 13.8976 -1
-      vertex -15.4784 13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8839 -14.1161 -1
-      vertex -10.494 -0.122521 -1
-      vertex -15.793 -14.0337 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.6945 13.9607 -1
-      vertex -15.5892 13.8976 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.494 -0.122521 -1
-      vertex -15.8839 -14.1161 -1
-      vertex -10.5 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.793 14.0337 -1
-      vertex -15.6945 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8839 14.1161 -1
-      vertex -10.5 0 -1
-      vertex -15.8839 -14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -15.8839 14.1161 -1
-      vertex -15.793 14.0337 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9663 -14.207 -1
-      vertex -15.8839 14.1161 -1
-      vertex -15.8839 -14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9663 -14.207 -1
-      vertex -15.9663 14.207 -1
-      vertex -15.8839 14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0393 -14.3055 -1
-      vertex -15.9663 14.207 -1
-      vertex -15.9663 -14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0393 -14.3055 -1
-      vertex -16.0393 14.3055 -1
-      vertex -15.9663 14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1024 -14.4108 -1
-      vertex -16.0393 14.3055 -1
-      vertex -16.0393 -14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1024 -14.4108 -1
-      vertex -16.1024 14.4108 -1
-      vertex -16.0393 14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -16.1024 -14.4108 -1
-      vertex -16.1549 -14.5216 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.1024 -14.4108 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.1024 14.4108 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -16.1549 -14.5216 -1
-      vertex -16.1962 -14.6371 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -16.1024 14.4108 -1
-      vertex -18.5 -18.5 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -16.1962 -14.6371 -1
-      vertex -16.226 -14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1024 14.4108 -1
-      vertex -18.5 18.5 -1
-      vertex -16.1549 14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -16.226 -14.7561 -1
-      vertex -16.244 -14.8775 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1549 14.5216 -1
-      vertex -18.5 18.5 -1
-      vertex -16.1962 14.6371 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -16.244 -14.8775 -1
-      vertex -16.25 -15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1962 14.6371 -1
-      vertex -18.5 18.5 -1
-      vertex -16.226 14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1962 -14.6371 -1
-      vertex 18.5 -18.5 -1
-      vertex 16.226 -14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 18.5 -1
-      vertex 16.244 14.8775 -1
-      vertex 16.25 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1549 -14.5216 -1
-      vertex 18.5 -18.5 -1
-      vertex 16.1962 -14.6371 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 18.5 -1
-      vertex 16.226 14.7561 -1
-      vertex 16.244 14.8775 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1024 -14.4108 -1
-      vertex 18.5 -18.5 -1
-      vertex 16.1549 -14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 18.5 -1
-      vertex 16.1962 14.6371 -1
-      vertex 16.226 14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.1024 -14.4108 -1
-      vertex 18.5 18.5 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 18.5 -1
-      vertex 16.1549 14.5216 -1
-      vertex 16.1962 14.6371 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1024 14.4108 -1
-      vertex 18.5 18.5 -1
-      vertex 16.1024 -14.4108 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 18.5 -1
-      vertex 16.1024 14.4108 -1
-      vertex 16.1549 14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.0393 -14.3055 -1
-      vertex 16.1024 14.4108 -1
-      vertex 16.1024 -14.4108 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.0393 -14.3055 -1
-      vertex 16.0393 14.3055 -1
-      vertex 16.1024 14.4108 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9663 -14.207 -1
-      vertex 16.0393 14.3055 -1
-      vertex 16.0393 -14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9663 -14.207 -1
-      vertex 15.9663 14.207 -1
-      vertex 16.0393 14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8839 -14.1161 -1
-      vertex 15.9663 14.207 -1
-      vertex 15.9663 -14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8839 -14.1161 -1
-      vertex 15.8839 14.1161 -1
-      vertex 15.9663 14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.494 -0.122521 -1
-      vertex 15.8839 -14.1161 -1
-      vertex 15.793 -14.0337 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8839 -14.1161 -1
-      vertex 10.5 0 -1
-      vertex 15.8839 14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.476 -0.243862 -1
-      vertex 15.793 -14.0337 -1
-      vertex 15.6945 -13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.494 0.122521 -1
-      vertex 15.8839 14.1161 -1
-      vertex 10.5 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.4462 -0.362855 -1
-      vertex 15.6945 -13.9607 -1
-      vertex 15.5892 -13.8976 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8839 14.1161 -1
-      vertex 10.494 0.122521 -1
-      vertex 15.793 14.0337 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.4048 -0.478354 -1
-      vertex 15.5892 -13.8976 -1
-      vertex 15.4784 -13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.476 0.243862 -1
-      vertex 15.793 14.0337 -1
-      vertex 10.494 0.122521 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.3524 -0.589246 -1
-      vertex 15.4784 -13.8451 -1
-      vertex 15.3629 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.793 14.0337 -1
-      vertex 10.476 0.243862 -1
-      vertex 15.6945 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.2893 -0.694463 -1
-      vertex 15.3629 -13.8038 -1
-      vertex 15.2439 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.4462 0.362855 -1
-      vertex 15.6945 13.9607 -1
-      vertex 10.476 0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.2163 -0.792991 -1
-      vertex 15.2439 -13.774 -1
-      vertex 15.1225 -13.756 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.6945 13.9607 -1
-      vertex 10.4462 0.362855 -1
-      vertex 15.5892 13.8976 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.1339 -0.883883 -1
-      vertex 15.1225 -13.756 -1
-      vertex 15 -13.75 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.4048 0.478354 -1
-      vertex 15.5892 13.8976 -1
-      vertex 10.4462 0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.043 -0.966263 -1
-      vertex 15 -13.75 -1
-      vertex 14.8775 -13.756 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.5892 13.8976 -1
-      vertex 10.4048 0.478354 -1
-      vertex 15.4784 13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.94446 -1.03934 -1
-      vertex 14.8775 -13.756 -1
-      vertex 14.7561 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.3524 0.589246 -1
-      vertex 15.4784 13.8451 -1
-      vertex 10.4048 0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.83925 -1.1024 -1
-      vertex 14.7561 -13.774 -1
-      vertex 14.6371 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.4784 13.8451 -1
-      vertex 10.3524 0.589246 -1
-      vertex 15.3629 13.8038 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.72835 -1.15485 -1
-      vertex 14.6371 -13.8038 -1
-      vertex 14.5216 -13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.2893 0.694463 -1
-      vertex 15.3629 13.8038 -1
-      vertex 10.3524 0.589246 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.61285 -1.19617 -1
-      vertex 14.5216 -13.8451 -1
-      vertex 14.4108 -13.8976 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.3629 13.8038 -1
-      vertex 10.2893 0.694463 -1
-      vertex 15.2439 13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.49386 -1.22598 -1
-      vertex 14.4108 -13.8976 -1
-      vertex 14.3055 -13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.2163 0.792991 -1
-      vertex 15.2439 13.774 -1
-      vertex 10.2893 0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.37252 -1.24398 -1
-      vertex 14.3055 -13.9607 -1
-      vertex 14.207 -14.0337 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.2439 13.774 -1
-      vertex 10.2163 0.792991 -1
-      vertex 15.1225 13.756 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.25 -1.25 -1
-      vertex 14.207 -14.0337 -1
-      vertex 14.1161 -14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.1339 0.883883 -1
-      vertex 15.1225 13.756 -1
-      vertex 10.2163 0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.12748 -1.24398 -1
-      vertex 14.1161 -14.1161 -1
-      vertex 14.0337 -14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.1225 13.756 -1
-      vertex 10.1339 0.883883 -1
-      vertex 15 13.75 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.00614 -1.22598 -1
-      vertex 14.0337 -14.207 -1
-      vertex 13.9607 -14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.043 0.966263 -1
-      vertex 15 13.75 -1
-      vertex 10.1339 0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.88714 -1.19617 -1
-      vertex 13.9607 -14.3055 -1
-      vertex 13.8976 -14.4108 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15 13.75 -1
-      vertex 10.043 0.966263 -1
-      vertex 14.8775 13.756 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.77165 -1.15485 -1
-      vertex 13.8976 -14.4108 -1
-      vertex 13.8451 -14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.94446 1.03934 -1
-      vertex 14.8775 13.756 -1
-      vertex 10.043 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.66075 -1.1024 -1
-      vertex 13.8451 -14.5216 -1
-      vertex 13.8038 -14.6371 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.8775 13.756 -1
-      vertex 9.94446 1.03934 -1
-      vertex 14.7561 13.774 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.55554 -1.03934 -1
-      vertex 13.8038 -14.6371 -1
-      vertex 13.774 -14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.83925 1.1024 -1
-      vertex 14.7561 13.774 -1
-      vertex 9.94446 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.756 -14.8775 -1
-      vertex 13.756 -14.8775 -1
-      vertex -13.75 -15 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.7561 13.774 -1
-      vertex 9.83925 1.1024 -1
-      vertex 14.6371 13.8038 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 -15 -1
-      vertex 13.756 -14.8775 -1
-      vertex 13.75 -15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.72835 1.15485 -1
-      vertex 14.6371 13.8038 -1
-      vertex 9.83925 1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.244 -14.8775 -1
-      vertex 18.5 -18.5 -1
-      vertex 16.25 -15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.244 -15.1225 -1
-      vertex 16.25 -15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.226 -15.2439 -1
-      vertex 16.244 -15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.1962 -15.3629 -1
-      vertex 16.226 -15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.1549 -15.4784 -1
-      vertex 16.1962 -15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.1024 -15.5892 -1
-      vertex 16.1549 -15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 16.0393 -15.6945 -1
-      vertex 16.1024 -15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.9663 -15.793 -1
-      vertex 16.0393 -15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.8839 -15.8839 -1
-      vertex 15.9663 -15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.793 -15.9663 -1
-      vertex 15.8839 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.6945 -16.0393 -1
-      vertex 15.793 -15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.5892 -16.1024 -1
-      vertex 15.6945 -16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.4784 -16.1549 -1
-      vertex 15.5892 -16.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.3629 -16.1962 -1
-      vertex 15.4784 -16.1549 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.2439 -16.226 -1
-      vertex 15.3629 -16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15.1225 -16.244 -1
-      vertex 15.2439 -16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15 -16.25 -1
-      vertex 15.1225 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 14.8775 -16.244 -1
-      vertex 15 -16.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 14.7561 -16.226 -1
-      vertex 14.8775 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 14.6371 -16.1962 -1
-      vertex 14.7561 -16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 14.5216 -16.1549 -1
-      vertex 14.6371 -16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 14.4108 -16.1024 -1
-      vertex 14.5216 -16.1549 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.6371 13.8038 -1
-      vertex 9.72835 1.15485 -1
-      vertex 14.5216 13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 -15 -1
-      vertex 13.75 -15 -1
-      vertex 13.756 -15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.756 -15.1225 -1
-      vertex 13.756 -15.1225 -1
-      vertex 13.774 -15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8839 -14.1161 -1
-      vertex 10.494 -0.122521 -1
-      vertex 10.5 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.793 -14.0337 -1
-      vertex 10.476 -0.243862 -1
-      vertex 10.494 -0.122521 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.6945 -13.9607 -1
-      vertex 10.4462 -0.362855 -1
-      vertex 10.476 -0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.5892 -13.8976 -1
-      vertex 10.4048 -0.478354 -1
-      vertex 10.4462 -0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.4784 -13.8451 -1
-      vertex 10.3524 -0.589246 -1
-      vertex 10.4048 -0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.3629 -13.8038 -1
-      vertex 10.2893 -0.694463 -1
-      vertex 10.3524 -0.589246 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.2439 -13.774 -1
-      vertex 10.2163 -0.792991 -1
-      vertex 10.2893 -0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.1225 -13.756 -1
-      vertex 10.1339 -0.883883 -1
-      vertex 10.2163 -0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.774 -15.2439 -1
-      vertex 13.774 -15.2439 -1
-      vertex 13.8038 -15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15 -13.75 -1
-      vertex 10.043 -0.966263 -1
-      vertex 10.1339 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8775 -13.756 -1
-      vertex 9.94446 -1.03934 -1
-      vertex 10.043 -0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.7561 -13.774 -1
-      vertex 9.83925 -1.1024 -1
-      vertex 9.94446 -1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.6371 -13.8038 -1
-      vertex 9.72835 -1.15485 -1
-      vertex 9.83925 -1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.5216 -13.8451 -1
-      vertex 9.61285 -1.19617 -1
-      vertex 9.72835 -1.15485 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.4108 -13.8976 -1
-      vertex 9.49386 -1.22598 -1
-      vertex 9.61285 -1.19617 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3055 -13.9607 -1
-      vertex 9.37252 -1.24398 -1
-      vertex 9.49386 -1.22598 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.207 -14.0337 -1
-      vertex 9.25 -1.25 -1
-      vertex 9.37252 -1.24398 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1161 -14.1161 -1
-      vertex 9.12748 -1.24398 -1
-      vertex 9.25 -1.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0337 -14.207 -1
-      vertex 9.00614 -1.22598 -1
-      vertex 9.12748 -1.24398 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.9607 -14.3055 -1
-      vertex 8.88714 -1.19617 -1
-      vertex 9.00614 -1.22598 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8976 -14.4108 -1
-      vertex 8.77165 -1.15485 -1
-      vertex 8.88714 -1.19617 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8451 -14.5216 -1
-      vertex 8.66075 -1.1024 -1
-      vertex 8.77165 -1.15485 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8038 -15.3629 -1
-      vertex 13.8038 -15.3629 -1
-      vertex 13.8451 -15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8038 -14.6371 -1
-      vertex 8.55554 -1.03934 -1
-      vertex 8.66075 -1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.774 -14.7561 -1
-      vertex 8.45701 -0.966263 -1
-      vertex 8.55554 -1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.756 -14.8775 -1
-      vertex -13.756 -14.8775 -1
-      vertex 13.774 -14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.774 -14.7561 -1
-      vertex 13.774 -14.7561 -1
-      vertex -13.756 -14.8775 -1
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -8.36612 -0.883883 -1
-      vertex 8.36612 -0.883883 -1
-      vertex -8.45701 -0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.36612 -0.883883 -1
-      vertex -8.36612 -0.883883 -1
-      vertex 8.28374 -0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -8.28374 -0.792991 -1
-      vertex 8.28374 -0.792991 -1
-      vertex -8.36612 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.00602 -0.122521 -1
-      vertex -8 0 -1
-      vertex 8 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.00602 -0.122521 -1
-      vertex 8.00602 -0.122521 -1
-      vertex 8.02402 -0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.02402 -0.243862 -1
-      vertex 8.02402 -0.243862 -1
-      vertex 8.05382 -0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.05382 -0.362855 -1
-      vertex 8.05382 -0.362855 -1
-      vertex 8.09515 -0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.28374 -0.792991 -1
-      vertex -8.28374 -0.792991 -1
-      vertex 8.21066 -0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8451 -15.4784 -1
-      vertex 13.8451 -15.4784 -1
-      vertex 13.8976 -15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8976 -15.5892 -1
-      vertex 13.8976 -15.5892 -1
-      vertex 13.9607 -15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.9607 -15.6945 -1
-      vertex 13.9607 -15.6945 -1
-      vertex 14.0337 -15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.0337 -15.793 -1
-      vertex 14.0337 -15.793 -1
-      vertex 14.1161 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1161 -15.8839 -1
-      vertex 14.1161 -15.8839 -1
-      vertex 14.207 -15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.207 -15.9663 -1
-      vertex 14.207 -15.9663 -1
-      vertex 14.3055 -16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.00602 -0.122521 -1
-      vertex -8.00602 -0.122521 -1
-      vertex -8 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.02402 -0.243862 -1
-      vertex -8.02402 -0.243862 -1
-      vertex -8.00602 -0.122521 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.05382 -0.362855 -1
-      vertex -8.05382 -0.362855 -1
-      vertex -8.02402 -0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.09515 -0.478354 -1
-      vertex -8.09515 -0.478354 -1
-      vertex -8.05382 -0.362855 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 8.09515 -0.478354 -1
-      vertex -8.1476 -0.589246 -1
-      vertex -8.09515 -0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.1476 -0.589246 -1
-      vertex -8.1476 -0.589246 -1
-      vertex 8.09515 -0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -8.1476 -0.589246 -1
-      vertex 8.1476 -0.589246 -1
-      vertex -8.21066 -0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.21066 -0.694463 -1
-      vertex -8.21066 -0.694463 -1
-      vertex 8.1476 -0.589246 -1
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -8.21066 -0.694463 -1
-      vertex 8.21066 -0.694463 -1
-      vertex -8.28374 -0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.45701 -0.966263 -1
-      vertex -8.45701 -0.966263 -1
-      vertex 8.36612 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.774 -14.7561 -1
-      vertex -13.774 -14.7561 -1
-      vertex 8.45701 -0.966263 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 8.45701 -0.966263 -1
-      vertex -13.774 -14.7561 -1
-      vertex -8.45701 -0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.45701 -0.966263 -1
-      vertex -13.774 -14.7561 -1
-      vertex -8.55554 -1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8038 -14.6371 -1
-      vertex -8.55554 -1.03934 -1
-      vertex -13.774 -14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.55554 -1.03934 -1
-      vertex -13.8038 -14.6371 -1
-      vertex -8.66075 -1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8451 -14.5216 -1
-      vertex -8.66075 -1.1024 -1
-      vertex -13.8038 -14.6371 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.66075 -1.1024 -1
-      vertex -13.8451 -14.5216 -1
-      vertex -8.77165 -1.15485 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8976 -14.4108 -1
-      vertex -8.77165 -1.15485 -1
-      vertex -13.8451 -14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.77165 -1.15485 -1
-      vertex -13.8976 -14.4108 -1
-      vertex -8.88714 -1.19617 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.9607 -14.3055 -1
-      vertex -8.88714 -1.19617 -1
-      vertex -13.8976 -14.4108 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.88714 -1.19617 -1
-      vertex -13.9607 -14.3055 -1
-      vertex -9.00614 -1.22598 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.0337 -14.207 -1
-      vertex -9.00614 -1.22598 -1
-      vertex -13.9607 -14.3055 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.61285 -1.19617 -1
-      vertex -14.5216 -13.8451 -1
-      vertex -9.72835 -1.15485 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.5216 -13.8451 -1
-      vertex -9.61285 -1.19617 -1
-      vertex -14.4108 -13.8976 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.49386 -1.22598 -1
-      vertex -14.4108 -13.8976 -1
-      vertex -9.61285 -1.19617 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.4108 -13.8976 -1
-      vertex -9.49386 -1.22598 -1
-      vertex -14.3055 -13.9607 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.37252 -1.24398 -1
-      vertex -14.3055 -13.9607 -1
-      vertex -9.49386 -1.22598 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.3055 -13.9607 -1
-      vertex -9.37252 -1.24398 -1
-      vertex -14.207 -14.0337 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -9.25 -1.25 -1
-      vertex -14.207 -14.0337 -1
-      vertex -9.37252 -1.24398 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.207 -14.0337 -1
-      vertex -9.25 -1.25 -1
-      vertex -14.1161 -14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -9.12748 -1.24398 -1
-      vertex -14.1161 -14.1161 -1
-      vertex -9.25 -1.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1161 -14.1161 -1
-      vertex -9.12748 -1.24398 -1
-      vertex -14.0337 -14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -9.00614 -1.22598 -1
-      vertex -14.0337 -14.207 -1
-      vertex -9.12748 -1.24398 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.3055 -16.0393 -1
-      vertex 14.3055 -16.0393 -1
-      vertex 14.4108 -16.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.4108 -16.1024 -1
-      vertex 14.4108 -16.1024 -1
-      vertex 18.5 -18.5 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.756 -15.1225 -1
-      vertex -13.756 -15.1225 -1
-      vertex -13.75 -15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.774 -15.2439 -1
-      vertex -13.774 -15.2439 -1
-      vertex -13.756 -15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8038 -15.3629 -1
-      vertex -13.8038 -15.3629 -1
-      vertex -13.774 -15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8451 -15.4784 -1
-      vertex -13.8451 -15.4784 -1
-      vertex -13.8038 -15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8976 -15.5892 -1
-      vertex -13.8976 -15.5892 -1
-      vertex -13.8451 -15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.9607 -15.6945 -1
-      vertex -13.9607 -15.6945 -1
-      vertex -13.8976 -15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0337 -15.793 -1
-      vertex -14.0337 -15.793 -1
-      vertex -13.9607 -15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1161 -15.8839 -1
-      vertex -14.1161 -15.8839 -1
-      vertex -14.0337 -15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.207 -15.9663 -1
-      vertex -14.207 -15.9663 -1
-      vertex -14.1161 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3055 -16.0393 -1
-      vertex -14.3055 -16.0393 -1
-      vertex -14.207 -15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.4108 -16.1024 -1
-      vertex -14.4108 -16.1024 -1
-      vertex -14.3055 -16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -14.4108 -16.1024 -1
-      vertex 18.5 -18.5 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.4108 -16.1024 -1
-      vertex -18.5 -18.5 -1
-      vertex -14.5216 -16.1549 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.5216 -16.1549 -1
-      vertex -18.5 -18.5 -1
-      vertex -14.6371 -16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.6371 -16.1962 -1
-      vertex -18.5 -18.5 -1
-      vertex -14.7561 -16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.7561 -16.226 -1
-      vertex -18.5 -18.5 -1
-      vertex -14.8775 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.8775 -16.244 -1
-      vertex -18.5 -18.5 -1
-      vertex -15 -16.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.226 14.7561 -1
-      vertex -18.5 18.5 -1
-      vertex -16.244 14.8775 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.244 -15.1225 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.25 -15 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.226 -15.2439 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.244 -15.1225 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.1962 -15.3629 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.226 -15.2439 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.1549 -15.4784 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.1962 -15.3629 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.1024 -15.5892 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.1549 -15.4784 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -16.0393 -15.6945 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.1024 -15.5892 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.9663 -15.793 -1
-      vertex -18.5 -18.5 -1
-      vertex -16.0393 -15.6945 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.8839 -15.8839 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.9663 -15.793 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.793 -15.9663 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.8839 -15.8839 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.6945 -16.0393 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.793 -15.9663 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.5892 -16.1024 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.6945 -16.0393 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.4784 -16.1549 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.5892 -16.1024 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.3629 -16.1962 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.4784 -16.1549 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.2439 -16.226 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.3629 -16.1962 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.1225 -16.244 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.2439 -16.226 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15 -16.25 -1
-      vertex -18.5 -18.5 -1
-      vertex -15.1225 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.226 -14.7561 -1
-      vertex 18.5 -18.5 -1
-      vertex 16.244 -14.8775 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.244 15.1225 -1
-      vertex 18.5 18.5 -1
-      vertex 16.25 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.226 15.2439 -1
-      vertex 18.5 18.5 -1
-      vertex 16.244 15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1962 15.3629 -1
-      vertex 18.5 18.5 -1
-      vertex 16.226 15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1549 15.4784 -1
-      vertex 18.5 18.5 -1
-      vertex 16.1962 15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.1024 15.5892 -1
-      vertex 18.5 18.5 -1
-      vertex 16.1549 15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.0393 15.6945 -1
-      vertex 18.5 18.5 -1
-      vertex 16.1024 15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9663 15.793 -1
-      vertex 18.5 18.5 -1
-      vertex 16.0393 15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8839 15.8839 -1
-      vertex 18.5 18.5 -1
-      vertex 15.9663 15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.793 15.9663 -1
-      vertex 18.5 18.5 -1
-      vertex 15.8839 15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.6945 16.0393 -1
-      vertex 18.5 18.5 -1
-      vertex 15.793 15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.5892 16.1024 -1
-      vertex 18.5 18.5 -1
-      vertex 15.6945 16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.4784 16.1549 -1
-      vertex 18.5 18.5 -1
-      vertex 15.5892 16.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.3629 16.1962 -1
-      vertex 18.5 18.5 -1
-      vertex 15.4784 16.1549 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.2439 16.226 -1
-      vertex 18.5 18.5 -1
-      vertex 15.3629 16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.1225 16.244 -1
-      vertex 18.5 18.5 -1
-      vertex 15.2439 16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15 16.25 -1
-      vertex 18.5 18.5 -1
-      vertex 15.1225 16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8775 16.244 -1
-      vertex 18.5 18.5 -1
-      vertex 15 16.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.7561 16.226 -1
-      vertex 18.5 18.5 -1
-      vertex 14.8775 16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.6371 16.1962 -1
-      vertex 18.5 18.5 -1
-      vertex 14.7561 16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.5216 16.1549 -1
-      vertex 18.5 18.5 -1
-      vertex 14.6371 16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.4108 16.1024 -1
-      vertex 18.5 18.5 -1
-      vertex 14.5216 16.1549 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.61285 1.19617 -1
-      vertex 14.5216 13.8451 -1
-      vertex 9.72835 1.15485 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.5216 13.8451 -1
-      vertex 9.61285 1.19617 -1
-      vertex 14.4108 13.8976 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.49386 1.22598 -1
-      vertex 14.4108 13.8976 -1
-      vertex 9.61285 1.19617 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.4108 13.8976 -1
-      vertex 9.49386 1.22598 -1
-      vertex 14.3055 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.37252 1.24398 -1
-      vertex 14.3055 13.9607 -1
-      vertex 9.49386 1.22598 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.3055 13.9607 -1
-      vertex 9.37252 1.24398 -1
-      vertex 14.207 14.0337 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.25 1.25 -1
-      vertex 14.207 14.0337 -1
-      vertex 9.37252 1.24398 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.207 14.0337 -1
-      vertex 9.25 1.25 -1
-      vertex 14.1161 14.1161 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.12748 1.24398 -1
-      vertex 14.1161 14.1161 -1
-      vertex 9.25 1.25 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.1161 14.1161 -1
-      vertex 9.12748 1.24398 -1
-      vertex 14.0337 14.207 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.00614 1.22598 -1
-      vertex 14.0337 14.207 -1
-      vertex 9.12748 1.24398 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.0337 14.207 -1
-      vertex 9.00614 1.22598 -1
-      vertex 13.9607 14.3055 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.88714 1.19617 -1
-      vertex 13.9607 14.3055 -1
-      vertex 9.00614 1.22598 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 13.9607 14.3055 -1
-      vertex 8.88714 1.19617 -1
-      vertex 13.8976 14.4108 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.77165 1.15485 -1
-      vertex 13.8976 14.4108 -1
-      vertex 8.88714 1.19617 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 13.8976 14.4108 -1
-      vertex 8.77165 1.15485 -1
-      vertex 13.8451 14.5216 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.66075 1.1024 -1
-      vertex 13.8451 14.5216 -1
-      vertex 8.77165 1.15485 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 13.8451 14.5216 -1
-      vertex 8.66075 1.1024 -1
-      vertex 13.8038 14.6371 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.55554 1.03934 -1
-      vertex 13.8038 14.6371 -1
-      vertex 8.66075 1.1024 -1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 13.8038 14.6371 -1
-      vertex 8.55554 1.03934 -1
-      vertex 13.774 14.7561 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.45701 0.966263 -1
-      vertex 13.774 14.7561 -1
-      vertex 8.55554 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex 13.774 14.7561 -1
-      vertex 8.45701 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.774 14.7561 -1
-      vertex -13.75 15 -1
-      vertex 13.756 14.8775 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.756 14.8775 -1
-      vertex -13.75 15 -1
-      vertex 13.75 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.75 15 -1
-      vertex -13.75 15 -1
-      vertex 13.756 15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.756 15.1225 -1
-      vertex 13.756 15.1225 -1
-      vertex -13.75 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.756 15.1225 -1
-      vertex -13.756 15.1225 -1
-      vertex 13.774 15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.45701 0.966263 -1
-      vertex 8.45701 0.966263 -1
-      vertex 8.36612 0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.36612 0.883883 -1
-      vertex 8.36612 0.883883 -1
-      vertex 8.28374 0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.28374 0.792991 -1
-      vertex 8.28374 0.792991 -1
-      vertex 8.21066 0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.21066 0.694463 -1
-      vertex 8.21066 0.694463 -1
-      vertex 8.1476 0.589246 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.1476 0.589246 -1
-      vertex 8.1476 0.589246 -1
-      vertex 8.09515 0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 0 -1
-      vertex 8.00602 0.122521 -1
-      vertex 8 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.00602 0.122521 -1
-      vertex 8.00602 0.122521 -1
-      vertex -8 0 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.00602 0.122521 -1
-      vertex -8.00602 0.122521 -1
-      vertex 8.02402 0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.02402 0.243862 -1
-      vertex 8.02402 0.243862 -1
-      vertex -8.00602 0.122521 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.02402 0.243862 -1
-      vertex -8.02402 0.243862 -1
-      vertex 8.05382 0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.05382 0.362855 -1
-      vertex 8.05382 0.362855 -1
-      vertex -8.02402 0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.05382 0.362855 -1
-      vertex -8.05382 0.362855 -1
-      vertex 8.09515 0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.09515 0.478354 -1
-      vertex 8.09515 0.478354 -1
-      vertex -8.05382 0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.1476 0.589246 -1
-      vertex 8.09515 0.478354 -1
-      vertex -8.09515 0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.1476 0.589246 -1
-      vertex -8.1476 0.589246 -1
-      vertex -8.21066 0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.21066 0.694463 -1
-      vertex -8.21066 0.694463 -1
-      vertex -8.28374 0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.28374 0.792991 -1
-      vertex -8.28374 0.792991 -1
-      vertex -8.36612 0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.36612 0.883883 -1
-      vertex -8.36612 0.883883 -1
-      vertex -8.45701 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.45701 0.966263 -1
-      vertex -8.45701 0.966263 -1
-      vertex -13.75 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.774 15.2439 -1
-      vertex 13.774 15.2439 -1
-      vertex -13.756 15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.774 15.2439 -1
-      vertex -13.774 15.2439 -1
-      vertex 13.8038 15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8038 15.3629 -1
-      vertex 13.8038 15.3629 -1
-      vertex -13.774 15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8038 15.3629 -1
-      vertex -13.8038 15.3629 -1
-      vertex 13.8451 15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8451 15.4784 -1
-      vertex 13.8451 15.4784 -1
-      vertex -13.8038 15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8451 15.4784 -1
-      vertex -13.8451 15.4784 -1
-      vertex 13.8976 15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -8.45701 0.966263 -1
-      vertex -8.55554 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -8.55554 1.03934 -1
-      vertex -8.66075 1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -8.66075 1.1024 -1
-      vertex -8.77165 1.15485 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -8.77165 1.15485 -1
-      vertex -8.88714 1.19617 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -8.88714 1.19617 -1
-      vertex -9.00614 1.22598 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.00614 1.22598 -1
-      vertex -9.12748 1.24398 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.12748 1.24398 -1
-      vertex -9.25 1.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.25 1.25 -1
-      vertex -9.37252 1.24398 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.37252 1.24398 -1
-      vertex -9.49386 1.22598 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.49386 1.22598 -1
-      vertex -9.61285 1.19617 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.61285 1.19617 -1
-      vertex -9.72835 1.15485 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.72835 1.15485 -1
-      vertex -9.83925 1.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.83925 1.1024 -1
-      vertex -9.94446 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.6371 -13.8038 -1
-      vertex -9.72835 -1.15485 -1
-      vertex -14.5216 -13.8451 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5 0 -1
-      vertex -13.75 15 -1
-      vertex -10.494 0.122521 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.494 0.122521 -1
-      vertex -13.75 15 -1
-      vertex -10.476 0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.4462 0.362855 -1
-      vertex -10.476 0.243862 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.4048 0.478354 -1
-      vertex -10.4462 0.362855 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.3524 0.589246 -1
-      vertex -10.4048 0.478354 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.2893 0.694463 -1
-      vertex -10.3524 0.589246 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.2163 0.792991 -1
-      vertex -10.2893 0.694463 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.1339 0.883883 -1
-      vertex -10.2163 0.792991 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -10.043 0.966263 -1
-      vertex -10.1339 0.883883 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.75 15 -1
-      vertex -9.94446 1.03934 -1
-      vertex -10.043 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8976 15.5892 -1
-      vertex 13.8976 15.5892 -1
-      vertex -13.8451 15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.8976 15.5892 -1
-      vertex -13.8976 15.5892 -1
-      vertex 13.9607 15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.9607 15.6945 -1
-      vertex 13.9607 15.6945 -1
-      vertex -13.8976 15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.9607 15.6945 -1
-      vertex -13.9607 15.6945 -1
-      vertex 14.0337 15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.0337 15.793 -1
-      vertex 14.0337 15.793 -1
-      vertex -13.9607 15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0337 15.793 -1
-      vertex -14.0337 15.793 -1
-      vertex 14.1161 15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.1161 15.8839 -1
-      vertex 14.1161 15.8839 -1
-      vertex -14.0337 15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.1161 15.8839 -1
-      vertex -14.1161 15.8839 -1
-      vertex 14.207 15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.207 15.9663 -1
-      vertex 14.207 15.9663 -1
-      vertex -14.1161 15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.207 15.9663 -1
-      vertex -14.207 15.9663 -1
-      vertex 14.3055 16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.3055 16.0393 -1
-      vertex 14.3055 16.0393 -1
-      vertex -14.207 15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3055 16.0393 -1
-      vertex -14.3055 16.0393 -1
-      vertex 14.4108 16.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.4108 16.1024 -1
-      vertex 14.4108 16.1024 -1
-      vertex -14.3055 16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.4108 16.1024 -1
-      vertex -14.4108 16.1024 -1
-      vertex 18.5 18.5 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -14.4108 16.1024 -1
-      vertex -14.5216 16.1549 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -14.5216 16.1549 -1
-      vertex -14.6371 16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -14.6371 16.1962 -1
-      vertex -14.7561 16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -14.7561 16.226 -1
-      vertex -14.8775 16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -14.8775 16.244 -1
-      vertex -15 16.25 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -18.5 18.5 -1
-      vertex -15 16.25 -1
-      vertex -15.1225 16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.244 14.8775 -1
-      vertex -18.5 18.5 -1
-      vertex -16.25 15 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.4108 16.1024 -1
-      vertex -18.5 18.5 -1
-      vertex 18.5 18.5 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.2439 16.226 -1
-      vertex -18.5 18.5 -1
-      vertex -15.1225 16.244 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.3629 16.1962 -1
-      vertex -18.5 18.5 -1
-      vertex -15.2439 16.226 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.4784 16.1549 -1
-      vertex -18.5 18.5 -1
-      vertex -15.3629 16.1962 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.5892 16.1024 -1
-      vertex -18.5 18.5 -1
-      vertex -15.4784 16.1549 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.6945 16.0393 -1
-      vertex -18.5 18.5 -1
-      vertex -15.5892 16.1024 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.793 15.9663 -1
-      vertex -18.5 18.5 -1
-      vertex -15.6945 16.0393 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8839 15.8839 -1
-      vertex -18.5 18.5 -1
-      vertex -15.793 15.9663 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.9663 15.793 -1
-      vertex -18.5 18.5 -1
-      vertex -15.8839 15.8839 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.0393 15.6945 -1
-      vertex -18.5 18.5 -1
-      vertex -15.9663 15.793 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1024 15.5892 -1
-      vertex -18.5 18.5 -1
-      vertex -16.0393 15.6945 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1549 15.4784 -1
-      vertex -18.5 18.5 -1
-      vertex -16.1024 15.5892 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.1962 15.3629 -1
-      vertex -18.5 18.5 -1
-      vertex -16.1549 15.4784 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.226 15.2439 -1
-      vertex -18.5 18.5 -1
-      vertex -16.1962 15.3629 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.244 15.1225 -1
-      vertex -18.5 18.5 -1
-      vertex -16.226 15.2439 -1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.25 15 -1
-      vertex -18.5 18.5 -1
-      vertex -16.244 15.1225 -1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -18.5 -18.5 -1
-      vertex -15 -18.5 1
-      vertex -18.5 -18.5 1
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -15 -18.5 1
-      vertex -18.5 -18.5 -1
-      vertex 15 -18.5 1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 18.5 -18.5 -1
-      vertex 15 -18.5 1
-      vertex -18.5 -18.5 -1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 15 -18.5 1
-      vertex 18.5 -18.5 -1
-      vertex 18.5 -18.5 1
     endloop
   endfacet
   facet normal 0 1 -0
@@ -5627,60 +4787,32 @@ solid OpenSCAD_Model
       vertex -18.5 18.5 1
     endloop
   endfacet
-  facet normal 0.595659 0.803237 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 17.2204 17.7055 1
-      vertex 16.9445 17.9101 6
-      vertex 17.2204 17.7055 6
+      vertex -18.5 -18.5 -1
+      vertex -15 -18.5 1
+      vertex -18.5 -18.5 1
     endloop
   endfacet
-  facet normal 0.595659 0.803237 0
+  facet normal 0 -1 -0
     outer loop
-      vertex 16.9445 17.9101 6
-      vertex 17.2204 17.7055 1
-      vertex 16.9445 17.9101 1
+      vertex -15 -18.5 1
+      vertex -18.5 -18.5 -1
+      vertex 15 -18.5 1
     endloop
   endfacet
-  facet normal -0.427661 0.903939 0
+  facet normal 0 -1 0
     outer loop
-      vertex 13.6606 18.2336 1
-      vertex 13.3501 18.0867 6
-      vertex 13.6606 18.2336 6
+      vertex 18.5 -18.5 -1
+      vertex 15 -18.5 1
+      vertex -18.5 -18.5 -1
     endloop
   endfacet
-  facet normal -0.427661 0.903939 0
+  facet normal 0 -1 0
     outer loop
-      vertex 13.3501 18.0867 6
-      vertex 13.6606 18.2336 1
-      vertex 13.3501 18.0867 1
-    endloop
-  endfacet
-  facet normal -0.941557 0.336853 0
-    outer loop
-      vertex 11.6507 16.016 1
-      vertex 11.7664 16.3394 6
-      vertex 11.7664 16.3394 1
-    endloop
-  endfacet
-  facet normal -0.941557 0.336853 0
-    outer loop
-      vertex 11.7664 16.3394 6
-      vertex 11.6507 16.016 1
-      vertex 11.6507 16.016 6
-    endloop
-  endfacet
-  facet normal 0.941557 -0.336853 0
-    outer loop
-      vertex 18.2336 13.6606 6
-      vertex 18.3493 13.984 1
-      vertex 18.3493 13.984 6
-    endloop
-  endfacet
-  facet normal 0.941557 -0.336853 0
-    outer loop
-      vertex 18.3493 13.984 1
-      vertex 18.2336 13.6606 6
-      vertex 18.2336 13.6606 1
+      vertex 15 -18.5 1
+      vertex 18.5 -18.5 -1
+      vertex 18.5 -18.5 1
     endloop
   endfacet
   facet normal -0.336853 -0.941557 0
@@ -5697,32 +4829,74 @@ solid OpenSCAD_Model
       vertex 13.984 11.6507 1
     endloop
   endfacet
-  facet normal 0.903939 0.427661 0
+  facet normal 0.989172 0.14676 0
     outer loop
-      vertex 18.2336 16.3394 6
-      vertex 18.0867 16.6499 1
-      vertex 18.0867 16.6499 6
+      vertex 18.4831 15.3431 6
+      vertex 18.4327 15.6828 1
+      vertex 18.4327 15.6828 6
     endloop
   endfacet
-  facet normal 0.903939 0.427661 0
+  facet normal 0.989172 0.14676 0
     outer loop
-      vertex 18.0867 16.6499 1
-      vertex 18.2336 16.3394 6
-      vertex 18.2336 16.3394 1
+      vertex 18.4327 15.6828 1
+      vertex 18.4831 15.3431 6
+      vertex 18.4831 15.3431 1
     endloop
   endfacet
-  facet normal 0.857698 0.514153 0
+  facet normal 0.998789 0.0491971 0
     outer loop
-      vertex 18.0867 16.6499 6
-      vertex 17.9101 16.9445 1
-      vertex 17.9101 16.9445 6
+      vertex 18.5 15 6
+      vertex 18.4831 15.3431 1
+      vertex 18.4831 15.3431 6
     endloop
   endfacet
-  facet normal 0.857698 0.514153 0
+  facet normal 0.998789 0.0491971 0
     outer loop
-      vertex 17.9101 16.9445 1
-      vertex 18.0867 16.6499 6
-      vertex 18.0867 16.6499 1
+      vertex 18.4831 15.3431 1
+      vertex 18.5 15 6
+      vertex 18.5 15 1
+    endloop
+  endfacet
+  facet normal 0.970074 0.24281 0
+    outer loop
+      vertex 18.4327 15.6828 6
+      vertex 18.3493 16.016 1
+      vertex 18.3493 16.016 6
+    endloop
+  endfacet
+  facet normal 0.970074 0.24281 0
+    outer loop
+      vertex 18.3493 16.016 1
+      vertex 18.4327 15.6828 6
+      vertex 18.4327 15.6828 1
+    endloop
+  endfacet
+  facet normal -0.989172 0.14676 0
+    outer loop
+      vertex 11.5169 15.3431 1
+      vertex 11.5673 15.6828 6
+      vertex 11.5673 15.6828 1
+    endloop
+  endfacet
+  facet normal -0.989172 0.14676 0
+    outer loop
+      vertex 11.5673 15.6828 6
+      vertex 11.5169 15.3431 1
+      vertex 11.5169 15.3431 6
+    endloop
+  endfacet
+  facet normal -0.24281 -0.970074 0
+    outer loop
+      vertex 13.984 11.6507 1
+      vertex 14.3172 11.5673 6
+      vertex 13.984 11.6507 6
+    endloop
+  endfacet
+  facet normal -0.24281 -0.970074 -0
+    outer loop
+      vertex 14.3172 11.5673 6
+      vertex 13.984 11.6507 1
+      vertex 14.3172 11.5673 1
     endloop
   endfacet
   facet normal 0.336853 0.941557 -0
@@ -5739,46 +4913,32 @@ solid OpenSCAD_Model
       vertex 16.016 18.3493 1
     endloop
   endfacet
-  facet normal 0.0491971 0.998789 -0
+  facet normal -0.514153 0.857698 0
     outer loop
-      vertex 15.3431 18.4831 1
-      vertex 15 18.5 6
-      vertex 15.3431 18.4831 6
+      vertex 13.3501 18.0867 1
+      vertex 13.0555 17.9101 6
+      vertex 13.3501 18.0867 6
     endloop
   endfacet
-  facet normal 0.0491971 0.998789 0
+  facet normal -0.514153 0.857698 0
     outer loop
-      vertex 15 18.5 6
-      vertex 15.3431 18.4831 1
-      vertex 15 18.5 1
+      vertex 13.0555 17.9101 6
+      vertex 13.3501 18.0867 1
+      vertex 13.0555 17.9101 1
     endloop
   endfacet
-  facet normal -0.998789 0.0491971 0
+  facet normal -0.903939 -0.427661 0
     outer loop
-      vertex 11.5 15 1
-      vertex 11.5169 15.3431 6
-      vertex 11.5169 15.3431 1
+      vertex 11.9133 13.3501 1
+      vertex 11.7664 13.6606 6
+      vertex 11.7664 13.6606 1
     endloop
   endfacet
-  facet normal -0.998789 0.0491971 0
+  facet normal -0.903939 -0.427661 0
     outer loop
-      vertex 11.5169 15.3431 6
-      vertex 11.5 15 1
-      vertex 11.5 15 6
-    endloop
-  endfacet
-  facet normal -0.803237 0.595659 0
-    outer loop
-      vertex 12.0899 16.9445 1
-      vertex 12.2945 17.2204 6
-      vertex 12.2945 17.2204 1
-    endloop
-  endfacet
-  facet normal -0.803237 0.595659 0
-    outer loop
-      vertex 12.2945 17.2204 6
-      vertex 12.0899 16.9445 1
-      vertex 12.0899 16.9445 6
+      vertex 11.7664 13.6606 6
+      vertex 11.9133 13.3501 1
+      vertex 11.9133 13.3501 6
     endloop
   endfacet
   facet normal -0.24281 0.970074 0
@@ -5795,46 +4955,32 @@ solid OpenSCAD_Model
       vertex 13.984 18.3493 1
     endloop
   endfacet
-  facet normal 0.998789 -0.0491971 0
+  facet normal -0.857698 -0.514153 0
     outer loop
-      vertex 18.4831 14.6569 6
-      vertex 18.5 15 1
-      vertex 18.5 15 6
+      vertex 12.0899 13.0555 1
+      vertex 11.9133 13.3501 6
+      vertex 11.9133 13.3501 1
     endloop
   endfacet
-  facet normal 0.998789 -0.0491971 0
+  facet normal -0.857698 -0.514153 0
     outer loop
-      vertex 18.5 15 1
-      vertex 18.4831 14.6569 6
-      vertex 18.4831 14.6569 1
+      vertex 11.9133 13.3501 6
+      vertex 12.0899 13.0555 1
+      vertex 12.0899 13.0555 6
     endloop
   endfacet
-  facet normal 0.803237 -0.595659 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex 17.7055 12.7796 6
-      vertex 17.9101 13.0555 1
-      vertex 17.9101 13.0555 6
+      vertex 15.6828 11.5673 1
+      vertex 16.016 11.6507 6
+      vertex 15.6828 11.5673 6
     endloop
   endfacet
-  facet normal 0.803237 -0.595659 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex 17.9101 13.0555 1
-      vertex 17.7055 12.7796 6
-      vertex 17.7055 12.7796 1
-    endloop
-  endfacet
-  facet normal -0.0491971 -0.998789 0
-    outer loop
-      vertex 14.6569 11.5169 1
-      vertex 15 11.5 6
-      vertex 14.6569 11.5169 6
-    endloop
-  endfacet
-  facet normal -0.0491971 -0.998789 -0
-    outer loop
-      vertex 15 11.5 6
-      vertex 14.6569 11.5169 1
-      vertex 15 11.5 1
+      vertex 16.016 11.6507 6
+      vertex 15.6828 11.5673 1
+      vertex 16.016 11.6507 1
     endloop
   endfacet
   facet normal -0.595659 -0.803237 0
@@ -5851,144 +4997,32 @@ solid OpenSCAD_Model
       vertex 13.0555 12.0899 1
     endloop
   endfacet
-  facet normal 0.989172 0.14676 0
+  facet normal 0.514153 -0.857698 0
     outer loop
-      vertex 18.4831 15.3431 6
-      vertex 18.4327 15.6828 1
-      vertex 18.4327 15.6828 6
+      vertex 16.6499 11.9133 1
+      vertex 16.9445 12.0899 6
+      vertex 16.6499 11.9133 6
     endloop
   endfacet
-  facet normal 0.989172 0.14676 0
+  facet normal 0.514153 -0.857698 0
     outer loop
-      vertex 18.4327 15.6828 1
-      vertex 18.4831 15.3431 6
-      vertex 18.4831 15.3431 1
+      vertex 16.9445 12.0899 6
+      vertex 16.6499 11.9133 1
+      vertex 16.9445 12.0899 1
     endloop
   endfacet
-  facet normal 0.970074 0.24281 0
+  facet normal 0.803237 -0.595659 0
     outer loop
-      vertex 18.4327 15.6828 6
-      vertex 18.3493 16.016 1
-      vertex 18.3493 16.016 6
+      vertex 17.7055 12.7796 6
+      vertex 17.9101 13.0555 1
+      vertex 17.9101 13.0555 6
     endloop
   endfacet
-  facet normal 0.970074 0.24281 0
+  facet normal 0.803237 -0.595659 0
     outer loop
-      vertex 18.3493 16.016 1
-      vertex 18.4327 15.6828 6
-      vertex 18.4327 15.6828 1
-    endloop
-  endfacet
-  facet normal 0.941557 0.336853 0
-    outer loop
-      vertex 18.3493 16.016 6
-      vertex 18.2336 16.3394 1
-      vertex 18.2336 16.3394 6
-    endloop
-  endfacet
-  facet normal 0.941557 0.336853 0
-    outer loop
-      vertex 18.2336 16.3394 1
-      vertex 18.3493 16.016 6
-      vertex 18.3493 16.016 1
-    endloop
-  endfacet
-  facet normal 0.741046 0.671454 0
-    outer loop
-      vertex 17.7055 17.2204 6
-      vertex 17.4749 17.4749 1
-      vertex 17.4749 17.4749 6
-    endloop
-  endfacet
-  facet normal 0.741046 0.671454 0
-    outer loop
-      vertex 17.4749 17.4749 1
-      vertex 17.7055 17.2204 6
-      vertex 17.7055 17.2204 1
-    endloop
-  endfacet
-  facet normal 0.803237 0.595659 0
-    outer loop
-      vertex 17.9101 16.9445 6
-      vertex 17.7055 17.2204 1
-      vertex 17.7055 17.2204 6
-    endloop
-  endfacet
-  facet normal 0.803237 0.595659 0
-    outer loop
-      vertex 17.7055 17.2204 1
-      vertex 17.9101 16.9445 6
-      vertex 17.9101 16.9445 1
-    endloop
-  endfacet
-  facet normal 0.671454 0.741046 -0
-    outer loop
-      vertex 17.4749 17.4749 1
-      vertex 17.2204 17.7055 6
-      vertex 17.4749 17.4749 6
-    endloop
-  endfacet
-  facet normal 0.671454 0.741046 0
-    outer loop
-      vertex 17.2204 17.7055 6
-      vertex 17.4749 17.4749 1
-      vertex 17.2204 17.7055 1
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 -0
-    outer loop
-      vertex 16.9445 17.9101 1
-      vertex 16.6499 18.0867 6
-      vertex 16.9445 17.9101 6
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 0
-    outer loop
-      vertex 16.6499 18.0867 6
-      vertex 16.9445 17.9101 1
-      vertex 16.6499 18.0867 1
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex 15 18.5 1
-      vertex 14.6569 18.4831 6
-      vertex 15 18.5 6
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex 14.6569 18.4831 6
-      vertex 15 18.5 1
-      vertex 14.6569 18.4831 1
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 -0
-    outer loop
-      vertex 16.6499 18.0867 1
-      vertex 16.3394 18.2336 6
-      vertex 16.6499 18.0867 6
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 0
-    outer loop
-      vertex 16.3394 18.2336 6
-      vertex 16.6499 18.0867 1
-      vertex 16.3394 18.2336 1
-    endloop
-  endfacet
-  facet normal 0.24281 0.970074 -0
-    outer loop
-      vertex 16.016 18.3493 1
-      vertex 15.6828 18.4327 6
-      vertex 16.016 18.3493 6
-    endloop
-  endfacet
-  facet normal 0.24281 0.970074 0
-    outer loop
-      vertex 15.6828 18.4327 6
-      vertex 16.016 18.3493 1
-      vertex 15.6828 18.4327 1
+      vertex 17.9101 13.0555 1
+      vertex 17.7055 12.7796 6
+      vertex 17.7055 12.7796 1
     endloop
   endfacet
   facet normal 0.14676 0.989172 -0
@@ -6005,986 +5039,6 @@ solid OpenSCAD_Model
       vertex 15.3431 18.4831 1
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.25 15 6
-      vertex 18.5 15 6
-      vertex 18.4831 15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.244 15.1225 6
-      vertex 18.4831 15.3431 6
-      vertex 18.4327 15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 15 6
-      vertex 16.25 15 6
-      vertex 18.4831 14.6569 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.226 15.2439 6
-      vertex 18.4327 15.6828 6
-      vertex 18.3493 16.016 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.244 14.8775 6
-      vertex 18.4831 14.6569 6
-      vertex 16.25 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1962 15.3629 6
-      vertex 18.3493 16.016 6
-      vertex 18.2336 16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4831 14.6569 6
-      vertex 16.244 14.8775 6
-      vertex 18.4327 14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1549 15.4784 6
-      vertex 18.2336 16.3394 6
-      vertex 18.0867 16.6499 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.226 14.7561 6
-      vertex 18.4327 14.3172 6
-      vertex 16.244 14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1024 15.5892 6
-      vertex 18.0867 16.6499 6
-      vertex 17.9101 16.9445 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4327 14.3172 6
-      vertex 16.226 14.7561 6
-      vertex 18.3493 13.984 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0393 15.6945 6
-      vertex 17.9101 16.9445 6
-      vertex 17.7055 17.2204 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1962 14.6371 6
-      vertex 18.3493 13.984 6
-      vertex 16.226 14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.9663 15.793 6
-      vertex 17.7055 17.2204 6
-      vertex 17.4749 17.4749 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3493 13.984 6
-      vertex 16.1962 14.6371 6
-      vertex 18.2336 13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.8839 15.8839 6
-      vertex 17.4749 17.4749 6
-      vertex 17.2204 17.7055 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1549 14.5216 6
-      vertex 18.2336 13.6606 6
-      vertex 16.1962 14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.793 15.9663 6
-      vertex 17.2204 17.7055 6
-      vertex 16.9445 17.9101 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2336 13.6606 6
-      vertex 16.1549 14.5216 6
-      vertex 18.0867 13.3501 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6945 16.0393 6
-      vertex 16.9445 17.9101 6
-      vertex 16.6499 18.0867 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1024 14.4108 6
-      vertex 18.0867 13.3501 6
-      vertex 16.1549 14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.5892 16.1024 6
-      vertex 16.6499 18.0867 6
-      vertex 16.3394 18.2336 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0867 13.3501 6
-      vertex 16.1024 14.4108 6
-      vertex 17.9101 13.0555 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.0393 14.3055 6
-      vertex 17.9101 13.0555 6
-      vertex 16.1024 14.4108 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4831 15.3431 6
-      vertex 16.244 15.1225 6
-      vertex 16.25 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4327 15.6828 6
-      vertex 16.226 15.2439 6
-      vertex 16.244 15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3493 16.016 6
-      vertex 16.1962 15.3629 6
-      vertex 16.226 15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2336 16.3394 6
-      vertex 16.1549 15.4784 6
-      vertex 16.1962 15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0867 16.6499 6
-      vertex 16.1024 15.5892 6
-      vertex 16.1549 15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9101 16.9445 6
-      vertex 16.0393 15.6945 6
-      vertex 16.1024 15.5892 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.4784 16.1549 6
-      vertex 16.3394 18.2336 6
-      vertex 16.016 18.3493 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7055 17.2204 6
-      vertex 15.9663 15.793 6
-      vertex 16.0393 15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.4749 17.4749 6
-      vertex 15.8839 15.8839 6
-      vertex 15.9663 15.793 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.2204 17.7055 6
-      vertex 15.793 15.9663 6
-      vertex 15.8839 15.8839 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 17.9101 6
-      vertex 15.6945 16.0393 6
-      vertex 15.793 15.9663 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.3629 16.1962 6
-      vertex 16.016 18.3493 6
-      vertex 15.6828 18.4327 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6499 18.0867 6
-      vertex 15.5892 16.1024 6
-      vertex 15.6945 16.0393 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3394 18.2336 6
-      vertex 15.4784 16.1549 6
-      vertex 15.5892 16.1024 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.016 18.3493 6
-      vertex 15.3629 16.1962 6
-      vertex 15.4784 16.1549 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.2439 16.226 6
-      vertex 15.6828 18.4327 6
-      vertex 15.3431 18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6828 18.4327 6
-      vertex 15.2439 16.226 6
-      vertex 15.3629 16.1962 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.3431 18.4831 6
-      vertex 15.1225 16.244 6
-      vertex 15.2439 16.226 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 18.5 6
-      vertex 15.1225 16.244 6
-      vertex 15.3431 18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 18.5 6
-      vertex 15 16.25 6
-      vertex 15.1225 16.244 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 18.5 6
-      vertex 14.8775 16.244 6
-      vertex 15 16.25 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.6569 18.4831 6
-      vertex 14.8775 16.244 6
-      vertex 15 18.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8775 16.244 6
-      vertex 14.6569 18.4831 6
-      vertex 14.7561 16.226 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.3172 18.4327 6
-      vertex 14.7561 16.226 6
-      vertex 14.6569 18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.7561 16.226 6
-      vertex 14.3172 18.4327 6
-      vertex 14.6371 16.1962 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.984 18.3493 6
-      vertex 14.6371 16.1962 6
-      vertex 14.3172 18.4327 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6371 16.1962 6
-      vertex 13.984 18.3493 6
-      vertex 14.5216 16.1549 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.6606 18.2336 6
-      vertex 14.5216 16.1549 6
-      vertex 13.984 18.3493 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.5216 16.1549 6
-      vertex 13.6606 18.2336 6
-      vertex 14.4108 16.1024 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.3501 18.0867 6
-      vertex 14.4108 16.1024 6
-      vertex 13.6606 18.2336 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4108 16.1024 6
-      vertex 13.3501 18.0867 6
-      vertex 14.3055 16.0393 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0555 17.9101 6
-      vertex 14.3055 16.0393 6
-      vertex 13.3501 18.0867 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3055 16.0393 6
-      vertex 13.0555 17.9101 6
-      vertex 14.207 15.9663 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.7796 17.7055 6
-      vertex 14.207 15.9663 6
-      vertex 13.0555 17.9101 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.207 15.9663 6
-      vertex 12.7796 17.7055 6
-      vertex 14.1161 15.8839 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.5251 17.4749 6
-      vertex 14.1161 15.8839 6
-      vertex 12.7796 17.7055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1161 15.8839 6
-      vertex 12.5251 17.4749 6
-      vertex 14.0337 15.793 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.2945 17.2204 6
-      vertex 14.0337 15.793 6
-      vertex 12.5251 17.4749 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.0899 16.9445 6
-      vertex 13.9607 15.6945 6
-      vertex 12.2945 17.2204 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0337 15.793 6
-      vertex 12.2945 17.2204 6
-      vertex 13.9607 15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9101 13.0555 6
-      vertex 16.0393 14.3055 6
-      vertex 17.7055 12.7796 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.9663 14.207 6
-      vertex 17.7055 12.7796 6
-      vertex 16.0393 14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7055 12.7796 6
-      vertex 15.9663 14.207 6
-      vertex 17.4749 12.5251 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.8839 14.1161 6
-      vertex 17.4749 12.5251 6
-      vertex 15.9663 14.207 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.4749 12.5251 6
-      vertex 15.8839 14.1161 6
-      vertex 17.2204 12.2945 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.793 14.0337 6
-      vertex 17.2204 12.2945 6
-      vertex 15.8839 14.1161 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.2204 12.2945 6
-      vertex 15.793 14.0337 6
-      vertex 16.9445 12.0899 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.6945 13.9607 6
-      vertex 16.9445 12.0899 6
-      vertex 15.793 14.0337 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 12.0899 6
-      vertex 15.6945 13.9607 6
-      vertex 16.6499 11.9133 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.5892 13.8976 6
-      vertex 16.6499 11.9133 6
-      vertex 15.6945 13.9607 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6499 11.9133 6
-      vertex 15.5892 13.8976 6
-      vertex 16.3394 11.7664 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.4784 13.8451 6
-      vertex 16.3394 11.7664 6
-      vertex 15.5892 13.8976 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3394 11.7664 6
-      vertex 15.4784 13.8451 6
-      vertex 16.016 11.6507 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.3629 13.8038 6
-      vertex 16.016 11.6507 6
-      vertex 15.4784 13.8451 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.016 11.6507 6
-      vertex 15.3629 13.8038 6
-      vertex 15.6828 11.5673 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.2439 13.774 6
-      vertex 15.6828 11.5673 6
-      vertex 15.3629 13.8038 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6828 11.5673 6
-      vertex 15.2439 13.774 6
-      vertex 15.3431 11.5169 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.1225 13.756 6
-      vertex 15.3431 11.5169 6
-      vertex 15.2439 13.774 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15 13.75 6
-      vertex 15.3431 11.5169 6
-      vertex 15.1225 13.756 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 13.75 6
-      vertex 15 11.5 6
-      vertex 15.3431 11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8775 13.756 6
-      vertex 15 11.5 6
-      vertex 15 13.75 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6569 11.5169 6
-      vertex 14.8775 13.756 6
-      vertex 14.7561 13.774 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8775 13.756 6
-      vertex 14.6569 11.5169 6
-      vertex 15 11.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3172 11.5673 6
-      vertex 14.7561 13.774 6
-      vertex 14.6371 13.8038 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.984 11.6507 6
-      vertex 14.6371 13.8038 6
-      vertex 14.5216 13.8451 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6606 11.7664 6
-      vertex 14.5216 13.8451 6
-      vertex 14.4108 13.8976 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.7561 13.774 6
-      vertex 14.3172 11.5673 6
-      vertex 14.6569 11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.3501 11.9133 6
-      vertex 14.4108 13.8976 6
-      vertex 14.3055 13.9607 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0555 12.0899 6
-      vertex 14.3055 13.9607 6
-      vertex 14.207 14.0337 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7796 12.2945 6
-      vertex 14.207 14.0337 6
-      vertex 14.1161 14.1161 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5251 12.5251 6
-      vertex 14.1161 14.1161 6
-      vertex 14.0337 14.207 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6371 13.8038 6
-      vertex 13.984 11.6507 6
-      vertex 14.3172 11.5673 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2945 12.7796 6
-      vertex 14.0337 14.207 6
-      vertex 13.9607 14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0899 13.0555 6
-      vertex 13.9607 14.3055 6
-      vertex 13.8976 14.4108 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.9133 13.3501 6
-      vertex 13.8976 14.4108 6
-      vertex 13.8451 14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7664 13.6606 6
-      vertex 13.8451 14.5216 6
-      vertex 13.8038 14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6507 13.984 6
-      vertex 13.8038 14.6371 6
-      vertex 13.774 14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5673 14.3172 6
-      vertex 13.774 14.7561 6
-      vertex 13.756 14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.5216 13.8451 6
-      vertex 13.6606 11.7664 6
-      vertex 13.984 11.6507 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 14.6569 6
-      vertex 13.756 14.8775 6
-      vertex 13.75 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.9607 15.6945 6
-      vertex 12.0899 16.9445 6
-      vertex 13.8976 15.5892 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.9133 16.6499 6
-      vertex 13.8976 15.5892 6
-      vertex 12.0899 16.9445 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4108 13.8976 6
-      vertex 13.3501 11.9133 6
-      vertex 13.6606 11.7664 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8976 15.5892 6
-      vertex 11.9133 16.6499 6
-      vertex 13.8451 15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3055 13.9607 6
-      vertex 13.0555 12.0899 6
-      vertex 13.3501 11.9133 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.7664 16.3394 6
-      vertex 13.8451 15.4784 6
-      vertex 11.9133 16.6499 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.207 14.0337 6
-      vertex 12.7796 12.2945 6
-      vertex 13.0555 12.0899 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8451 15.4784 6
-      vertex 11.7664 16.3394 6
-      vertex 13.8038 15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1161 14.1161 6
-      vertex 12.5251 12.5251 6
-      vertex 12.7796 12.2945 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.6507 16.016 6
-      vertex 13.8038 15.3629 6
-      vertex 11.7664 16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0337 14.207 6
-      vertex 12.2945 12.7796 6
-      vertex 12.5251 12.5251 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8038 15.3629 6
-      vertex 11.6507 16.016 6
-      vertex 13.774 15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.9607 14.3055 6
-      vertex 12.0899 13.0555 6
-      vertex 12.2945 12.7796 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.5673 15.6828 6
-      vertex 13.774 15.2439 6
-      vertex 11.6507 16.016 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8976 14.4108 6
-      vertex 11.9133 13.3501 6
-      vertex 12.0899 13.0555 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.774 15.2439 6
-      vertex 11.5673 15.6828 6
-      vertex 13.756 15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8451 14.5216 6
-      vertex 11.7664 13.6606 6
-      vertex 11.9133 13.3501 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.5169 15.3431 6
-      vertex 13.756 15.1225 6
-      vertex 11.5673 15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8038 14.6371 6
-      vertex 11.6507 13.984 6
-      vertex 11.7664 13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.756 15.1225 6
-      vertex 11.5169 15.3431 6
-      vertex 13.75 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.774 14.7561 6
-      vertex 11.5673 14.3172 6
-      vertex 11.6507 13.984 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5 15 6
-      vertex 13.75 15 6
-      vertex 11.5169 15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.756 14.8775 6
-      vertex 11.5169 14.6569 6
-      vertex 11.5673 14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.75 15 6
-      vertex 11.5 15 6
-      vertex 11.5169 14.6569 6
-    endloop
-  endfacet
-  facet normal -0.970074 0.24281 0
-    outer loop
-      vertex 11.5673 15.6828 1
-      vertex 11.6507 16.016 6
-      vertex 11.6507 16.016 1
-    endloop
-  endfacet
-  facet normal -0.970074 0.24281 0
-    outer loop
-      vertex 11.6507 16.016 6
-      vertex 11.5673 15.6828 1
-      vertex 11.5673 15.6828 6
-    endloop
-  endfacet
-  facet normal -0.989172 0.14676 0
-    outer loop
-      vertex 11.5169 15.3431 1
-      vertex 11.5673 15.6828 6
-      vertex 11.5673 15.6828 1
-    endloop
-  endfacet
-  facet normal -0.989172 0.14676 0
-    outer loop
-      vertex 11.5673 15.6828 6
-      vertex 11.5169 15.3431 1
-      vertex 11.5169 15.3431 6
-    endloop
-  endfacet
-  facet normal -0.903939 0.427661 0
-    outer loop
-      vertex 11.7664 16.3394 1
-      vertex 11.9133 16.6499 6
-      vertex 11.9133 16.6499 1
-    endloop
-  endfacet
-  facet normal -0.903939 0.427661 0
-    outer loop
-      vertex 11.9133 16.6499 6
-      vertex 11.7664 16.3394 1
-      vertex 11.7664 16.3394 6
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex 11.9133 16.6499 1
-      vertex 12.0899 16.9445 6
-      vertex 12.0899 16.9445 1
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex 12.0899 16.9445 6
-      vertex 11.9133 16.6499 1
-      vertex 11.9133 16.6499 6
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex 13.984 18.3493 1
-      vertex 13.6606 18.2336 6
-      vertex 13.984 18.3493 6
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex 13.6606 18.2336 6
-      vertex 13.984 18.3493 1
-      vertex 13.6606 18.2336 1
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
-      vertex 14.6569 18.4831 1
-      vertex 14.3172 18.4327 6
-      vertex 14.6569 18.4831 6
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
-      vertex 14.3172 18.4327 6
-      vertex 14.6569 18.4831 1
-      vertex 14.3172 18.4327 1
-    endloop
-  endfacet
   facet normal -0.595659 0.803237 0
     outer loop
       vertex 13.0555 17.9101 1
@@ -6997,6 +5051,146 @@ solid OpenSCAD_Model
       vertex 12.7796 17.7055 6
       vertex 13.0555 17.9101 1
       vertex 12.7796 17.7055 1
+    endloop
+  endfacet
+  facet normal 0.427661 -0.903939 0
+    outer loop
+      vertex 16.3394 11.7664 1
+      vertex 16.6499 11.9133 6
+      vertex 16.3394 11.7664 6
+    endloop
+  endfacet
+  facet normal 0.427661 -0.903939 0
+    outer loop
+      vertex 16.6499 11.9133 6
+      vertex 16.3394 11.7664 1
+      vertex 16.6499 11.9133 1
+    endloop
+  endfacet
+  facet normal -0.803237 0.595659 0
+    outer loop
+      vertex 12.0899 16.9445 1
+      vertex 12.2945 17.2204 6
+      vertex 12.2945 17.2204 1
+    endloop
+  endfacet
+  facet normal -0.803237 0.595659 0
+    outer loop
+      vertex 12.2945 17.2204 6
+      vertex 12.0899 16.9445 1
+      vertex 12.0899 16.9445 6
+    endloop
+  endfacet
+  facet normal 0.989172 -0.14676 0
+    outer loop
+      vertex 18.4327 14.3172 6
+      vertex 18.4831 14.6569 1
+      vertex 18.4831 14.6569 6
+    endloop
+  endfacet
+  facet normal 0.989172 -0.14676 0
+    outer loop
+      vertex 18.4831 14.6569 1
+      vertex 18.4327 14.3172 6
+      vertex 18.4327 14.3172 1
+    endloop
+  endfacet
+  facet normal -0.941557 0.336853 0
+    outer loop
+      vertex 11.6507 16.016 1
+      vertex 11.7664 16.3394 6
+      vertex 11.7664 16.3394 1
+    endloop
+  endfacet
+  facet normal -0.941557 0.336853 0
+    outer loop
+      vertex 11.7664 16.3394 6
+      vertex 11.6507 16.016 1
+      vertex 11.6507 16.016 6
+    endloop
+  endfacet
+  facet normal 0.427661 0.903939 -0
+    outer loop
+      vertex 16.6499 18.0867 1
+      vertex 16.3394 18.2336 6
+      vertex 16.6499 18.0867 6
+    endloop
+  endfacet
+  facet normal 0.427661 0.903939 0
+    outer loop
+      vertex 16.3394 18.2336 6
+      vertex 16.6499 18.0867 1
+      vertex 16.3394 18.2336 1
+    endloop
+  endfacet
+  facet normal -0.941557 -0.336853 0
+    outer loop
+      vertex 11.7664 13.6606 1
+      vertex 11.6507 13.984 6
+      vertex 11.6507 13.984 1
+    endloop
+  endfacet
+  facet normal -0.941557 -0.336853 0
+    outer loop
+      vertex 11.6507 13.984 6
+      vertex 11.7664 13.6606 1
+      vertex 11.7664 13.6606 6
+    endloop
+  endfacet
+  facet normal 0.970074 -0.24281 0
+    outer loop
+      vertex 18.3493 13.984 6
+      vertex 18.4327 14.3172 1
+      vertex 18.4327 14.3172 6
+    endloop
+  endfacet
+  facet normal 0.970074 -0.24281 0
+    outer loop
+      vertex 18.4327 14.3172 1
+      vertex 18.3493 13.984 6
+      vertex 18.3493 13.984 1
+    endloop
+  endfacet
+  facet normal -0.0491971 0.998789 0
+    outer loop
+      vertex 15 18.5 1
+      vertex 14.6569 18.4831 6
+      vertex 15 18.5 6
+    endloop
+  endfacet
+  facet normal -0.0491971 0.998789 0
+    outer loop
+      vertex 14.6569 18.4831 6
+      vertex 15 18.5 1
+      vertex 14.6569 18.4831 1
+    endloop
+  endfacet
+  facet normal 0.671454 0.741046 -0
+    outer loop
+      vertex 17.4749 17.4749 1
+      vertex 17.2204 17.7055 6
+      vertex 17.4749 17.4749 6
+    endloop
+  endfacet
+  facet normal 0.671454 0.741046 0
+    outer loop
+      vertex 17.2204 17.7055 6
+      vertex 17.4749 17.4749 1
+      vertex 17.2204 17.7055 1
+    endloop
+  endfacet
+  facet normal -0.427661 0.903939 0
+    outer loop
+      vertex 13.6606 18.2336 1
+      vertex 13.3501 18.0867 6
+      vertex 13.6606 18.2336 6
+    endloop
+  endfacet
+  facet normal -0.427661 0.903939 0
+    outer loop
+      vertex 13.3501 18.0867 6
+      vertex 13.6606 18.2336 1
+      vertex 13.3501 18.0867 1
     endloop
   endfacet
   facet normal -0.671454 0.741046 0
@@ -7013,62 +5207,6 @@ solid OpenSCAD_Model
       vertex 12.5251 17.4749 1
     endloop
   endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex 13.3501 18.0867 1
-      vertex 13.0555 17.9101 6
-      vertex 13.3501 18.0867 6
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex 13.0555 17.9101 6
-      vertex 13.3501 18.0867 1
-      vertex 13.0555 17.9101 1
-    endloop
-  endfacet
-  facet normal -0.741046 0.671454 0
-    outer loop
-      vertex 12.2945 17.2204 1
-      vertex 12.5251 17.4749 6
-      vertex 12.5251 17.4749 1
-    endloop
-  endfacet
-  facet normal -0.741046 0.671454 0
-    outer loop
-      vertex 12.5251 17.4749 6
-      vertex 12.2945 17.2204 1
-      vertex 12.2945 17.2204 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex 18.5 15 6
-      vertex 18.4831 15.3431 1
-      vertex 18.4831 15.3431 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex 18.4831 15.3431 1
-      vertex 18.5 15 6
-      vertex 18.5 15 1
-    endloop
-  endfacet
-  facet normal 0.14676 -0.989172 0
-    outer loop
-      vertex 15.3431 11.5169 1
-      vertex 15.6828 11.5673 6
-      vertex 15.3431 11.5169 6
-    endloop
-  endfacet
-  facet normal 0.14676 -0.989172 0
-    outer loop
-      vertex 15.6828 11.5673 6
-      vertex 15.3431 11.5169 1
-      vertex 15.6828 11.5673 1
-    endloop
-  endfacet
   facet normal 0.336853 -0.941557 0
     outer loop
       vertex 16.016 11.6507 1
@@ -7083,32 +5221,60 @@ solid OpenSCAD_Model
       vertex 16.3394 11.7664 1
     endloop
   endfacet
-  facet normal 0.671454 -0.741046 0
+  facet normal -0.336853 0.941557 0
     outer loop
-      vertex 17.2204 12.2945 1
-      vertex 17.4749 12.5251 6
-      vertex 17.2204 12.2945 6
+      vertex 13.984 18.3493 1
+      vertex 13.6606 18.2336 6
+      vertex 13.984 18.3493 6
     endloop
   endfacet
-  facet normal 0.671454 -0.741046 0
+  facet normal -0.336853 0.941557 0
     outer loop
-      vertex 17.4749 12.5251 6
-      vertex 17.2204 12.2945 1
-      vertex 17.4749 12.5251 1
+      vertex 13.6606 18.2336 6
+      vertex 13.984 18.3493 1
+      vertex 13.6606 18.2336 1
     endloop
   endfacet
-  facet normal 0.514153 -0.857698 0
+  facet normal 0.803237 0.595659 0
     outer loop
-      vertex 16.6499 11.9133 1
-      vertex 16.9445 12.0899 6
-      vertex 16.6499 11.9133 6
+      vertex 17.9101 16.9445 6
+      vertex 17.7055 17.2204 1
+      vertex 17.7055 17.2204 6
     endloop
   endfacet
-  facet normal 0.514153 -0.857698 0
+  facet normal 0.803237 0.595659 0
     outer loop
-      vertex 16.9445 12.0899 6
-      vertex 16.6499 11.9133 1
-      vertex 16.9445 12.0899 1
+      vertex 17.7055 17.2204 1
+      vertex 17.9101 16.9445 6
+      vertex 17.9101 16.9445 1
+    endloop
+  endfacet
+  facet normal -0.857698 0.514153 0
+    outer loop
+      vertex 11.9133 16.6499 1
+      vertex 12.0899 16.9445 6
+      vertex 12.0899 16.9445 1
+    endloop
+  endfacet
+  facet normal -0.857698 0.514153 0
+    outer loop
+      vertex 12.0899 16.9445 6
+      vertex 11.9133 16.6499 1
+      vertex 11.9133 16.6499 6
+    endloop
+  endfacet
+  facet normal 0.998789 -0.0491971 0
+    outer loop
+      vertex 18.4831 14.6569 6
+      vertex 18.5 15 1
+      vertex 18.5 15 6
+    endloop
+  endfacet
+  facet normal 0.998789 -0.0491971 0
+    outer loop
+      vertex 18.5 15 1
+      vertex 18.4831 14.6569 6
+      vertex 18.4831 14.6569 1
     endloop
   endfacet
   facet normal 0.903939 -0.427661 0
@@ -7125,116 +5291,914 @@ solid OpenSCAD_Model
       vertex 18.0867 13.3501 1
     endloop
   endfacet
-  facet normal 0.0491971 -0.998789 0
+  facet normal 0.857698 0.514153 0
     outer loop
-      vertex 15 11.5 1
+      vertex 18.0867 16.6499 6
+      vertex 17.9101 16.9445 1
+      vertex 17.9101 16.9445 6
+    endloop
+  endfacet
+  facet normal 0.857698 0.514153 0
+    outer loop
+      vertex 17.9101 16.9445 1
+      vertex 18.0867 16.6499 6
+      vertex 18.0867 16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.25 15 6
+      vertex 18.5 15 6
+      vertex 18.4831 15.3431 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.244 15.1225 6
+      vertex 18.4831 15.3431 6
+      vertex 18.4327 15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 15 6
+      vertex 16.25 15 6
+      vertex 18.4831 14.6569 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.226 15.2439 6
+      vertex 18.4327 15.6828 6
+      vertex 18.3493 16.016 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.244 14.8775 6
+      vertex 18.4831 14.6569 6
+      vertex 16.25 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1962 15.3629 6
+      vertex 18.3493 16.016 6
+      vertex 18.2336 16.3394 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4831 14.6569 6
+      vertex 16.244 14.8775 6
+      vertex 18.4327 14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1549 15.4784 6
+      vertex 18.2336 16.3394 6
+      vertex 18.0867 16.6499 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.226 14.7561 6
+      vertex 18.4327 14.3172 6
+      vertex 16.244 14.8775 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1024 15.5892 6
+      vertex 18.0867 16.6499 6
+      vertex 17.9101 16.9445 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4327 14.3172 6
+      vertex 16.226 14.7561 6
+      vertex 18.3493 13.984 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0393 15.6945 6
+      vertex 17.9101 16.9445 6
+      vertex 17.7055 17.2204 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.1962 14.6371 6
+      vertex 18.3493 13.984 6
+      vertex 16.226 14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9663 15.793 6
+      vertex 17.7055 17.2204 6
+      vertex 17.4749 17.4749 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3493 13.984 6
+      vertex 16.1962 14.6371 6
+      vertex 18.2336 13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8839 15.8839 6
+      vertex 17.4749 17.4749 6
+      vertex 17.2204 17.7055 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.1549 14.5216 6
+      vertex 18.2336 13.6606 6
+      vertex 16.1962 14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.793 15.9663 6
+      vertex 17.2204 17.7055 6
+      vertex 16.9445 17.9101 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2336 13.6606 6
+      vertex 16.1549 14.5216 6
+      vertex 18.0867 13.3501 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6945 16.0393 6
+      vertex 16.9445 17.9101 6
+      vertex 16.6499 18.0867 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.1024 14.4108 6
+      vertex 18.0867 13.3501 6
+      vertex 16.1549 14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5892 16.1024 6
+      vertex 16.6499 18.0867 6
+      vertex 16.3394 18.2336 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0867 13.3501 6
+      vertex 16.1024 14.4108 6
+      vertex 17.9101 13.0555 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.0393 14.3055 6
+      vertex 17.9101 13.0555 6
+      vertex 16.1024 14.4108 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4831 15.3431 6
+      vertex 16.244 15.1225 6
+      vertex 16.25 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4327 15.6828 6
+      vertex 16.226 15.2439 6
+      vertex 16.244 15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3493 16.016 6
+      vertex 16.1962 15.3629 6
+      vertex 16.226 15.2439 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2336 16.3394 6
+      vertex 16.1549 15.4784 6
+      vertex 16.1962 15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0867 16.6499 6
+      vertex 16.1024 15.5892 6
+      vertex 16.1549 15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9101 16.9445 6
+      vertex 16.0393 15.6945 6
+      vertex 16.1024 15.5892 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4784 16.1549 6
+      vertex 16.3394 18.2336 6
+      vertex 16.016 18.3493 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7055 17.2204 6
+      vertex 15.9663 15.793 6
+      vertex 16.0393 15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4749 17.4749 6
+      vertex 15.8839 15.8839 6
+      vertex 15.9663 15.793 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2204 17.7055 6
+      vertex 15.793 15.9663 6
+      vertex 15.8839 15.8839 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 17.9101 6
+      vertex 15.6945 16.0393 6
+      vertex 15.793 15.9663 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3629 16.1962 6
+      vertex 16.016 18.3493 6
+      vertex 15.6828 18.4327 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6499 18.0867 6
+      vertex 15.5892 16.1024 6
+      vertex 15.6945 16.0393 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3394 18.2336 6
+      vertex 15.4784 16.1549 6
+      vertex 15.5892 16.1024 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.016 18.3493 6
+      vertex 15.3629 16.1962 6
+      vertex 15.4784 16.1549 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2439 16.226 6
+      vertex 15.6828 18.4327 6
+      vertex 15.3431 18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6828 18.4327 6
+      vertex 15.2439 16.226 6
+      vertex 15.3629 16.1962 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3431 18.4831 6
+      vertex 15.1225 16.244 6
+      vertex 15.2439 16.226 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 18.5 6
+      vertex 15.1225 16.244 6
+      vertex 15.3431 18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 18.5 6
+      vertex 15 16.25 6
+      vertex 15.1225 16.244 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 18.5 6
+      vertex 14.8775 16.244 6
+      vertex 15 16.25 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.6569 18.4831 6
+      vertex 14.8775 16.244 6
+      vertex 15 18.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8775 16.244 6
+      vertex 14.6569 18.4831 6
+      vertex 14.7561 16.226 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.3172 18.4327 6
+      vertex 14.7561 16.226 6
+      vertex 14.6569 18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.7561 16.226 6
+      vertex 14.3172 18.4327 6
+      vertex 14.6371 16.1962 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.984 18.3493 6
+      vertex 14.6371 16.1962 6
+      vertex 14.3172 18.4327 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6371 16.1962 6
+      vertex 13.984 18.3493 6
+      vertex 14.5216 16.1549 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6606 18.2336 6
+      vertex 14.5216 16.1549 6
+      vertex 13.984 18.3493 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5216 16.1549 6
+      vertex 13.6606 18.2336 6
+      vertex 14.4108 16.1024 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.3501 18.0867 6
+      vertex 14.4108 16.1024 6
+      vertex 13.6606 18.2336 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4108 16.1024 6
+      vertex 13.3501 18.0867 6
+      vertex 14.3055 16.0393 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0555 17.9101 6
+      vertex 14.3055 16.0393 6
+      vertex 13.3501 18.0867 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3055 16.0393 6
+      vertex 13.0555 17.9101 6
+      vertex 14.207 15.9663 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.7796 17.7055 6
+      vertex 14.207 15.9663 6
+      vertex 13.0555 17.9101 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.207 15.9663 6
+      vertex 12.7796 17.7055 6
+      vertex 14.1161 15.8839 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.5251 17.4749 6
+      vertex 14.1161 15.8839 6
+      vertex 12.7796 17.7055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1161 15.8839 6
+      vertex 12.5251 17.4749 6
+      vertex 14.0337 15.793 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.2945 17.2204 6
+      vertex 14.0337 15.793 6
+      vertex 12.5251 17.4749 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.0899 16.9445 6
+      vertex 13.9607 15.6945 6
+      vertex 12.2945 17.2204 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0337 15.793 6
+      vertex 12.2945 17.2204 6
+      vertex 13.9607 15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9101 13.0555 6
+      vertex 16.0393 14.3055 6
+      vertex 17.7055 12.7796 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.9663 14.207 6
+      vertex 17.7055 12.7796 6
+      vertex 16.0393 14.3055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7055 12.7796 6
+      vertex 15.9663 14.207 6
+      vertex 17.4749 12.5251 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.8839 14.1161 6
+      vertex 17.4749 12.5251 6
+      vertex 15.9663 14.207 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4749 12.5251 6
+      vertex 15.8839 14.1161 6
+      vertex 17.2204 12.2945 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.793 14.0337 6
+      vertex 17.2204 12.2945 6
+      vertex 15.8839 14.1161 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2204 12.2945 6
+      vertex 15.793 14.0337 6
+      vertex 16.9445 12.0899 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.6945 13.9607 6
+      vertex 16.9445 12.0899 6
+      vertex 15.793 14.0337 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 12.0899 6
+      vertex 15.6945 13.9607 6
+      vertex 16.6499 11.9133 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.5892 13.8976 6
+      vertex 16.6499 11.9133 6
+      vertex 15.6945 13.9607 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6499 11.9133 6
+      vertex 15.5892 13.8976 6
+      vertex 16.3394 11.7664 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.4784 13.8451 6
+      vertex 16.3394 11.7664 6
+      vertex 15.5892 13.8976 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3394 11.7664 6
+      vertex 15.4784 13.8451 6
+      vertex 16.016 11.6507 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.3629 13.8038 6
+      vertex 16.016 11.6507 6
+      vertex 15.4784 13.8451 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.016 11.6507 6
+      vertex 15.3629 13.8038 6
+      vertex 15.6828 11.5673 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.2439 13.774 6
+      vertex 15.6828 11.5673 6
+      vertex 15.3629 13.8038 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6828 11.5673 6
+      vertex 15.2439 13.774 6
       vertex 15.3431 11.5169 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.1225 13.756 6
+      vertex 15.3431 11.5169 6
+      vertex 15.2439 13.774 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15 13.75 6
+      vertex 15.3431 11.5169 6
+      vertex 15.1225 13.756 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 13.75 6
+      vertex 15 11.5 6
+      vertex 15.3431 11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8775 13.756 6
+      vertex 15 11.5 6
+      vertex 15 13.75 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6569 11.5169 6
+      vertex 14.8775 13.756 6
+      vertex 14.7561 13.774 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8775 13.756 6
+      vertex 14.6569 11.5169 6
       vertex 15 11.5 6
     endloop
   endfacet
-  facet normal 0.0491971 -0.998789 0
+  facet normal 0 0 1
     outer loop
-      vertex 15.3431 11.5169 6
-      vertex 15 11.5 1
-      vertex 15.3431 11.5169 1
+      vertex 14.3172 11.5673 6
+      vertex 14.7561 13.774 6
+      vertex 14.6371 13.8038 6
     endloop
   endfacet
-  facet normal -0.24281 -0.970074 0
+  facet normal 0 0 1
     outer loop
-      vertex 13.984 11.6507 1
+      vertex 13.984 11.6507 6
+      vertex 14.6371 13.8038 6
+      vertex 14.5216 13.8451 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6606 11.7664 6
+      vertex 14.5216 13.8451 6
+      vertex 14.4108 13.8976 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.7561 13.774 6
       vertex 14.3172 11.5673 6
+      vertex 14.6569 11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3501 11.9133 6
+      vertex 14.4108 13.8976 6
+      vertex 14.3055 13.9607 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0555 12.0899 6
+      vertex 14.3055 13.9607 6
+      vertex 14.207 14.0337 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7796 12.2945 6
+      vertex 14.207 14.0337 6
+      vertex 14.1161 14.1161 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5251 12.5251 6
+      vertex 14.1161 14.1161 6
+      vertex 14.0337 14.207 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6371 13.8038 6
+      vertex 13.984 11.6507 6
+      vertex 14.3172 11.5673 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2945 12.7796 6
+      vertex 14.0337 14.207 6
+      vertex 13.9607 14.3055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0899 13.0555 6
+      vertex 13.9607 14.3055 6
+      vertex 13.8976 14.4108 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9133 13.3501 6
+      vertex 13.8976 14.4108 6
+      vertex 13.8451 14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7664 13.6606 6
+      vertex 13.8451 14.5216 6
+      vertex 13.8038 14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6507 13.984 6
+      vertex 13.8038 14.6371 6
+      vertex 13.774 14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5673 14.3172 6
+      vertex 13.774 14.7561 6
+      vertex 13.756 14.8775 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5216 13.8451 6
+      vertex 13.6606 11.7664 6
       vertex 13.984 11.6507 6
     endloop
   endfacet
-  facet normal -0.24281 -0.970074 -0
+  facet normal 0 0 1
     outer loop
-      vertex 14.3172 11.5673 6
-      vertex 13.984 11.6507 1
-      vertex 14.3172 11.5673 1
+      vertex 11.5169 14.6569 6
+      vertex 13.756 14.8775 6
+      vertex 13.75 15 6
     endloop
   endfacet
-  facet normal -0.427661 -0.903939 0
+  facet normal 0 0 1
     outer loop
-      vertex 13.3501 11.9133 1
+      vertex 13.9607 15.6945 6
+      vertex 12.0899 16.9445 6
+      vertex 13.8976 15.5892 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.9133 16.6499 6
+      vertex 13.8976 15.5892 6
+      vertex 12.0899 16.9445 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4108 13.8976 6
+      vertex 13.3501 11.9133 6
       vertex 13.6606 11.7664 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8976 15.5892 6
+      vertex 11.9133 16.6499 6
+      vertex 13.8451 15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3055 13.9607 6
+      vertex 13.0555 12.0899 6
       vertex 13.3501 11.9133 6
     endloop
   endfacet
-  facet normal -0.427661 -0.903939 -0
+  facet normal -0 0 1
     outer loop
-      vertex 13.6606 11.7664 6
-      vertex 13.3501 11.9133 1
-      vertex 13.6606 11.7664 1
+      vertex 11.7664 16.3394 6
+      vertex 13.8451 15.4784 6
+      vertex 11.9133 16.6499 6
     endloop
   endfacet
-  facet normal -0.941557 -0.336853 0
+  facet normal 0 0 1
     outer loop
-      vertex 11.7664 13.6606 1
-      vertex 11.6507 13.984 6
-      vertex 11.6507 13.984 1
+      vertex 14.207 14.0337 6
+      vertex 12.7796 12.2945 6
+      vertex 13.0555 12.0899 6
     endloop
   endfacet
-  facet normal -0.941557 -0.336853 0
+  facet normal 0 0 1
     outer loop
-      vertex 11.6507 13.984 6
-      vertex 11.7664 13.6606 1
-      vertex 11.7664 13.6606 6
+      vertex 13.8451 15.4784 6
+      vertex 11.7664 16.3394 6
+      vertex 13.8038 15.3629 6
     endloop
   endfacet
-  facet normal -0.903939 -0.427661 0
+  facet normal 0 0 1
     outer loop
-      vertex 11.9133 13.3501 1
-      vertex 11.7664 13.6606 6
-      vertex 11.7664 13.6606 1
+      vertex 14.1161 14.1161 6
+      vertex 12.5251 12.5251 6
+      vertex 12.7796 12.2945 6
     endloop
   endfacet
-  facet normal -0.903939 -0.427661 0
+  facet normal -0 0 1
     outer loop
-      vertex 11.7664 13.6606 6
-      vertex 11.9133 13.3501 1
-      vertex 11.9133 13.3501 6
+      vertex 11.6507 16.016 6
+      vertex 13.8038 15.3629 6
+      vertex 11.7664 16.3394 6
     endloop
   endfacet
-  facet normal -0.989172 -0.14676 0
+  facet normal 0 0 1
     outer loop
-      vertex 11.5673 14.3172 1
-      vertex 11.5169 14.6569 6
-      vertex 11.5169 14.6569 1
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex 11.5169 14.6569 6
-      vertex 11.5673 14.3172 1
-      vertex 11.5673 14.3172 6
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex 12.5251 12.5251 1
+      vertex 14.0337 14.207 6
       vertex 12.2945 12.7796 6
-      vertex 12.2945 12.7796 1
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex 12.2945 12.7796 6
-      vertex 12.5251 12.5251 1
       vertex 12.5251 12.5251 6
     endloop
   endfacet
-  facet normal -0.857698 -0.514153 0
+  facet normal 0 0 1
     outer loop
-      vertex 12.0899 13.0555 1
-      vertex 11.9133 13.3501 6
-      vertex 11.9133 13.3501 1
+      vertex 13.8038 15.3629 6
+      vertex 11.6507 16.016 6
+      vertex 13.774 15.2439 6
     endloop
   endfacet
-  facet normal -0.857698 -0.514153 0
+  facet normal 0 0 1
     outer loop
-      vertex 11.9133 13.3501 6
-      vertex 12.0899 13.0555 1
+      vertex 13.9607 14.3055 6
       vertex 12.0899 13.0555 6
+      vertex 12.2945 12.7796 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.5673 15.6828 6
+      vertex 13.774 15.2439 6
+      vertex 11.6507 16.016 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8976 14.4108 6
+      vertex 11.9133 13.3501 6
+      vertex 12.0899 13.0555 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.774 15.2439 6
+      vertex 11.5673 15.6828 6
+      vertex 13.756 15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8451 14.5216 6
+      vertex 11.7664 13.6606 6
+      vertex 11.9133 13.3501 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.5169 15.3431 6
+      vertex 13.756 15.1225 6
+      vertex 11.5673 15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8038 14.6371 6
+      vertex 11.6507 13.984 6
+      vertex 11.7664 13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.756 15.1225 6
+      vertex 11.5169 15.3431 6
+      vertex 13.75 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.774 14.7561 6
+      vertex 11.5673 14.3172 6
+      vertex 11.6507 13.984 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5 15 6
+      vertex 13.75 15 6
+      vertex 11.5169 15.3431 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.756 14.8775 6
+      vertex 11.5169 14.6569 6
+      vertex 11.5673 14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.75 15 6
+      vertex 11.5 15 6
+      vertex 11.5169 14.6569 6
     endloop
   endfacet
   facet normal -0.671454 -0.741046 0
@@ -7251,130 +6215,18 @@ solid OpenSCAD_Model
       vertex 12.7796 12.2945 1
     endloop
   endfacet
-  facet normal -0.998789 -0.0491971 0
+  facet normal 0.595659 0.803237 -0
     outer loop
-      vertex 11.5169 14.6569 1
-      vertex 11.5 15 6
-      vertex 11.5 15 1
+      vertex 17.2204 17.7055 1
+      vertex 16.9445 17.9101 6
+      vertex 17.2204 17.7055 6
     endloop
   endfacet
-  facet normal -0.998789 -0.0491971 0
+  facet normal 0.595659 0.803237 0
     outer loop
-      vertex 11.5 15 6
-      vertex 11.5169 14.6569 1
-      vertex 11.5169 14.6569 6
-    endloop
-  endfacet
-  facet normal 0.989172 -0.14676 0
-    outer loop
-      vertex 18.4327 14.3172 6
-      vertex 18.4831 14.6569 1
-      vertex 18.4831 14.6569 6
-    endloop
-  endfacet
-  facet normal 0.989172 -0.14676 0
-    outer loop
-      vertex 18.4831 14.6569 1
-      vertex 18.4327 14.3172 6
-      vertex 18.4327 14.3172 1
-    endloop
-  endfacet
-  facet normal 0.970074 -0.24281 0
-    outer loop
-      vertex 18.3493 13.984 6
-      vertex 18.4327 14.3172 1
-      vertex 18.4327 14.3172 6
-    endloop
-  endfacet
-  facet normal 0.970074 -0.24281 0
-    outer loop
-      vertex 18.4327 14.3172 1
-      vertex 18.3493 13.984 6
-      vertex 18.3493 13.984 1
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex 15.6828 11.5673 1
-      vertex 16.016 11.6507 6
-      vertex 15.6828 11.5673 6
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex 16.016 11.6507 6
-      vertex 15.6828 11.5673 1
-      vertex 16.016 11.6507 1
-    endloop
-  endfacet
-  facet normal 0.427661 -0.903939 0
-    outer loop
-      vertex 16.3394 11.7664 1
-      vertex 16.6499 11.9133 6
-      vertex 16.3394 11.7664 6
-    endloop
-  endfacet
-  facet normal 0.427661 -0.903939 0
-    outer loop
-      vertex 16.6499 11.9133 6
-      vertex 16.3394 11.7664 1
-      vertex 16.6499 11.9133 1
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex 17.4749 12.5251 6
-      vertex 17.7055 12.7796 1
-      vertex 17.7055 12.7796 6
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex 17.7055 12.7796 1
-      vertex 17.4749 12.5251 6
-      vertex 17.4749 12.5251 1
-    endloop
-  endfacet
-  facet normal 0.595659 -0.803237 0
-    outer loop
-      vertex 16.9445 12.0899 1
-      vertex 17.2204 12.2945 6
-      vertex 16.9445 12.0899 6
-    endloop
-  endfacet
-  facet normal 0.595659 -0.803237 0
-    outer loop
-      vertex 17.2204 12.2945 6
-      vertex 16.9445 12.0899 1
-      vertex 17.2204 12.2945 1
-    endloop
-  endfacet
-  facet normal 0.857698 -0.514153 0
-    outer loop
-      vertex 17.9101 13.0555 6
-      vertex 18.0867 13.3501 1
-      vertex 18.0867 13.3501 6
-    endloop
-  endfacet
-  facet normal 0.857698 -0.514153 0
-    outer loop
-      vertex 18.0867 13.3501 1
-      vertex 17.9101 13.0555 6
-      vertex 17.9101 13.0555 1
-    endloop
-  endfacet
-  facet normal -0.14676 -0.989172 0
-    outer loop
-      vertex 14.3172 11.5673 1
-      vertex 14.6569 11.5169 6
-      vertex 14.3172 11.5673 6
-    endloop
-  endfacet
-  facet normal -0.14676 -0.989172 -0
-    outer loop
-      vertex 14.6569 11.5169 6
-      vertex 14.3172 11.5673 1
-      vertex 14.6569 11.5169 1
+      vertex 16.9445 17.9101 6
+      vertex 17.2204 17.7055 1
+      vertex 16.9445 17.9101 1
     endloop
   endfacet
   facet normal -0.514153 -0.857698 0
@@ -7391,6 +6243,244 @@ solid OpenSCAD_Model
       vertex 13.3501 11.9133 1
     endloop
   endfacet
+  facet normal 0.514153 0.857698 -0
+    outer loop
+      vertex 16.9445 17.9101 1
+      vertex 16.6499 18.0867 6
+      vertex 16.9445 17.9101 6
+    endloop
+  endfacet
+  facet normal 0.514153 0.857698 0
+    outer loop
+      vertex 16.6499 18.0867 6
+      vertex 16.9445 17.9101 1
+      vertex 16.6499 18.0867 1
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex 15.3431 11.5169 1
+      vertex 15.6828 11.5673 6
+      vertex 15.3431 11.5169 6
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex 15.6828 11.5673 6
+      vertex 15.3431 11.5169 1
+      vertex 15.6828 11.5673 1
+    endloop
+  endfacet
+  facet normal 0.941557 0.336853 0
+    outer loop
+      vertex 18.3493 16.016 6
+      vertex 18.2336 16.3394 1
+      vertex 18.2336 16.3394 6
+    endloop
+  endfacet
+  facet normal 0.941557 0.336853 0
+    outer loop
+      vertex 18.2336 16.3394 1
+      vertex 18.3493 16.016 6
+      vertex 18.3493 16.016 1
+    endloop
+  endfacet
+  facet normal 0.857698 -0.514153 0
+    outer loop
+      vertex 17.9101 13.0555 6
+      vertex 18.0867 13.3501 1
+      vertex 18.0867 13.3501 6
+    endloop
+  endfacet
+  facet normal 0.857698 -0.514153 0
+    outer loop
+      vertex 18.0867 13.3501 1
+      vertex 17.9101 13.0555 6
+      vertex 17.9101 13.0555 1
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491971 0
+    outer loop
+      vertex 11.5169 14.6569 1
+      vertex 11.5 15 6
+      vertex 11.5 15 1
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491971 0
+    outer loop
+      vertex 11.5 15 6
+      vertex 11.5169 14.6569 1
+      vertex 11.5169 14.6569 6
+    endloop
+  endfacet
+  facet normal 0.941557 -0.336853 0
+    outer loop
+      vertex 18.2336 13.6606 6
+      vertex 18.3493 13.984 1
+      vertex 18.3493 13.984 6
+    endloop
+  endfacet
+  facet normal 0.941557 -0.336853 0
+    outer loop
+      vertex 18.3493 13.984 1
+      vertex 18.2336 13.6606 6
+      vertex 18.2336 13.6606 1
+    endloop
+  endfacet
+  facet normal 0.741046 0.671454 0
+    outer loop
+      vertex 17.7055 17.2204 6
+      vertex 17.4749 17.4749 1
+      vertex 17.4749 17.4749 6
+    endloop
+  endfacet
+  facet normal 0.741046 0.671454 0
+    outer loop
+      vertex 17.4749 17.4749 1
+      vertex 17.7055 17.2204 6
+      vertex 17.7055 17.2204 1
+    endloop
+  endfacet
+  facet normal 0.0491971 0.998789 -0
+    outer loop
+      vertex 15.3431 18.4831 1
+      vertex 15 18.5 6
+      vertex 15.3431 18.4831 6
+    endloop
+  endfacet
+  facet normal 0.0491971 0.998789 0
+    outer loop
+      vertex 15 18.5 6
+      vertex 15.3431 18.4831 1
+      vertex 15 18.5 1
+    endloop
+  endfacet
+  facet normal 0.903939 0.427661 0
+    outer loop
+      vertex 18.2336 16.3394 6
+      vertex 18.0867 16.6499 1
+      vertex 18.0867 16.6499 6
+    endloop
+  endfacet
+  facet normal 0.903939 0.427661 0
+    outer loop
+      vertex 18.0867 16.6499 1
+      vertex 18.2336 16.3394 6
+      vertex 18.2336 16.3394 1
+    endloop
+  endfacet
+  facet normal -0.14676 -0.989172 0
+    outer loop
+      vertex 14.3172 11.5673 1
+      vertex 14.6569 11.5169 6
+      vertex 14.3172 11.5673 6
+    endloop
+  endfacet
+  facet normal -0.14676 -0.989172 -0
+    outer loop
+      vertex 14.6569 11.5169 6
+      vertex 14.3172 11.5673 1
+      vertex 14.6569 11.5169 1
+    endloop
+  endfacet
+  facet normal 0.671454 -0.741046 0
+    outer loop
+      vertex 17.2204 12.2945 1
+      vertex 17.4749 12.5251 6
+      vertex 17.2204 12.2945 6
+    endloop
+  endfacet
+  facet normal 0.671454 -0.741046 0
+    outer loop
+      vertex 17.4749 12.5251 6
+      vertex 17.2204 12.2945 1
+      vertex 17.4749 12.5251 1
+    endloop
+  endfacet
+  facet normal -0.0491971 -0.998789 0
+    outer loop
+      vertex 14.6569 11.5169 1
+      vertex 15 11.5 6
+      vertex 14.6569 11.5169 6
+    endloop
+  endfacet
+  facet normal -0.0491971 -0.998789 -0
+    outer loop
+      vertex 15 11.5 6
+      vertex 14.6569 11.5169 1
+      vertex 15 11.5 1
+    endloop
+  endfacet
+  facet normal -0.741046 0.671454 0
+    outer loop
+      vertex 12.2945 17.2204 1
+      vertex 12.5251 17.4749 6
+      vertex 12.5251 17.4749 1
+    endloop
+  endfacet
+  facet normal -0.741046 0.671454 0
+    outer loop
+      vertex 12.5251 17.4749 6
+      vertex 12.2945 17.2204 1
+      vertex 12.2945 17.2204 6
+    endloop
+  endfacet
+  facet normal -0.14676 0.989172 0
+    outer loop
+      vertex 14.6569 18.4831 1
+      vertex 14.3172 18.4327 6
+      vertex 14.6569 18.4831 6
+    endloop
+  endfacet
+  facet normal -0.14676 0.989172 0
+    outer loop
+      vertex 14.3172 18.4327 6
+      vertex 14.6569 18.4831 1
+      vertex 14.3172 18.4327 1
+    endloop
+  endfacet
+  facet normal -0.903939 0.427661 0
+    outer loop
+      vertex 11.7664 16.3394 1
+      vertex 11.9133 16.6499 6
+      vertex 11.9133 16.6499 1
+    endloop
+  endfacet
+  facet normal -0.903939 0.427661 0
+    outer loop
+      vertex 11.9133 16.6499 6
+      vertex 11.7664 16.3394 1
+      vertex 11.7664 16.3394 6
+    endloop
+  endfacet
+  facet normal -0.970074 0.24281 0
+    outer loop
+      vertex 11.5673 15.6828 1
+      vertex 11.6507 16.016 6
+      vertex 11.6507 16.016 1
+    endloop
+  endfacet
+  facet normal -0.970074 0.24281 0
+    outer loop
+      vertex 11.6507 16.016 6
+      vertex 11.5673 15.6828 1
+      vertex 11.5673 15.6828 6
+    endloop
+  endfacet
+  facet normal 0.24281 0.970074 -0
+    outer loop
+      vertex 16.016 18.3493 1
+      vertex 15.6828 18.4327 6
+      vertex 16.016 18.3493 6
+    endloop
+  endfacet
+  facet normal 0.24281 0.970074 0
+    outer loop
+      vertex 15.6828 18.4327 6
+      vertex 16.016 18.3493 1
+      vertex 15.6828 18.4327 1
+    endloop
+  endfacet
   facet normal -0.970074 -0.24281 0
     outer loop
       vertex 11.6507 13.984 1
@@ -7403,6 +6493,76 @@ solid OpenSCAD_Model
       vertex 11.5673 14.3172 6
       vertex 11.6507 13.984 1
       vertex 11.6507 13.984 6
+    endloop
+  endfacet
+  facet normal -0.427661 -0.903939 0
+    outer loop
+      vertex 13.3501 11.9133 1
+      vertex 13.6606 11.7664 6
+      vertex 13.3501 11.9133 6
+    endloop
+  endfacet
+  facet normal -0.427661 -0.903939 -0
+    outer loop
+      vertex 13.6606 11.7664 6
+      vertex 13.3501 11.9133 1
+      vertex 13.6606 11.7664 1
+    endloop
+  endfacet
+  facet normal -0.741046 -0.671454 0
+    outer loop
+      vertex 12.5251 12.5251 1
+      vertex 12.2945 12.7796 6
+      vertex 12.2945 12.7796 1
+    endloop
+  endfacet
+  facet normal -0.741046 -0.671454 0
+    outer loop
+      vertex 12.2945 12.7796 6
+      vertex 12.5251 12.5251 1
+      vertex 12.5251 12.5251 6
+    endloop
+  endfacet
+  facet normal 0.0491971 -0.998789 0
+    outer loop
+      vertex 15 11.5 1
+      vertex 15.3431 11.5169 6
+      vertex 15 11.5 6
+    endloop
+  endfacet
+  facet normal 0.0491971 -0.998789 0
+    outer loop
+      vertex 15.3431 11.5169 6
+      vertex 15 11.5 1
+      vertex 15.3431 11.5169 1
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex 11.5673 14.3172 1
+      vertex 11.5169 14.6569 6
+      vertex 11.5169 14.6569 1
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex 11.5169 14.6569 6
+      vertex 11.5673 14.3172 1
+      vertex 11.5673 14.3172 6
+    endloop
+  endfacet
+  facet normal 0.595659 -0.803237 0
+    outer loop
+      vertex 16.9445 12.0899 1
+      vertex 17.2204 12.2945 6
+      vertex 16.9445 12.0899 6
+    endloop
+  endfacet
+  facet normal 0.595659 -0.803237 0
+    outer loop
+      vertex 17.2204 12.2945 6
+      vertex 16.9445 12.0899 1
+      vertex 17.2204 12.2945 1
     endloop
   endfacet
   facet normal -0.803237 -0.595659 0
@@ -7419,1012 +6579,32 @@ solid OpenSCAD_Model
       vertex 12.2945 12.7796 6
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.75 15 6
-      vertex -11.5 15 6
-      vertex -11.5169 15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.756 15.1225 6
-      vertex -11.5169 15.3431 6
-      vertex -11.5673 15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 15 6
-      vertex -13.75 15 6
-      vertex -11.5169 14.6569 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.774 15.2439 6
-      vertex -11.5673 15.6828 6
-      vertex -11.6507 16.016 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.756 14.8775 6
-      vertex -11.5169 14.6569 6
-      vertex -13.75 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.8038 15.3629 6
-      vertex -11.6507 16.016 6
-      vertex -11.7664 16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 14.6569 6
-      vertex -13.756 14.8775 6
-      vertex -11.5673 14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.8451 15.4784 6
-      vertex -11.7664 16.3394 6
-      vertex -11.9133 16.6499 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.774 14.7561 6
-      vertex -11.5673 14.3172 6
-      vertex -13.756 14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.8976 15.5892 6
-      vertex -11.9133 16.6499 6
-      vertex -12.0899 16.9445 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 14.3172 6
-      vertex -13.774 14.7561 6
-      vertex -11.6507 13.984 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.9607 15.6945 6
-      vertex -12.0899 16.9445 6
-      vertex -12.2945 17.2204 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8038 14.6371 6
-      vertex -11.6507 13.984 6
-      vertex -13.774 14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.0337 15.793 6
-      vertex -12.2945 17.2204 6
-      vertex -12.5251 17.4749 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 13.984 6
-      vertex -13.8038 14.6371 6
-      vertex -11.7664 13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.1161 15.8839 6
-      vertex -12.5251 17.4749 6
-      vertex -12.7796 17.7055 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8451 14.5216 6
-      vertex -11.7664 13.6606 6
-      vertex -13.8038 14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.207 15.9663 6
-      vertex -12.7796 17.7055 6
-      vertex -13.0555 17.9101 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7664 13.6606 6
-      vertex -13.8451 14.5216 6
-      vertex -11.9133 13.3501 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3055 16.0393 6
-      vertex -13.0555 17.9101 6
-      vertex -13.3501 18.0867 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8976 14.4108 6
-      vertex -11.9133 13.3501 6
-      vertex -13.8451 14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.4108 16.1024 6
-      vertex -13.3501 18.0867 6
-      vertex -13.6606 18.2336 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.9133 13.3501 6
-      vertex -13.8976 14.4108 6
-      vertex -12.0899 13.0555 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.9607 14.3055 6
-      vertex -12.0899 13.0555 6
-      vertex -13.8976 14.4108 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 15.3431 6
-      vertex -13.756 15.1225 6
-      vertex -13.75 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 15.6828 6
-      vertex -13.774 15.2439 6
-      vertex -13.756 15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 16.016 6
-      vertex -13.8038 15.3629 6
-      vertex -13.774 15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7664 16.3394 6
-      vertex -13.8451 15.4784 6
-      vertex -13.8038 15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.9133 16.6499 6
-      vertex -13.8976 15.5892 6
-      vertex -13.8451 15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0899 16.9445 6
-      vertex -13.9607 15.6945 6
-      vertex -13.8976 15.5892 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.5216 16.1549 6
-      vertex -13.6606 18.2336 6
-      vertex -13.984 18.3493 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2945 17.2204 6
-      vertex -14.0337 15.793 6
-      vertex -13.9607 15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5251 17.4749 6
-      vertex -14.1161 15.8839 6
-      vertex -14.0337 15.793 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.7796 17.7055 6
-      vertex -14.207 15.9663 6
-      vertex -14.1161 15.8839 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0555 17.9101 6
-      vertex -14.3055 16.0393 6
-      vertex -14.207 15.9663 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6371 16.1962 6
-      vertex -13.984 18.3493 6
-      vertex -14.3172 18.4327 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.3501 18.0867 6
-      vertex -14.4108 16.1024 6
-      vertex -14.3055 16.0393 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.6606 18.2336 6
-      vertex -14.5216 16.1549 6
-      vertex -14.4108 16.1024 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.984 18.3493 6
-      vertex -14.6371 16.1962 6
-      vertex -14.5216 16.1549 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7561 16.226 6
-      vertex -14.3172 18.4327 6
-      vertex -14.6569 18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3172 18.4327 6
-      vertex -14.7561 16.226 6
-      vertex -14.6371 16.1962 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6569 18.4831 6
-      vertex -14.8775 16.244 6
-      vertex -14.7561 16.226 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 18.5 6
-      vertex -14.8775 16.244 6
-      vertex -14.6569 18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 18.5 6
-      vertex -15 16.25 6
-      vertex -14.8775 16.244 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 18.5 6
-      vertex -15.1225 16.244 6
-      vertex -15 16.25 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.3431 18.4831 6
-      vertex -15.1225 16.244 6
-      vertex -15 18.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1225 16.244 6
-      vertex -15.3431 18.4831 6
-      vertex -15.2439 16.226 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.6828 18.4327 6
-      vertex -15.2439 16.226 6
-      vertex -15.3431 18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.2439 16.226 6
-      vertex -15.6828 18.4327 6
-      vertex -15.3629 16.1962 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.016 18.3493 6
-      vertex -15.3629 16.1962 6
-      vertex -15.6828 18.4327 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3629 16.1962 6
-      vertex -16.016 18.3493 6
-      vertex -15.4784 16.1549 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.3394 18.2336 6
-      vertex -15.4784 16.1549 6
-      vertex -16.016 18.3493 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.4784 16.1549 6
-      vertex -16.3394 18.2336 6
-      vertex -15.5892 16.1024 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.6499 18.0867 6
-      vertex -15.5892 16.1024 6
-      vertex -16.3394 18.2336 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.5892 16.1024 6
-      vertex -16.6499 18.0867 6
-      vertex -15.6945 16.0393 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.9445 17.9101 6
-      vertex -15.6945 16.0393 6
-      vertex -16.6499 18.0867 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6945 16.0393 6
-      vertex -16.9445 17.9101 6
-      vertex -15.793 15.9663 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.2204 17.7055 6
-      vertex -15.793 15.9663 6
-      vertex -16.9445 17.9101 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.793 15.9663 6
-      vertex -17.2204 17.7055 6
-      vertex -15.8839 15.8839 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.4749 17.4749 6
-      vertex -15.8839 15.8839 6
-      vertex -17.2204 17.7055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8839 15.8839 6
-      vertex -17.4749 17.4749 6
-      vertex -15.9663 15.793 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.7055 17.2204 6
-      vertex -15.9663 15.793 6
-      vertex -17.4749 17.4749 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.9101 16.9445 6
-      vertex -16.0393 15.6945 6
-      vertex -17.7055 17.2204 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9663 15.793 6
-      vertex -17.7055 17.2204 6
-      vertex -16.0393 15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0899 13.0555 6
-      vertex -13.9607 14.3055 6
-      vertex -12.2945 12.7796 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.0337 14.207 6
-      vertex -12.2945 12.7796 6
-      vertex -13.9607 14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2945 12.7796 6
-      vertex -14.0337 14.207 6
-      vertex -12.5251 12.5251 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.1161 14.1161 6
-      vertex -12.5251 12.5251 6
-      vertex -14.0337 14.207 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5251 12.5251 6
-      vertex -14.1161 14.1161 6
-      vertex -12.7796 12.2945 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.207 14.0337 6
-      vertex -12.7796 12.2945 6
-      vertex -14.1161 14.1161 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.7796 12.2945 6
-      vertex -14.207 14.0337 6
-      vertex -13.0555 12.0899 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.3055 13.9607 6
-      vertex -13.0555 12.0899 6
-      vertex -14.207 14.0337 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0555 12.0899 6
-      vertex -14.3055 13.9607 6
-      vertex -13.3501 11.9133 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.4108 13.8976 6
-      vertex -13.3501 11.9133 6
-      vertex -14.3055 13.9607 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.3501 11.9133 6
-      vertex -14.4108 13.8976 6
-      vertex -13.6606 11.7664 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.5216 13.8451 6
-      vertex -13.6606 11.7664 6
-      vertex -14.4108 13.8976 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.6606 11.7664 6
-      vertex -14.5216 13.8451 6
-      vertex -13.984 11.6507 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.6371 13.8038 6
-      vertex -13.984 11.6507 6
-      vertex -14.5216 13.8451 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.984 11.6507 6
-      vertex -14.6371 13.8038 6
-      vertex -14.3172 11.5673 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.7561 13.774 6
-      vertex -14.3172 11.5673 6
-      vertex -14.6371 13.8038 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3172 11.5673 6
-      vertex -14.7561 13.774 6
-      vertex -14.6569 11.5169 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.8775 13.756 6
-      vertex -14.6569 11.5169 6
-      vertex -14.7561 13.774 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15 13.75 6
-      vertex -14.6569 11.5169 6
-      vertex -14.8775 13.756 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 13.75 6
-      vertex -15 11.5 6
-      vertex -14.6569 11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1225 13.756 6
-      vertex -15 11.5 6
-      vertex -15 13.75 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3431 11.5169 6
-      vertex -15.1225 13.756 6
-      vertex -15.2439 13.774 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1225 13.756 6
-      vertex -15.3431 11.5169 6
-      vertex -15 11.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6828 11.5673 6
-      vertex -15.2439 13.774 6
-      vertex -15.3629 13.8038 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.016 11.6507 6
-      vertex -15.3629 13.8038 6
-      vertex -15.4784 13.8451 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.3394 11.7664 6
-      vertex -15.4784 13.8451 6
-      vertex -15.5892 13.8976 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.2439 13.774 6
-      vertex -15.6828 11.5673 6
-      vertex -15.3431 11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6499 11.9133 6
-      vertex -15.5892 13.8976 6
-      vertex -15.6945 13.9607 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.9445 12.0899 6
-      vertex -15.6945 13.9607 6
-      vertex -15.793 14.0337 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.2204 12.2945 6
-      vertex -15.793 14.0337 6
-      vertex -15.8839 14.1161 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.4749 12.5251 6
-      vertex -15.8839 14.1161 6
-      vertex -15.9663 14.207 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3629 13.8038 6
-      vertex -16.016 11.6507 6
-      vertex -15.6828 11.5673 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.7055 12.7796 6
-      vertex -15.9663 14.207 6
-      vertex -16.0393 14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9101 13.0555 6
-      vertex -16.0393 14.3055 6
-      vertex -16.1024 14.4108 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0867 13.3501 6
-      vertex -16.1024 14.4108 6
-      vertex -16.1549 14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2336 13.6606 6
-      vertex -16.1549 14.5216 6
-      vertex -16.1962 14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3493 13.984 6
-      vertex -16.1962 14.6371 6
-      vertex -16.226 14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4327 14.3172 6
-      vertex -16.226 14.7561 6
-      vertex -16.244 14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.4784 13.8451 6
-      vertex -16.3394 11.7664 6
-      vertex -16.016 11.6507 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 14.6569 6
-      vertex -16.244 14.8775 6
-      vertex -16.25 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0393 15.6945 6
-      vertex -17.9101 16.9445 6
-      vertex -16.1024 15.5892 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.0867 16.6499 6
-      vertex -16.1024 15.5892 6
-      vertex -17.9101 16.9445 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.5892 13.8976 6
-      vertex -16.6499 11.9133 6
-      vertex -16.3394 11.7664 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1024 15.5892 6
-      vertex -18.0867 16.6499 6
-      vertex -16.1549 15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6945 13.9607 6
-      vertex -16.9445 12.0899 6
-      vertex -16.6499 11.9133 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.2336 16.3394 6
-      vertex -16.1549 15.4784 6
-      vertex -18.0867 16.6499 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.793 14.0337 6
-      vertex -17.2204 12.2945 6
-      vertex -16.9445 12.0899 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1549 15.4784 6
-      vertex -18.2336 16.3394 6
-      vertex -16.1962 15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8839 14.1161 6
-      vertex -17.4749 12.5251 6
-      vertex -17.2204 12.2945 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.3493 16.016 6
-      vertex -16.1962 15.3629 6
-      vertex -18.2336 16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9663 14.207 6
-      vertex -17.7055 12.7796 6
-      vertex -17.4749 12.5251 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1962 15.3629 6
-      vertex -18.3493 16.016 6
-      vertex -16.226 15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0393 14.3055 6
-      vertex -17.9101 13.0555 6
-      vertex -17.7055 12.7796 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.4327 15.6828 6
-      vertex -16.226 15.2439 6
-      vertex -18.3493 16.016 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1024 14.4108 6
-      vertex -18.0867 13.3501 6
-      vertex -17.9101 13.0555 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.226 15.2439 6
-      vertex -18.4327 15.6828 6
-      vertex -16.244 15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1549 14.5216 6
-      vertex -18.2336 13.6606 6
-      vertex -18.0867 13.3501 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.4831 15.3431 6
-      vertex -16.244 15.1225 6
-      vertex -18.4327 15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1962 14.6371 6
-      vertex -18.3493 13.984 6
-      vertex -18.2336 13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.244 15.1225 6
-      vertex -18.4831 15.3431 6
-      vertex -16.25 15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.226 14.7561 6
-      vertex -18.4327 14.3172 6
-      vertex -18.3493 13.984 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 15 6
-      vertex -16.25 15 6
-      vertex -18.4831 15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.244 14.8775 6
-      vertex -18.4831 14.6569 6
-      vertex -18.4327 14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.25 15 6
-      vertex -18.5 15 6
-      vertex -18.4831 14.6569 6
+  facet normal -0.998789 0.0491971 0
+    outer loop
+      vertex 11.5 15 1
+      vertex 11.5169 15.3431 6
+      vertex 11.5169 15.3431 1
     endloop
   endfacet
   facet normal -0.998789 0.0491971 0
     outer loop
-      vertex -18.5 15 1
-      vertex -18.4831 15.3431 6
-      vertex -18.4831 15.3431 1
+      vertex 11.5169 15.3431 6
+      vertex 11.5 15 1
+      vertex 11.5 15 6
     endloop
   endfacet
-  facet normal -0.998789 0.0491971 0
+  facet normal 0.741046 -0.671454 0
     outer loop
-      vertex -18.4831 15.3431 6
-      vertex -18.5 15 1
-      vertex -18.5 15 6
+      vertex 17.4749 12.5251 6
+      vertex 17.7055 12.7796 1
+      vertex 17.7055 12.7796 6
     endloop
   endfacet
-  facet normal -0.803237 0.595659 0
+  facet normal 0.741046 -0.671454 0
     outer loop
-      vertex -17.9101 16.9445 1
-      vertex -17.7055 17.2204 6
-      vertex -17.7055 17.2204 1
-    endloop
-  endfacet
-  facet normal -0.803237 0.595659 0
-    outer loop
-      vertex -17.7055 17.2204 6
-      vertex -17.9101 16.9445 1
-      vertex -17.9101 16.9445 6
-    endloop
-  endfacet
-  facet normal 0.970074 -0.24281 0
-    outer loop
-      vertex -11.6507 13.984 6
-      vertex -11.5673 14.3172 1
-      vertex -11.5673 14.3172 6
-    endloop
-  endfacet
-  facet normal 0.970074 -0.24281 0
-    outer loop
-      vertex -11.5673 14.3172 1
-      vertex -11.6507 13.984 6
-      vertex -11.6507 13.984 1
-    endloop
-  endfacet
-  facet normal 0.14676 0.989172 -0
-    outer loop
-      vertex -14.3172 18.4327 1
-      vertex -14.6569 18.4831 6
-      vertex -14.3172 18.4327 6
-    endloop
-  endfacet
-  facet normal 0.14676 0.989172 0
-    outer loop
-      vertex -14.6569 18.4831 6
-      vertex -14.3172 18.4327 1
-      vertex -14.6569 18.4831 1
-    endloop
-  endfacet
-  facet normal -0.941557 -0.336853 0
-    outer loop
-      vertex -18.2336 13.6606 1
-      vertex -18.3493 13.984 6
-      vertex -18.3493 13.984 1
-    endloop
-  endfacet
-  facet normal -0.941557 -0.336853 0
-    outer loop
-      vertex -18.3493 13.984 6
-      vertex -18.2336 13.6606 1
-      vertex -18.2336 13.6606 6
-    endloop
-  endfacet
-  facet normal -0.970074 -0.24281 0
-    outer loop
-      vertex -18.3493 13.984 1
-      vertex -18.4327 14.3172 6
-      vertex -18.4327 14.3172 1
-    endloop
-  endfacet
-  facet normal -0.970074 -0.24281 0
-    outer loop
-      vertex -18.4327 14.3172 6
-      vertex -18.3493 13.984 1
-      vertex -18.3493 13.984 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex -11.5 15 6
-      vertex -11.5169 15.3431 1
-      vertex -11.5169 15.3431 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex -11.5169 15.3431 1
-      vertex -11.5 15 6
-      vertex -11.5 15 1
-    endloop
-  endfacet
-  facet normal -0.514153 -0.857698 0
-    outer loop
-      vertex -16.9445 12.0899 1
-      vertex -16.6499 11.9133 6
-      vertex -16.9445 12.0899 6
-    endloop
-  endfacet
-  facet normal -0.514153 -0.857698 -0
-    outer loop
-      vertex -16.6499 11.9133 6
-      vertex -16.9445 12.0899 1
-      vertex -16.6499 11.9133 1
+      vertex 17.7055 12.7796 1
+      vertex 17.4749 12.5251 6
+      vertex 17.4749 12.5251 1
     endloop
   endfacet
   facet normal -0.671454 -0.741046 0
@@ -8441,46 +6621,18 @@ solid OpenSCAD_Model
       vertex -17.2204 12.2945 1
     endloop
   endfacet
-  facet normal -0.989172 0.14676 0
+  facet normal 0.336853 -0.941557 0
     outer loop
-      vertex -18.4831 15.3431 1
-      vertex -18.4327 15.6828 6
-      vertex -18.4327 15.6828 1
+      vertex -13.984 11.6507 1
+      vertex -13.6606 11.7664 6
+      vertex -13.984 11.6507 6
     endloop
   endfacet
-  facet normal -0.989172 0.14676 0
+  facet normal 0.336853 -0.941557 0
     outer loop
-      vertex -18.4327 15.6828 6
-      vertex -18.4831 15.3431 1
-      vertex -18.4831 15.3431 6
-    endloop
-  endfacet
-  facet normal -0.671454 0.741046 0
-    outer loop
-      vertex -17.2204 17.7055 1
-      vertex -17.4749 17.4749 6
-      vertex -17.2204 17.7055 6
-    endloop
-  endfacet
-  facet normal -0.671454 0.741046 0
-    outer loop
-      vertex -17.4749 17.4749 6
-      vertex -17.2204 17.7055 1
-      vertex -17.4749 17.4749 1
-    endloop
-  endfacet
-  facet normal -0.24281 0.970074 0
-    outer loop
-      vertex -15.6828 18.4327 1
-      vertex -16.016 18.3493 6
-      vertex -15.6828 18.4327 6
-    endloop
-  endfacet
-  facet normal -0.24281 0.970074 0
-    outer loop
-      vertex -16.016 18.3493 6
-      vertex -15.6828 18.4327 1
-      vertex -16.016 18.3493 1
+      vertex -13.6606 11.7664 6
+      vertex -13.984 11.6507 1
+      vertex -13.6606 11.7664 1
     endloop
   endfacet
   facet normal 0.857698 -0.514153 0
@@ -8497,46 +6649,18 @@ solid OpenSCAD_Model
       vertex -12.0899 13.0555 1
     endloop
   endfacet
-  facet normal 0.998789 -0.0491971 0
+  facet normal -0.998789 0.0491971 0
     outer loop
-      vertex -11.5169 14.6569 6
-      vertex -11.5 15 1
-      vertex -11.5 15 6
+      vertex -18.5 15 1
+      vertex -18.4831 15.3431 6
+      vertex -18.4831 15.3431 1
     endloop
   endfacet
-  facet normal 0.998789 -0.0491971 0
+  facet normal -0.998789 0.0491971 0
     outer loop
-      vertex -11.5 15 1
-      vertex -11.5169 14.6569 6
-      vertex -11.5169 14.6569 1
-    endloop
-  endfacet
-  facet normal 0.970074 0.24281 0
-    outer loop
-      vertex -11.5673 15.6828 6
-      vertex -11.6507 16.016 1
-      vertex -11.6507 16.016 6
-    endloop
-  endfacet
-  facet normal 0.970074 0.24281 0
-    outer loop
-      vertex -11.6507 16.016 1
-      vertex -11.5673 15.6828 6
-      vertex -11.5673 15.6828 1
-    endloop
-  endfacet
-  facet normal 0.595659 -0.803237 0
-    outer loop
-      vertex -13.0555 12.0899 1
-      vertex -12.7796 12.2945 6
-      vertex -13.0555 12.0899 6
-    endloop
-  endfacet
-  facet normal 0.595659 -0.803237 0
-    outer loop
-      vertex -12.7796 12.2945 6
-      vertex -13.0555 12.0899 1
-      vertex -12.7796 12.2945 1
+      vertex -18.4831 15.3431 6
+      vertex -18.5 15 1
+      vertex -18.5 15 6
     endloop
   endfacet
   facet normal -0.595659 -0.803237 0
@@ -8553,20 +6677,6 @@ solid OpenSCAD_Model
       vertex -16.9445 12.0899 1
     endloop
   endfacet
-  facet normal -0.427661 -0.903939 0
-    outer loop
-      vertex -16.6499 11.9133 1
-      vertex -16.3394 11.7664 6
-      vertex -16.6499 11.9133 6
-    endloop
-  endfacet
-  facet normal -0.427661 -0.903939 -0
-    outer loop
-      vertex -16.3394 11.7664 6
-      vertex -16.6499 11.9133 1
-      vertex -16.3394 11.7664 1
-    endloop
-  endfacet
   facet normal -0.857698 -0.514153 0
     outer loop
       vertex -17.9101 13.0555 1
@@ -8579,104 +6689,6 @@ solid OpenSCAD_Model
       vertex -18.0867 13.3501 6
       vertex -17.9101 13.0555 1
       vertex -17.9101 13.0555 6
-    endloop
-  endfacet
-  facet normal -0.903939 -0.427661 0
-    outer loop
-      vertex -18.0867 13.3501 1
-      vertex -18.2336 13.6606 6
-      vertex -18.2336 13.6606 1
-    endloop
-  endfacet
-  facet normal -0.903939 -0.427661 0
-    outer loop
-      vertex -18.2336 13.6606 6
-      vertex -18.0867 13.3501 1
-      vertex -18.0867 13.3501 6
-    endloop
-  endfacet
-  facet normal -0.903939 0.427661 0
-    outer loop
-      vertex -18.2336 16.3394 1
-      vertex -18.0867 16.6499 6
-      vertex -18.0867 16.6499 1
-    endloop
-  endfacet
-  facet normal -0.903939 0.427661 0
-    outer loop
-      vertex -18.0867 16.6499 6
-      vertex -18.2336 16.3394 1
-      vertex -18.2336 16.3394 6
-    endloop
-  endfacet
-  facet normal -0.970074 0.24281 0
-    outer loop
-      vertex -18.4327 15.6828 1
-      vertex -18.3493 16.016 6
-      vertex -18.3493 16.016 1
-    endloop
-  endfacet
-  facet normal -0.970074 0.24281 0
-    outer loop
-      vertex -18.3493 16.016 6
-      vertex -18.4327 15.6828 1
-      vertex -18.4327 15.6828 6
-    endloop
-  endfacet
-  facet normal -0.941557 0.336853 0
-    outer loop
-      vertex -18.3493 16.016 1
-      vertex -18.2336 16.3394 6
-      vertex -18.2336 16.3394 1
-    endloop
-  endfacet
-  facet normal -0.941557 0.336853 0
-    outer loop
-      vertex -18.2336 16.3394 6
-      vertex -18.3493 16.016 1
-      vertex -18.3493 16.016 6
-    endloop
-  endfacet
-  facet normal -0.741046 0.671454 0
-    outer loop
-      vertex -17.7055 17.2204 1
-      vertex -17.4749 17.4749 6
-      vertex -17.4749 17.4749 1
-    endloop
-  endfacet
-  facet normal -0.741046 0.671454 0
-    outer loop
-      vertex -17.4749 17.4749 6
-      vertex -17.7055 17.2204 1
-      vertex -17.7055 17.2204 6
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
-      vertex -15.3431 18.4831 1
-      vertex -15.6828 18.4327 6
-      vertex -15.3431 18.4831 6
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
-      vertex -15.6828 18.4327 6
-      vertex -15.3431 18.4831 1
-      vertex -15.6828 18.4327 1
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex -15 18.5 1
-      vertex -15.3431 18.4831 6
-      vertex -15 18.5 6
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex -15.3431 18.4831 6
-      vertex -15 18.5 1
-      vertex -15.3431 18.4831 1
     endloop
   endfacet
   facet normal 0.0491971 0.998789 -0
@@ -8693,384 +6705,6 @@ solid OpenSCAD_Model
       vertex -15 18.5 1
     endloop
   endfacet
-  facet normal 0.903939 -0.427661 0
-    outer loop
-      vertex -11.9133 13.3501 6
-      vertex -11.7664 13.6606 1
-      vertex -11.7664 13.6606 6
-    endloop
-  endfacet
-  facet normal 0.903939 -0.427661 0
-    outer loop
-      vertex -11.7664 13.6606 1
-      vertex -11.9133 13.3501 6
-      vertex -11.9133 13.3501 1
-    endloop
-  endfacet
-  facet normal 0.803237 -0.595659 0
-    outer loop
-      vertex -12.2945 12.7796 6
-      vertex -12.0899 13.0555 1
-      vertex -12.0899 13.0555 6
-    endloop
-  endfacet
-  facet normal 0.803237 -0.595659 0
-    outer loop
-      vertex -12.0899 13.0555 1
-      vertex -12.2945 12.7796 6
-      vertex -12.2945 12.7796 1
-    endloop
-  endfacet
-  facet normal 0.989172 0.14676 0
-    outer loop
-      vertex -11.5169 15.3431 6
-      vertex -11.5673 15.6828 1
-      vertex -11.5673 15.6828 6
-    endloop
-  endfacet
-  facet normal 0.989172 0.14676 0
-    outer loop
-      vertex -11.5673 15.6828 1
-      vertex -11.5169 15.3431 6
-      vertex -11.5169 15.3431 1
-    endloop
-  endfacet
-  facet normal 0.803237 0.595659 0
-    outer loop
-      vertex -12.0899 16.9445 6
-      vertex -12.2945 17.2204 1
-      vertex -12.2945 17.2204 6
-    endloop
-  endfacet
-  facet normal 0.803237 0.595659 0
-    outer loop
-      vertex -12.2945 17.2204 1
-      vertex -12.0899 16.9445 6
-      vertex -12.0899 16.9445 1
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 -0
-    outer loop
-      vertex -13.3501 18.0867 1
-      vertex -13.6606 18.2336 6
-      vertex -13.3501 18.0867 6
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 0
-    outer loop
-      vertex -13.6606 18.2336 6
-      vertex -13.3501 18.0867 1
-      vertex -13.6606 18.2336 1
-    endloop
-  endfacet
-  facet normal 0.595659 0.803237 -0
-    outer loop
-      vertex -12.7796 17.7055 1
-      vertex -13.0555 17.9101 6
-      vertex -12.7796 17.7055 6
-    endloop
-  endfacet
-  facet normal 0.595659 0.803237 0
-    outer loop
-      vertex -13.0555 17.9101 6
-      vertex -12.7796 17.7055 1
-      vertex -13.0555 17.9101 1
-    endloop
-  endfacet
-  facet normal 0.336853 0.941557 -0
-    outer loop
-      vertex -13.6606 18.2336 1
-      vertex -13.984 18.3493 6
-      vertex -13.6606 18.2336 6
-    endloop
-  endfacet
-  facet normal 0.336853 0.941557 0
-    outer loop
-      vertex -13.984 18.3493 6
-      vertex -13.6606 18.2336 1
-      vertex -13.984 18.3493 1
-    endloop
-  endfacet
-  facet normal 0.14676 -0.989172 0
-    outer loop
-      vertex -14.6569 11.5169 1
-      vertex -14.3172 11.5673 6
-      vertex -14.6569 11.5169 6
-    endloop
-  endfacet
-  facet normal 0.14676 -0.989172 0
-    outer loop
-      vertex -14.3172 11.5673 6
-      vertex -14.6569 11.5169 1
-      vertex -14.3172 11.5673 1
-    endloop
-  endfacet
-  facet normal 0.427661 -0.903939 0
-    outer loop
-      vertex -13.6606 11.7664 1
-      vertex -13.3501 11.9133 6
-      vertex -13.6606 11.7664 6
-    endloop
-  endfacet
-  facet normal 0.427661 -0.903939 0
-    outer loop
-      vertex -13.3501 11.9133 6
-      vertex -13.6606 11.7664 1
-      vertex -13.3501 11.9133 1
-    endloop
-  endfacet
-  facet normal 0.336853 -0.941557 0
-    outer loop
-      vertex -13.984 11.6507 1
-      vertex -13.6606 11.7664 6
-      vertex -13.984 11.6507 6
-    endloop
-  endfacet
-  facet normal 0.336853 -0.941557 0
-    outer loop
-      vertex -13.6606 11.7664 6
-      vertex -13.984 11.6507 1
-      vertex -13.6606 11.7664 1
-    endloop
-  endfacet
-  facet normal -0.14676 -0.989172 0
-    outer loop
-      vertex -15.6828 11.5673 1
-      vertex -15.3431 11.5169 6
-      vertex -15.6828 11.5673 6
-    endloop
-  endfacet
-  facet normal -0.14676 -0.989172 -0
-    outer loop
-      vertex -15.3431 11.5169 6
-      vertex -15.6828 11.5673 1
-      vertex -15.3431 11.5169 1
-    endloop
-  endfacet
-  facet normal -0.0491971 -0.998789 0
-    outer loop
-      vertex -15.3431 11.5169 1
-      vertex -15 11.5 6
-      vertex -15.3431 11.5169 6
-    endloop
-  endfacet
-  facet normal -0.0491971 -0.998789 -0
-    outer loop
-      vertex -15 11.5 6
-      vertex -15.3431 11.5169 1
-      vertex -15 11.5 1
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex -17.4749 12.5251 1
-      vertex -17.7055 12.7796 6
-      vertex -17.7055 12.7796 1
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex -17.7055 12.7796 6
-      vertex -17.4749 12.5251 1
-      vertex -17.4749 12.5251 6
-    endloop
-  endfacet
-  facet normal -0.803237 -0.595659 0
-    outer loop
-      vertex -17.7055 12.7796 1
-      vertex -17.9101 13.0555 6
-      vertex -17.9101 13.0555 1
-    endloop
-  endfacet
-  facet normal -0.803237 -0.595659 0
-    outer loop
-      vertex -17.9101 13.0555 6
-      vertex -17.7055 12.7796 1
-      vertex -17.7055 12.7796 6
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex -18.4327 14.3172 1
-      vertex -18.4831 14.6569 6
-      vertex -18.4831 14.6569 1
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex -18.4831 14.6569 6
-      vertex -18.4327 14.3172 1
-      vertex -18.4327 14.3172 6
-    endloop
-  endfacet
-  facet normal -0.998789 -0.0491971 0
-    outer loop
-      vertex -18.4831 14.6569 1
-      vertex -18.5 15 6
-      vertex -18.5 15 1
-    endloop
-  endfacet
-  facet normal -0.998789 -0.0491971 0
-    outer loop
-      vertex -18.5 15 6
-      vertex -18.4831 14.6569 1
-      vertex -18.4831 14.6569 6
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex -18.0867 16.6499 1
-      vertex -17.9101 16.9445 6
-      vertex -17.9101 16.9445 1
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex -17.9101 16.9445 6
-      vertex -18.0867 16.6499 1
-      vertex -18.0867 16.6499 6
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex -16.6499 18.0867 1
-      vertex -16.9445 17.9101 6
-      vertex -16.6499 18.0867 6
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex -16.9445 17.9101 6
-      vertex -16.6499 18.0867 1
-      vertex -16.9445 17.9101 1
-    endloop
-  endfacet
-  facet normal 0.941557 -0.336853 0
-    outer loop
-      vertex -11.7664 13.6606 6
-      vertex -11.6507 13.984 1
-      vertex -11.6507 13.984 6
-    endloop
-  endfacet
-  facet normal 0.941557 -0.336853 0
-    outer loop
-      vertex -11.6507 13.984 1
-      vertex -11.7664 13.6606 6
-      vertex -11.7664 13.6606 1
-    endloop
-  endfacet
-  facet normal 0.989172 -0.14676 0
-    outer loop
-      vertex -11.5673 14.3172 6
-      vertex -11.5169 14.6569 1
-      vertex -11.5169 14.6569 6
-    endloop
-  endfacet
-  facet normal 0.989172 -0.14676 0
-    outer loop
-      vertex -11.5169 14.6569 1
-      vertex -11.5673 14.3172 6
-      vertex -11.5673 14.3172 1
-    endloop
-  endfacet
-  facet normal 0.857698 0.514153 0
-    outer loop
-      vertex -11.9133 16.6499 6
-      vertex -12.0899 16.9445 1
-      vertex -12.0899 16.9445 6
-    endloop
-  endfacet
-  facet normal 0.857698 0.514153 0
-    outer loop
-      vertex -12.0899 16.9445 1
-      vertex -11.9133 16.6499 6
-      vertex -11.9133 16.6499 1
-    endloop
-  endfacet
-  facet normal 0.671454 0.741046 -0
-    outer loop
-      vertex -12.5251 17.4749 1
-      vertex -12.7796 17.7055 6
-      vertex -12.5251 17.4749 6
-    endloop
-  endfacet
-  facet normal 0.671454 0.741046 0
-    outer loop
-      vertex -12.7796 17.7055 6
-      vertex -12.5251 17.4749 1
-      vertex -12.7796 17.7055 1
-    endloop
-  endfacet
-  facet normal 0.24281 0.970074 -0
-    outer loop
-      vertex -13.984 18.3493 1
-      vertex -14.3172 18.4327 6
-      vertex -13.984 18.3493 6
-    endloop
-  endfacet
-  facet normal 0.24281 0.970074 0
-    outer loop
-      vertex -14.3172 18.4327 6
-      vertex -13.984 18.3493 1
-      vertex -14.3172 18.4327 1
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 -0
-    outer loop
-      vertex -13.0555 17.9101 1
-      vertex -13.3501 18.0867 6
-      vertex -13.0555 17.9101 6
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 0
-    outer loop
-      vertex -13.3501 18.0867 6
-      vertex -13.0555 17.9101 1
-      vertex -13.3501 18.0867 1
-    endloop
-  endfacet
-  facet normal 0.514153 -0.857698 0
-    outer loop
-      vertex -13.3501 11.9133 1
-      vertex -13.0555 12.0899 6
-      vertex -13.3501 11.9133 6
-    endloop
-  endfacet
-  facet normal 0.514153 -0.857698 0
-    outer loop
-      vertex -13.0555 12.0899 6
-      vertex -13.3501 11.9133 1
-      vertex -13.0555 12.0899 1
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex -14.3172 11.5673 1
-      vertex -13.984 11.6507 6
-      vertex -14.3172 11.5673 6
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex -13.984 11.6507 6
-      vertex -14.3172 11.5673 1
-      vertex -13.984 11.6507 1
-    endloop
-  endfacet
-  facet normal -0.24281 -0.970074 0
-    outer loop
-      vertex -16.016 11.6507 1
-      vertex -15.6828 11.5673 6
-      vertex -16.016 11.6507 6
-    endloop
-  endfacet
-  facet normal -0.24281 -0.970074 -0
-    outer loop
-      vertex -15.6828 11.5673 6
-      vertex -16.016 11.6507 1
-      vertex -15.6828 11.5673 1
-    endloop
-  endfacet
   facet normal -0.336853 -0.941557 0
     outer loop
       vertex -16.3394 11.7664 1
@@ -9083,62 +6717,6 @@ solid OpenSCAD_Model
       vertex -16.016 11.6507 6
       vertex -16.3394 11.7664 1
       vertex -16.016 11.6507 1
-    endloop
-  endfacet
-  facet normal 0.0491971 -0.998789 0
-    outer loop
-      vertex -15 11.5 1
-      vertex -14.6569 11.5169 6
-      vertex -15 11.5 6
-    endloop
-  endfacet
-  facet normal 0.0491971 -0.998789 0
-    outer loop
-      vertex -14.6569 11.5169 6
-      vertex -15 11.5 1
-      vertex -14.6569 11.5169 1
-    endloop
-  endfacet
-  facet normal -0.595659 0.803237 0
-    outer loop
-      vertex -16.9445 17.9101 1
-      vertex -17.2204 17.7055 6
-      vertex -16.9445 17.9101 6
-    endloop
-  endfacet
-  facet normal -0.595659 0.803237 0
-    outer loop
-      vertex -17.2204 17.7055 6
-      vertex -16.9445 17.9101 1
-      vertex -17.2204 17.7055 1
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex -16.016 18.3493 1
-      vertex -16.3394 18.2336 6
-      vertex -16.016 18.3493 6
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex -16.3394 18.2336 6
-      vertex -16.016 18.3493 1
-      vertex -16.3394 18.2336 1
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex -12.5251 12.5251 6
-      vertex -12.2945 12.7796 1
-      vertex -12.2945 12.7796 6
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex -12.2945 12.7796 1
-      vertex -12.5251 12.5251 6
-      vertex -12.5251 12.5251 1
     endloop
   endfacet
   facet normal 0.671454 -0.741046 0
@@ -9155,46 +6733,970 @@ solid OpenSCAD_Model
       vertex -12.5251 12.5251 1
     endloop
   endfacet
-  facet normal 0.903939 0.427661 0
+  facet normal -0.741046 0.671454 0
     outer loop
+      vertex -17.7055 17.2204 1
+      vertex -17.4749 17.4749 6
+      vertex -17.4749 17.4749 1
+    endloop
+  endfacet
+  facet normal -0.741046 0.671454 0
+    outer loop
+      vertex -17.4749 17.4749 6
+      vertex -17.7055 17.2204 1
+      vertex -17.7055 17.2204 6
+    endloop
+  endfacet
+  facet normal 0.970074 -0.24281 0
+    outer loop
+      vertex -11.6507 13.984 6
+      vertex -11.5673 14.3172 1
+      vertex -11.5673 14.3172 6
+    endloop
+  endfacet
+  facet normal 0.970074 -0.24281 0
+    outer loop
+      vertex -11.5673 14.3172 1
+      vertex -11.6507 13.984 6
+      vertex -11.6507 13.984 1
+    endloop
+  endfacet
+  facet normal -0.336853 0.941557 0
+    outer loop
+      vertex -16.016 18.3493 1
+      vertex -16.3394 18.2336 6
+      vertex -16.016 18.3493 6
+    endloop
+  endfacet
+  facet normal -0.336853 0.941557 0
+    outer loop
+      vertex -16.3394 18.2336 6
+      vertex -16.016 18.3493 1
+      vertex -16.3394 18.2336 1
+    endloop
+  endfacet
+  facet normal 0.989172 -0.14676 0
+    outer loop
+      vertex -11.5673 14.3172 6
+      vertex -11.5169 14.6569 1
+      vertex -11.5169 14.6569 6
+    endloop
+  endfacet
+  facet normal 0.989172 -0.14676 0
+    outer loop
+      vertex -11.5169 14.6569 1
+      vertex -11.5673 14.3172 6
+      vertex -11.5673 14.3172 1
+    endloop
+  endfacet
+  facet normal -0.941557 -0.336853 0
+    outer loop
+      vertex -18.2336 13.6606 1
+      vertex -18.3493 13.984 6
+      vertex -18.3493 13.984 1
+    endloop
+  endfacet
+  facet normal -0.941557 -0.336853 0
+    outer loop
+      vertex -18.3493 13.984 6
+      vertex -18.2336 13.6606 1
+      vertex -18.2336 13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.75 15 6
+      vertex -11.5 15 6
+      vertex -11.5169 15.3431 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.756 15.1225 6
+      vertex -11.5169 15.3431 6
+      vertex -11.5673 15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 15 6
+      vertex -13.75 15 6
+      vertex -11.5169 14.6569 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.774 15.2439 6
+      vertex -11.5673 15.6828 6
+      vertex -11.6507 16.016 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.756 14.8775 6
+      vertex -11.5169 14.6569 6
+      vertex -13.75 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.8038 15.3629 6
+      vertex -11.6507 16.016 6
       vertex -11.7664 16.3394 6
-      vertex -11.9133 16.6499 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5169 14.6569 6
+      vertex -13.756 14.8775 6
+      vertex -11.5673 14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.8451 15.4784 6
+      vertex -11.7664 16.3394 6
       vertex -11.9133 16.6499 6
     endloop
   endfacet
-  facet normal 0.903939 0.427661 0
+  facet normal -0 0 1
     outer loop
-      vertex -11.9133 16.6499 1
-      vertex -11.7664 16.3394 6
-      vertex -11.7664 16.3394 1
+      vertex -13.774 14.7561 6
+      vertex -11.5673 14.3172 6
+      vertex -13.756 14.8775 6
     endloop
   endfacet
-  facet normal 0.941557 0.336853 0
+  facet normal 0 0 1
     outer loop
-      vertex -11.6507 16.016 6
-      vertex -11.7664 16.3394 1
-      vertex -11.7664 16.3394 6
+      vertex -13.8976 15.5892 6
+      vertex -11.9133 16.6499 6
+      vertex -12.0899 16.9445 6
     endloop
   endfacet
-  facet normal 0.941557 0.336853 0
+  facet normal 0 0 1
     outer loop
-      vertex -11.7664 16.3394 1
-      vertex -11.6507 16.016 6
-      vertex -11.6507 16.016 1
+      vertex -11.5673 14.3172 6
+      vertex -13.774 14.7561 6
+      vertex -11.6507 13.984 6
     endloop
   endfacet
-  facet normal 0.741046 0.671454 0
+  facet normal 0 0 1
     outer loop
+      vertex -13.9607 15.6945 6
+      vertex -12.0899 16.9445 6
       vertex -12.2945 17.2204 6
-      vertex -12.5251 17.4749 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8038 14.6371 6
+      vertex -11.6507 13.984 6
+      vertex -13.774 14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0337 15.793 6
+      vertex -12.2945 17.2204 6
       vertex -12.5251 17.4749 6
     endloop
   endfacet
-  facet normal 0.741046 0.671454 0
+  facet normal 0 0 1
     outer loop
-      vertex -12.5251 17.4749 1
+      vertex -11.6507 13.984 6
+      vertex -13.8038 14.6371 6
+      vertex -11.7664 13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.1161 15.8839 6
+      vertex -12.5251 17.4749 6
+      vertex -12.7796 17.7055 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8451 14.5216 6
+      vertex -11.7664 13.6606 6
+      vertex -13.8038 14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.207 15.9663 6
+      vertex -12.7796 17.7055 6
+      vertex -13.0555 17.9101 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7664 13.6606 6
+      vertex -13.8451 14.5216 6
+      vertex -11.9133 13.3501 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3055 16.0393 6
+      vertex -13.0555 17.9101 6
+      vertex -13.3501 18.0867 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8976 14.4108 6
+      vertex -11.9133 13.3501 6
+      vertex -13.8451 14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4108 16.1024 6
+      vertex -13.3501 18.0867 6
+      vertex -13.6606 18.2336 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9133 13.3501 6
+      vertex -13.8976 14.4108 6
+      vertex -12.0899 13.0555 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.9607 14.3055 6
+      vertex -12.0899 13.0555 6
+      vertex -13.8976 14.4108 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5169 15.3431 6
+      vertex -13.756 15.1225 6
+      vertex -13.75 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5673 15.6828 6
+      vertex -13.774 15.2439 6
+      vertex -13.756 15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6507 16.016 6
+      vertex -13.8038 15.3629 6
+      vertex -13.774 15.2439 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7664 16.3394 6
+      vertex -13.8451 15.4784 6
+      vertex -13.8038 15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9133 16.6499 6
+      vertex -13.8976 15.5892 6
+      vertex -13.8451 15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0899 16.9445 6
+      vertex -13.9607 15.6945 6
+      vertex -13.8976 15.5892 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5216 16.1549 6
+      vertex -13.6606 18.2336 6
+      vertex -13.984 18.3493 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex -12.2945 17.2204 6
-      vertex -12.2945 17.2204 1
+      vertex -14.0337 15.793 6
+      vertex -13.9607 15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5251 17.4749 6
+      vertex -14.1161 15.8839 6
+      vertex -14.0337 15.793 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.7796 17.7055 6
+      vertex -14.207 15.9663 6
+      vertex -14.1161 15.8839 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0555 17.9101 6
+      vertex -14.3055 16.0393 6
+      vertex -14.207 15.9663 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6371 16.1962 6
+      vertex -13.984 18.3493 6
+      vertex -14.3172 18.4327 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3501 18.0867 6
+      vertex -14.4108 16.1024 6
+      vertex -14.3055 16.0393 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6606 18.2336 6
+      vertex -14.5216 16.1549 6
+      vertex -14.4108 16.1024 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.984 18.3493 6
+      vertex -14.6371 16.1962 6
+      vertex -14.5216 16.1549 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7561 16.226 6
+      vertex -14.3172 18.4327 6
+      vertex -14.6569 18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3172 18.4327 6
+      vertex -14.7561 16.226 6
+      vertex -14.6371 16.1962 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6569 18.4831 6
+      vertex -14.8775 16.244 6
+      vertex -14.7561 16.226 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 18.5 6
+      vertex -14.8775 16.244 6
+      vertex -14.6569 18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 18.5 6
+      vertex -15 16.25 6
+      vertex -14.8775 16.244 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 18.5 6
+      vertex -15.1225 16.244 6
+      vertex -15 16.25 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.3431 18.4831 6
+      vertex -15.1225 16.244 6
+      vertex -15 18.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1225 16.244 6
+      vertex -15.3431 18.4831 6
+      vertex -15.2439 16.226 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.6828 18.4327 6
+      vertex -15.2439 16.226 6
+      vertex -15.3431 18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.2439 16.226 6
+      vertex -15.6828 18.4327 6
+      vertex -15.3629 16.1962 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.016 18.3493 6
+      vertex -15.3629 16.1962 6
+      vertex -15.6828 18.4327 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3629 16.1962 6
+      vertex -16.016 18.3493 6
+      vertex -15.4784 16.1549 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.3394 18.2336 6
+      vertex -15.4784 16.1549 6
+      vertex -16.016 18.3493 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4784 16.1549 6
+      vertex -16.3394 18.2336 6
+      vertex -15.5892 16.1024 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.6499 18.0867 6
+      vertex -15.5892 16.1024 6
+      vertex -16.3394 18.2336 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5892 16.1024 6
+      vertex -16.6499 18.0867 6
+      vertex -15.6945 16.0393 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.9445 17.9101 6
+      vertex -15.6945 16.0393 6
+      vertex -16.6499 18.0867 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6945 16.0393 6
+      vertex -16.9445 17.9101 6
+      vertex -15.793 15.9663 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.2204 17.7055 6
+      vertex -15.793 15.9663 6
+      vertex -16.9445 17.9101 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.793 15.9663 6
+      vertex -17.2204 17.7055 6
+      vertex -15.8839 15.8839 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.4749 17.4749 6
+      vertex -15.8839 15.8839 6
+      vertex -17.2204 17.7055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8839 15.8839 6
+      vertex -17.4749 17.4749 6
+      vertex -15.9663 15.793 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.7055 17.2204 6
+      vertex -15.9663 15.793 6
+      vertex -17.4749 17.4749 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.9101 16.9445 6
+      vertex -16.0393 15.6945 6
+      vertex -17.7055 17.2204 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9663 15.793 6
+      vertex -17.7055 17.2204 6
+      vertex -16.0393 15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0899 13.0555 6
+      vertex -13.9607 14.3055 6
+      vertex -12.2945 12.7796 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.0337 14.207 6
+      vertex -12.2945 12.7796 6
+      vertex -13.9607 14.3055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2945 12.7796 6
+      vertex -14.0337 14.207 6
+      vertex -12.5251 12.5251 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.1161 14.1161 6
+      vertex -12.5251 12.5251 6
+      vertex -14.0337 14.207 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5251 12.5251 6
+      vertex -14.1161 14.1161 6
+      vertex -12.7796 12.2945 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.207 14.0337 6
+      vertex -12.7796 12.2945 6
+      vertex -14.1161 14.1161 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.7796 12.2945 6
+      vertex -14.207 14.0337 6
+      vertex -13.0555 12.0899 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.3055 13.9607 6
+      vertex -13.0555 12.0899 6
+      vertex -14.207 14.0337 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0555 12.0899 6
+      vertex -14.3055 13.9607 6
+      vertex -13.3501 11.9133 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.4108 13.8976 6
+      vertex -13.3501 11.9133 6
+      vertex -14.3055 13.9607 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3501 11.9133 6
+      vertex -14.4108 13.8976 6
+      vertex -13.6606 11.7664 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.5216 13.8451 6
+      vertex -13.6606 11.7664 6
+      vertex -14.4108 13.8976 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6606 11.7664 6
+      vertex -14.5216 13.8451 6
+      vertex -13.984 11.6507 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.6371 13.8038 6
+      vertex -13.984 11.6507 6
+      vertex -14.5216 13.8451 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.984 11.6507 6
+      vertex -14.6371 13.8038 6
+      vertex -14.3172 11.5673 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.7561 13.774 6
+      vertex -14.3172 11.5673 6
+      vertex -14.6371 13.8038 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3172 11.5673 6
+      vertex -14.7561 13.774 6
+      vertex -14.6569 11.5169 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.8775 13.756 6
+      vertex -14.6569 11.5169 6
+      vertex -14.7561 13.774 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15 13.75 6
+      vertex -14.6569 11.5169 6
+      vertex -14.8775 13.756 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 13.75 6
+      vertex -15 11.5 6
+      vertex -14.6569 11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1225 13.756 6
+      vertex -15 11.5 6
+      vertex -15 13.75 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3431 11.5169 6
+      vertex -15.1225 13.756 6
+      vertex -15.2439 13.774 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1225 13.756 6
+      vertex -15.3431 11.5169 6
+      vertex -15 11.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6828 11.5673 6
+      vertex -15.2439 13.774 6
+      vertex -15.3629 13.8038 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.016 11.6507 6
+      vertex -15.3629 13.8038 6
+      vertex -15.4784 13.8451 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3394 11.7664 6
+      vertex -15.4784 13.8451 6
+      vertex -15.5892 13.8976 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.2439 13.774 6
+      vertex -15.6828 11.5673 6
+      vertex -15.3431 11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6499 11.9133 6
+      vertex -15.5892 13.8976 6
+      vertex -15.6945 13.9607 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9445 12.0899 6
+      vertex -15.6945 13.9607 6
+      vertex -15.793 14.0337 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2204 12.2945 6
+      vertex -15.793 14.0337 6
+      vertex -15.8839 14.1161 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4749 12.5251 6
+      vertex -15.8839 14.1161 6
+      vertex -15.9663 14.207 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3629 13.8038 6
+      vertex -16.016 11.6507 6
+      vertex -15.6828 11.5673 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.7055 12.7796 6
+      vertex -15.9663 14.207 6
+      vertex -16.0393 14.3055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9101 13.0555 6
+      vertex -16.0393 14.3055 6
+      vertex -16.1024 14.4108 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0867 13.3501 6
+      vertex -16.1024 14.4108 6
+      vertex -16.1549 14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2336 13.6606 6
+      vertex -16.1549 14.5216 6
+      vertex -16.1962 14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3493 13.984 6
+      vertex -16.1962 14.6371 6
+      vertex -16.226 14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4327 14.3172 6
+      vertex -16.226 14.7561 6
+      vertex -16.244 14.8775 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4784 13.8451 6
+      vertex -16.3394 11.7664 6
+      vertex -16.016 11.6507 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 14.6569 6
+      vertex -16.244 14.8775 6
+      vertex -16.25 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0393 15.6945 6
+      vertex -17.9101 16.9445 6
+      vertex -16.1024 15.5892 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.0867 16.6499 6
+      vertex -16.1024 15.5892 6
+      vertex -17.9101 16.9445 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5892 13.8976 6
+      vertex -16.6499 11.9133 6
+      vertex -16.3394 11.7664 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1024 15.5892 6
+      vertex -18.0867 16.6499 6
+      vertex -16.1549 15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6945 13.9607 6
+      vertex -16.9445 12.0899 6
+      vertex -16.6499 11.9133 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.2336 16.3394 6
+      vertex -16.1549 15.4784 6
+      vertex -18.0867 16.6499 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.793 14.0337 6
+      vertex -17.2204 12.2945 6
+      vertex -16.9445 12.0899 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1549 15.4784 6
+      vertex -18.2336 16.3394 6
+      vertex -16.1962 15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8839 14.1161 6
+      vertex -17.4749 12.5251 6
+      vertex -17.2204 12.2945 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.3493 16.016 6
+      vertex -16.1962 15.3629 6
+      vertex -18.2336 16.3394 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.9663 14.207 6
+      vertex -17.7055 12.7796 6
+      vertex -17.4749 12.5251 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1962 15.3629 6
+      vertex -18.3493 16.016 6
+      vertex -16.226 15.2439 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0393 14.3055 6
+      vertex -17.9101 13.0555 6
+      vertex -17.7055 12.7796 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4327 15.6828 6
+      vertex -16.226 15.2439 6
+      vertex -18.3493 16.016 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1024 14.4108 6
+      vertex -18.0867 13.3501 6
+      vertex -17.9101 13.0555 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.226 15.2439 6
+      vertex -18.4327 15.6828 6
+      vertex -16.244 15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1549 14.5216 6
+      vertex -18.2336 13.6606 6
+      vertex -18.0867 13.3501 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.4831 15.3431 6
+      vertex -16.244 15.1225 6
+      vertex -18.4327 15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1962 14.6371 6
+      vertex -18.3493 13.984 6
+      vertex -18.2336 13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.244 15.1225 6
+      vertex -18.4831 15.3431 6
+      vertex -16.25 15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.226 14.7561 6
+      vertex -18.4327 14.3172 6
+      vertex -18.3493 13.984 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 15 6
+      vertex -16.25 15 6
+      vertex -18.4831 15.3431 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.244 14.8775 6
+      vertex -18.4831 14.6569 6
+      vertex -18.4327 14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.25 15 6
+      vertex -18.5 15 6
+      vertex -18.4831 14.6569 6
     endloop
   endfacet
   facet normal -0.427661 0.903939 0
@@ -9211,242 +7713,690 @@ solid OpenSCAD_Model
       vertex -16.6499 18.0867 1
     endloop
   endfacet
-  facet normal 0.998789 -0.0491971 0
+  facet normal 0.989172 0.14676 0
     outer loop
-      vertex 18.4831 -15.3431 6
-      vertex 18.5 -15 1
-      vertex 18.5 -15 6
+      vertex -11.5169 15.3431 6
+      vertex -11.5673 15.6828 1
+      vertex -11.5673 15.6828 6
     endloop
   endfacet
-  facet normal 0.998789 -0.0491971 0
+  facet normal 0.989172 0.14676 0
     outer loop
-      vertex 18.5 -15 1
-      vertex 18.4831 -15.3431 6
-      vertex 18.4831 -15.3431 1
+      vertex -11.5673 15.6828 1
+      vertex -11.5169 15.3431 6
+      vertex -11.5169 15.3431 1
     endloop
   endfacet
-  facet normal -0.941557 0.336853 0
+  facet normal -0.741046 -0.671454 0
     outer loop
-      vertex 11.6507 -13.984 1
-      vertex 11.7664 -13.6606 6
-      vertex 11.7664 -13.6606 1
+      vertex -17.4749 12.5251 1
+      vertex -17.7055 12.7796 6
+      vertex -17.7055 12.7796 1
     endloop
   endfacet
-  facet normal -0.941557 0.336853 0
+  facet normal -0.741046 -0.671454 0
     outer loop
-      vertex 11.7664 -13.6606 6
-      vertex 11.6507 -13.984 1
-      vertex 11.6507 -13.984 6
+      vertex -17.7055 12.7796 6
+      vertex -17.4749 12.5251 1
+      vertex -17.4749 12.5251 6
     endloop
   endfacet
-  facet normal 0.803237 -0.595659 0
+  facet normal -0.903939 -0.427661 0
     outer loop
-      vertex 17.7055 -17.2204 6
-      vertex 17.9101 -16.9445 1
-      vertex 17.9101 -16.9445 6
+      vertex -18.0867 13.3501 1
+      vertex -18.2336 13.6606 6
+      vertex -18.2336 13.6606 1
     endloop
   endfacet
-  facet normal 0.803237 -0.595659 0
+  facet normal -0.903939 -0.427661 0
     outer loop
-      vertex 17.9101 -16.9445 1
-      vertex 17.7055 -17.2204 6
-      vertex 17.7055 -17.2204 1
+      vertex -18.2336 13.6606 6
+      vertex -18.0867 13.3501 1
+      vertex -18.0867 13.3501 6
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex -18.4327 14.3172 1
+      vertex -18.4831 14.6569 6
+      vertex -18.4831 14.6569 1
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex -18.4831 14.6569 6
+      vertex -18.4327 14.3172 1
+      vertex -18.4327 14.3172 6
+    endloop
+  endfacet
+  facet normal -0.857698 0.514153 0
+    outer loop
+      vertex -18.0867 16.6499 1
+      vertex -17.9101 16.9445 6
+      vertex -17.9101 16.9445 1
+    endloop
+  endfacet
+  facet normal -0.857698 0.514153 0
+    outer loop
+      vertex -17.9101 16.9445 6
+      vertex -18.0867 16.6499 1
+      vertex -18.0867 16.6499 6
+    endloop
+  endfacet
+  facet normal -0.970074 0.24281 0
+    outer loop
+      vertex -18.4327 15.6828 1
+      vertex -18.3493 16.016 6
+      vertex -18.3493 16.016 1
+    endloop
+  endfacet
+  facet normal -0.970074 0.24281 0
+    outer loop
+      vertex -18.3493 16.016 6
+      vertex -18.4327 15.6828 1
+      vertex -18.4327 15.6828 6
+    endloop
+  endfacet
+  facet normal -0.0491971 0.998789 0
+    outer loop
+      vertex -15 18.5 1
+      vertex -15.3431 18.4831 6
+      vertex -15 18.5 6
+    endloop
+  endfacet
+  facet normal -0.0491971 0.998789 0
+    outer loop
+      vertex -15.3431 18.4831 6
+      vertex -15 18.5 1
+      vertex -15.3431 18.4831 1
     endloop
   endfacet
   facet normal -0.14676 -0.989172 0
     outer loop
-      vertex 14.3172 -18.4327 1
-      vertex 14.6569 -18.4831 6
-      vertex 14.3172 -18.4327 6
+      vertex -15.6828 11.5673 1
+      vertex -15.3431 11.5169 6
+      vertex -15.6828 11.5673 6
     endloop
   endfacet
   facet normal -0.14676 -0.989172 -0
     outer loop
-      vertex 14.6569 -18.4831 6
-      vertex 14.3172 -18.4327 1
-      vertex 14.6569 -18.4831 1
+      vertex -15.3431 11.5169 6
+      vertex -15.6828 11.5673 1
+      vertex -15.3431 11.5169 1
     endloop
   endfacet
-  facet normal 0.941557 0.336853 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex 18.3493 -13.984 6
-      vertex 18.2336 -13.6606 1
-      vertex 18.2336 -13.6606 6
+      vertex -14.3172 11.5673 1
+      vertex -13.984 11.6507 6
+      vertex -14.3172 11.5673 6
     endloop
   endfacet
-  facet normal 0.941557 0.336853 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex 18.2336 -13.6606 1
-      vertex 18.3493 -13.984 6
-      vertex 18.3493 -13.984 1
+      vertex -13.984 11.6507 6
+      vertex -14.3172 11.5673 1
+      vertex -13.984 11.6507 1
     endloop
   endfacet
-  facet normal 0.970074 0.24281 0
+  facet normal 0.0491971 -0.998789 0
     outer loop
-      vertex 18.4327 -14.3172 6
-      vertex 18.3493 -13.984 1
-      vertex 18.3493 -13.984 6
+      vertex -15 11.5 1
+      vertex -14.6569 11.5169 6
+      vertex -15 11.5 6
     endloop
   endfacet
-  facet normal 0.970074 0.24281 0
+  facet normal 0.0491971 -0.998789 0
     outer loop
-      vertex 18.3493 -13.984 1
-      vertex 18.4327 -14.3172 6
-      vertex 18.4327 -14.3172 1
+      vertex -14.6569 11.5169 6
+      vertex -15 11.5 1
+      vertex -14.6569 11.5169 1
     endloop
   endfacet
-  facet normal 0.941557 -0.336853 0
+  facet normal 0.741046 -0.671454 0
     outer loop
-      vertex 18.2336 -16.3394 6
-      vertex 18.3493 -16.016 1
-      vertex 18.3493 -16.016 6
+      vertex -12.5251 12.5251 6
+      vertex -12.2945 12.7796 1
+      vertex -12.2945 12.7796 6
     endloop
   endfacet
-  facet normal 0.941557 -0.336853 0
+  facet normal 0.741046 -0.671454 0
     outer loop
-      vertex 18.3493 -16.016 1
-      vertex 18.2336 -16.3394 6
-      vertex 18.2336 -16.3394 1
+      vertex -12.2945 12.7796 1
+      vertex -12.5251 12.5251 6
+      vertex -12.5251 12.5251 1
     endloop
   endfacet
-  facet normal 0.14676 -0.989172 0
+  facet normal 0.741046 0.671454 0
     outer loop
-      vertex 15.3431 -18.4831 1
-      vertex 15.6828 -18.4327 6
-      vertex 15.3431 -18.4831 6
+      vertex -12.2945 17.2204 6
+      vertex -12.5251 17.4749 1
+      vertex -12.5251 17.4749 6
     endloop
   endfacet
-  facet normal 0.14676 -0.989172 0
+  facet normal 0.741046 0.671454 0
     outer loop
-      vertex 15.6828 -18.4327 6
-      vertex 15.3431 -18.4831 1
-      vertex 15.6828 -18.4327 1
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex 13.984 -11.6507 1
-      vertex 13.6606 -11.7664 6
-      vertex 13.984 -11.6507 6
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex 13.6606 -11.7664 6
-      vertex 13.984 -11.6507 1
-      vertex 13.6606 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 -0
-    outer loop
-      vertex 16.9445 -12.0899 1
-      vertex 16.6499 -11.9133 6
-      vertex 16.9445 -12.0899 6
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 0
-    outer loop
-      vertex 16.6499 -11.9133 6
-      vertex 16.9445 -12.0899 1
-      vertex 16.6499 -11.9133 1
-    endloop
-  endfacet
-  facet normal 0.671454 -0.741046 0
-    outer loop
-      vertex 17.2204 -17.7055 1
-      vertex 17.4749 -17.4749 6
-      vertex 17.2204 -17.7055 6
-    endloop
-  endfacet
-  facet normal 0.671454 -0.741046 0
-    outer loop
-      vertex 17.4749 -17.4749 6
-      vertex 17.2204 -17.7055 1
-      vertex 17.4749 -17.4749 1
+      vertex -12.5251 17.4749 1
+      vertex -12.2945 17.2204 6
+      vertex -12.2945 17.2204 1
     endloop
   endfacet
   facet normal -0.0491971 -0.998789 0
     outer loop
-      vertex 14.6569 -18.4831 1
-      vertex 15 -18.5 6
-      vertex 14.6569 -18.4831 6
+      vertex -15.3431 11.5169 1
+      vertex -15 11.5 6
+      vertex -15.3431 11.5169 6
     endloop
   endfacet
   facet normal -0.0491971 -0.998789 -0
     outer loop
-      vertex 15 -18.5 6
-      vertex 14.6569 -18.4831 1
-      vertex 15 -18.5 1
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex 15.6828 -18.4327 1
-      vertex 16.016 -18.3493 6
-      vertex 15.6828 -18.4327 6
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex 16.016 -18.3493 6
-      vertex 15.6828 -18.4327 1
-      vertex 16.016 -18.3493 1
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex 11.9133 -13.3501 1
-      vertex 12.0899 -13.0555 6
-      vertex 12.0899 -13.0555 1
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex 12.0899 -13.0555 6
-      vertex 11.9133 -13.3501 1
-      vertex 11.9133 -13.3501 6
-    endloop
-  endfacet
-  facet normal -0.998789 0.0491971 0
-    outer loop
-      vertex 11.5 -15 1
-      vertex 11.5169 -14.6569 6
-      vertex 11.5169 -14.6569 1
-    endloop
-  endfacet
-  facet normal -0.998789 0.0491971 0
-    outer loop
-      vertex 11.5169 -14.6569 6
-      vertex 11.5 -15 1
-      vertex 11.5 -15 6
-    endloop
-  endfacet
-  facet normal -0.595659 0.803237 0
-    outer loop
-      vertex 13.0555 -12.0899 1
-      vertex 12.7796 -12.2945 6
-      vertex 13.0555 -12.0899 6
-    endloop
-  endfacet
-  facet normal -0.595659 0.803237 0
-    outer loop
-      vertex 12.7796 -12.2945 6
-      vertex 13.0555 -12.0899 1
-      vertex 12.7796 -12.2945 1
+      vertex -15 11.5 6
+      vertex -15.3431 11.5169 1
+      vertex -15 11.5 1
     endloop
   endfacet
   facet normal 0.14676 0.989172 -0
     outer loop
-      vertex 15.6828 -11.5673 1
-      vertex 15.3431 -11.5169 6
-      vertex 15.6828 -11.5673 6
+      vertex -14.3172 18.4327 1
+      vertex -14.6569 18.4831 6
+      vertex -14.3172 18.4327 6
     endloop
   endfacet
   facet normal 0.14676 0.989172 0
     outer loop
-      vertex 15.3431 -11.5169 6
-      vertex 15.6828 -11.5673 1
-      vertex 15.3431 -11.5169 1
+      vertex -14.6569 18.4831 6
+      vertex -14.3172 18.4327 1
+      vertex -14.6569 18.4831 1
+    endloop
+  endfacet
+  facet normal 0.941557 -0.336853 0
+    outer loop
+      vertex -11.7664 13.6606 6
+      vertex -11.6507 13.984 1
+      vertex -11.6507 13.984 6
+    endloop
+  endfacet
+  facet normal 0.941557 -0.336853 0
+    outer loop
+      vertex -11.6507 13.984 1
+      vertex -11.7664 13.6606 6
+      vertex -11.7664 13.6606 1
+    endloop
+  endfacet
+  facet normal -0.989172 0.14676 0
+    outer loop
+      vertex -18.4831 15.3431 1
+      vertex -18.4327 15.6828 6
+      vertex -18.4327 15.6828 1
+    endloop
+  endfacet
+  facet normal -0.989172 0.14676 0
+    outer loop
+      vertex -18.4327 15.6828 6
+      vertex -18.4831 15.3431 1
+      vertex -18.4831 15.3431 6
+    endloop
+  endfacet
+  facet normal -0.941557 0.336853 0
+    outer loop
+      vertex -18.3493 16.016 1
+      vertex -18.2336 16.3394 6
+      vertex -18.2336 16.3394 1
+    endloop
+  endfacet
+  facet normal -0.941557 0.336853 0
+    outer loop
+      vertex -18.2336 16.3394 6
+      vertex -18.3493 16.016 1
+      vertex -18.3493 16.016 6
+    endloop
+  endfacet
+  facet normal -0.24281 0.970074 0
+    outer loop
+      vertex -15.6828 18.4327 1
+      vertex -16.016 18.3493 6
+      vertex -15.6828 18.4327 6
+    endloop
+  endfacet
+  facet normal -0.24281 0.970074 0
+    outer loop
+      vertex -16.016 18.3493 6
+      vertex -15.6828 18.4327 1
+      vertex -16.016 18.3493 1
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491971 0
+    outer loop
+      vertex -18.4831 14.6569 1
+      vertex -18.5 15 6
+      vertex -18.5 15 1
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491971 0
+    outer loop
+      vertex -18.5 15 6
+      vertex -18.4831 14.6569 1
+      vertex -18.4831 14.6569 6
+    endloop
+  endfacet
+  facet normal -0.427661 -0.903939 0
+    outer loop
+      vertex -16.6499 11.9133 1
+      vertex -16.3394 11.7664 6
+      vertex -16.6499 11.9133 6
+    endloop
+  endfacet
+  facet normal -0.427661 -0.903939 -0
+    outer loop
+      vertex -16.3394 11.7664 6
+      vertex -16.6499 11.9133 1
+      vertex -16.3394 11.7664 1
+    endloop
+  endfacet
+  facet normal 0.998789 -0.0491971 0
+    outer loop
+      vertex -11.5169 14.6569 6
+      vertex -11.5 15 1
+      vertex -11.5 15 6
+    endloop
+  endfacet
+  facet normal 0.998789 -0.0491971 0
+    outer loop
+      vertex -11.5 15 1
+      vertex -11.5169 14.6569 6
+      vertex -11.5169 14.6569 1
+    endloop
+  endfacet
+  facet normal 0.427661 -0.903939 0
+    outer loop
+      vertex -13.6606 11.7664 1
+      vertex -13.3501 11.9133 6
+      vertex -13.6606 11.7664 6
+    endloop
+  endfacet
+  facet normal 0.427661 -0.903939 0
+    outer loop
+      vertex -13.3501 11.9133 6
+      vertex -13.6606 11.7664 1
+      vertex -13.3501 11.9133 1
+    endloop
+  endfacet
+  facet normal 0.24281 0.970074 -0
+    outer loop
+      vertex -13.984 18.3493 1
+      vertex -14.3172 18.4327 6
+      vertex -13.984 18.3493 6
+    endloop
+  endfacet
+  facet normal 0.24281 0.970074 0
+    outer loop
+      vertex -14.3172 18.4327 6
+      vertex -13.984 18.3493 1
+      vertex -14.3172 18.4327 1
+    endloop
+  endfacet
+  facet normal -0.14676 0.989172 0
+    outer loop
+      vertex -15.3431 18.4831 1
+      vertex -15.6828 18.4327 6
+      vertex -15.3431 18.4831 6
+    endloop
+  endfacet
+  facet normal -0.14676 0.989172 0
+    outer loop
+      vertex -15.6828 18.4327 6
+      vertex -15.3431 18.4831 1
+      vertex -15.6828 18.4327 1
+    endloop
+  endfacet
+  facet normal -0.803237 -0.595659 0
+    outer loop
+      vertex -17.7055 12.7796 1
+      vertex -17.9101 13.0555 6
+      vertex -17.9101 13.0555 1
+    endloop
+  endfacet
+  facet normal -0.803237 -0.595659 0
+    outer loop
+      vertex -17.9101 13.0555 6
+      vertex -17.7055 12.7796 1
+      vertex -17.7055 12.7796 6
+    endloop
+  endfacet
+  facet normal -0.671454 0.741046 0
+    outer loop
+      vertex -17.2204 17.7055 1
+      vertex -17.4749 17.4749 6
+      vertex -17.2204 17.7055 6
+    endloop
+  endfacet
+  facet normal -0.671454 0.741046 0
+    outer loop
+      vertex -17.4749 17.4749 6
+      vertex -17.2204 17.7055 1
+      vertex -17.4749 17.4749 1
+    endloop
+  endfacet
+  facet normal 0.803237 0.595659 0
+    outer loop
+      vertex -12.0899 16.9445 6
+      vertex -12.2945 17.2204 1
+      vertex -12.2945 17.2204 6
+    endloop
+  endfacet
+  facet normal 0.803237 0.595659 0
+    outer loop
+      vertex -12.2945 17.2204 1
+      vertex -12.0899 16.9445 6
+      vertex -12.0899 16.9445 1
+    endloop
+  endfacet
+  facet normal 0.903939 -0.427661 0
+    outer loop
+      vertex -11.9133 13.3501 6
+      vertex -11.7664 13.6606 1
+      vertex -11.7664 13.6606 6
+    endloop
+  endfacet
+  facet normal 0.903939 -0.427661 0
+    outer loop
+      vertex -11.7664 13.6606 1
+      vertex -11.9133 13.3501 6
+      vertex -11.9133 13.3501 1
+    endloop
+  endfacet
+  facet normal 0.336853 0.941557 -0
+    outer loop
+      vertex -13.6606 18.2336 1
+      vertex -13.984 18.3493 6
+      vertex -13.6606 18.2336 6
+    endloop
+  endfacet
+  facet normal 0.336853 0.941557 0
+    outer loop
+      vertex -13.984 18.3493 6
+      vertex -13.6606 18.2336 1
+      vertex -13.984 18.3493 1
+    endloop
+  endfacet
+  facet normal -0.24281 -0.970074 0
+    outer loop
+      vertex -16.016 11.6507 1
+      vertex -15.6828 11.5673 6
+      vertex -16.016 11.6507 6
+    endloop
+  endfacet
+  facet normal -0.24281 -0.970074 -0
+    outer loop
+      vertex -15.6828 11.5673 6
+      vertex -16.016 11.6507 1
+      vertex -15.6828 11.5673 1
+    endloop
+  endfacet
+  facet normal -0.514153 -0.857698 0
+    outer loop
+      vertex -16.9445 12.0899 1
+      vertex -16.6499 11.9133 6
+      vertex -16.9445 12.0899 6
+    endloop
+  endfacet
+  facet normal -0.514153 -0.857698 -0
+    outer loop
+      vertex -16.6499 11.9133 6
+      vertex -16.9445 12.0899 1
+      vertex -16.6499 11.9133 1
+    endloop
+  endfacet
+  facet normal 0.671454 0.741046 -0
+    outer loop
+      vertex -12.5251 17.4749 1
+      vertex -12.7796 17.7055 6
+      vertex -12.5251 17.4749 6
+    endloop
+  endfacet
+  facet normal 0.671454 0.741046 0
+    outer loop
+      vertex -12.7796 17.7055 6
+      vertex -12.5251 17.4749 1
+      vertex -12.7796 17.7055 1
+    endloop
+  endfacet
+  facet normal -0.903939 0.427661 0
+    outer loop
+      vertex -18.2336 16.3394 1
+      vertex -18.0867 16.6499 6
+      vertex -18.0867 16.6499 1
+    endloop
+  endfacet
+  facet normal -0.903939 0.427661 0
+    outer loop
+      vertex -18.0867 16.6499 6
+      vertex -18.2336 16.3394 1
+      vertex -18.2336 16.3394 6
+    endloop
+  endfacet
+  facet normal 0.998789 0.0491971 0
+    outer loop
+      vertex -11.5 15 6
+      vertex -11.5169 15.3431 1
+      vertex -11.5169 15.3431 6
+    endloop
+  endfacet
+  facet normal 0.998789 0.0491971 0
+    outer loop
+      vertex -11.5169 15.3431 1
+      vertex -11.5 15 6
+      vertex -11.5 15 1
+    endloop
+  endfacet
+  facet normal -0.970074 -0.24281 0
+    outer loop
+      vertex -18.3493 13.984 1
+      vertex -18.4327 14.3172 6
+      vertex -18.4327 14.3172 1
+    endloop
+  endfacet
+  facet normal -0.970074 -0.24281 0
+    outer loop
+      vertex -18.4327 14.3172 6
+      vertex -18.3493 13.984 1
+      vertex -18.3493 13.984 6
+    endloop
+  endfacet
+  facet normal 0.595659 -0.803237 0
+    outer loop
+      vertex -13.0555 12.0899 1
+      vertex -12.7796 12.2945 6
+      vertex -13.0555 12.0899 6
+    endloop
+  endfacet
+  facet normal 0.595659 -0.803237 0
+    outer loop
+      vertex -12.7796 12.2945 6
+      vertex -13.0555 12.0899 1
+      vertex -12.7796 12.2945 1
+    endloop
+  endfacet
+  facet normal 0.941557 0.336853 0
+    outer loop
+      vertex -11.6507 16.016 6
+      vertex -11.7664 16.3394 1
+      vertex -11.7664 16.3394 6
+    endloop
+  endfacet
+  facet normal 0.941557 0.336853 0
+    outer loop
+      vertex -11.7664 16.3394 1
+      vertex -11.6507 16.016 6
+      vertex -11.6507 16.016 1
+    endloop
+  endfacet
+  facet normal 0.857698 0.514153 0
+    outer loop
+      vertex -11.9133 16.6499 6
+      vertex -12.0899 16.9445 1
+      vertex -12.0899 16.9445 6
+    endloop
+  endfacet
+  facet normal 0.857698 0.514153 0
+    outer loop
+      vertex -12.0899 16.9445 1
+      vertex -11.9133 16.6499 6
+      vertex -11.9133 16.6499 1
+    endloop
+  endfacet
+  facet normal 0.903939 0.427661 0
+    outer loop
+      vertex -11.7664 16.3394 6
+      vertex -11.9133 16.6499 1
+      vertex -11.9133 16.6499 6
+    endloop
+  endfacet
+  facet normal 0.903939 0.427661 0
+    outer loop
+      vertex -11.9133 16.6499 1
+      vertex -11.7664 16.3394 6
+      vertex -11.7664 16.3394 1
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 0
+    outer loop
+      vertex -12.2945 12.7796 6
+      vertex -12.0899 13.0555 1
+      vertex -12.0899 13.0555 6
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 0
+    outer loop
+      vertex -12.0899 13.0555 1
+      vertex -12.2945 12.7796 6
+      vertex -12.2945 12.7796 1
+    endloop
+  endfacet
+  facet normal 0.595659 0.803237 -0
+    outer loop
+      vertex -12.7796 17.7055 1
+      vertex -13.0555 17.9101 6
+      vertex -12.7796 17.7055 6
+    endloop
+  endfacet
+  facet normal 0.595659 0.803237 0
+    outer loop
+      vertex -13.0555 17.9101 6
+      vertex -12.7796 17.7055 1
+      vertex -13.0555 17.9101 1
+    endloop
+  endfacet
+  facet normal -0.514153 0.857698 0
+    outer loop
+      vertex -16.6499 18.0867 1
+      vertex -16.9445 17.9101 6
+      vertex -16.6499 18.0867 6
+    endloop
+  endfacet
+  facet normal -0.514153 0.857698 0
+    outer loop
+      vertex -16.9445 17.9101 6
+      vertex -16.6499 18.0867 1
+      vertex -16.9445 17.9101 1
+    endloop
+  endfacet
+  facet normal 0.427661 0.903939 -0
+    outer loop
+      vertex -13.3501 18.0867 1
+      vertex -13.6606 18.2336 6
+      vertex -13.3501 18.0867 6
+    endloop
+  endfacet
+  facet normal 0.427661 0.903939 0
+    outer loop
+      vertex -13.6606 18.2336 6
+      vertex -13.3501 18.0867 1
+      vertex -13.6606 18.2336 1
+    endloop
+  endfacet
+  facet normal 0.514153 -0.857698 0
+    outer loop
+      vertex -13.3501 11.9133 1
+      vertex -13.0555 12.0899 6
+      vertex -13.3501 11.9133 6
+    endloop
+  endfacet
+  facet normal 0.514153 -0.857698 0
+    outer loop
+      vertex -13.0555 12.0899 6
+      vertex -13.3501 11.9133 1
+      vertex -13.0555 12.0899 1
+    endloop
+  endfacet
+  facet normal 0.514153 0.857698 -0
+    outer loop
+      vertex -13.0555 17.9101 1
+      vertex -13.3501 18.0867 6
+      vertex -13.0555 17.9101 6
+    endloop
+  endfacet
+  facet normal 0.514153 0.857698 0
+    outer loop
+      vertex -13.3501 18.0867 6
+      vertex -13.0555 17.9101 1
+      vertex -13.3501 18.0867 1
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex -14.6569 11.5169 1
+      vertex -14.3172 11.5673 6
+      vertex -14.6569 11.5169 6
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex -14.3172 11.5673 6
+      vertex -14.6569 11.5169 1
+      vertex -14.3172 11.5673 1
+    endloop
+  endfacet
+  facet normal -0.803237 0.595659 0
+    outer loop
+      vertex -17.9101 16.9445 1
+      vertex -17.7055 17.2204 6
+      vertex -17.7055 17.2204 1
+    endloop
+  endfacet
+  facet normal -0.803237 0.595659 0
+    outer loop
+      vertex -17.7055 17.2204 6
+      vertex -17.9101 16.9445 1
+      vertex -17.9101 16.9445 6
+    endloop
+  endfacet
+  facet normal -0.595659 0.803237 0
+    outer loop
+      vertex -16.9445 17.9101 1
+      vertex -17.2204 17.7055 6
+      vertex -16.9445 17.9101 6
+    endloop
+  endfacet
+  facet normal -0.595659 0.803237 0
+    outer loop
+      vertex -17.2204 17.7055 6
+      vertex -16.9445 17.9101 1
+      vertex -17.2204 17.7055 1
+    endloop
+  endfacet
+  facet normal 0.970074 0.24281 0
+    outer loop
+      vertex -11.5673 15.6828 6
+      vertex -11.6507 16.016 1
+      vertex -11.6507 16.016 6
+    endloop
+  endfacet
+  facet normal 0.970074 0.24281 0
+    outer loop
+      vertex -11.6507 16.016 1
+      vertex -11.5673 15.6828 6
+      vertex -11.5673 15.6828 1
     endloop
   endfacet
   facet normal 0.671454 0.741046 -0
@@ -9463,60 +8413,18 @@ solid OpenSCAD_Model
       vertex 17.2204 -12.2945 1
     endloop
   endfacet
-  facet normal 0.741046 0.671454 0
+  facet normal 0.336853 0.941557 -0
     outer loop
-      vertex 17.7055 -12.7796 6
-      vertex 17.4749 -12.5251 1
-      vertex 17.4749 -12.5251 6
+      vertex 16.3394 -11.7664 1
+      vertex 16.016 -11.6507 6
+      vertex 16.3394 -11.7664 6
     endloop
   endfacet
-  facet normal 0.741046 0.671454 0
+  facet normal 0.336853 0.941557 0
     outer loop
-      vertex 17.4749 -12.5251 1
-      vertex 17.7055 -12.7796 6
-      vertex 17.7055 -12.7796 1
-    endloop
-  endfacet
-  facet normal 0.903939 0.427661 0
-    outer loop
-      vertex 18.2336 -13.6606 6
-      vertex 18.0867 -13.3501 1
-      vertex 18.0867 -13.3501 6
-    endloop
-  endfacet
-  facet normal 0.903939 0.427661 0
-    outer loop
-      vertex 18.0867 -13.3501 1
-      vertex 18.2336 -13.6606 6
-      vertex 18.2336 -13.6606 1
-    endloop
-  endfacet
-  facet normal 0.857698 -0.514153 0
-    outer loop
-      vertex 17.9101 -16.9445 6
-      vertex 18.0867 -16.6499 1
-      vertex 18.0867 -16.6499 6
-    endloop
-  endfacet
-  facet normal 0.857698 -0.514153 0
-    outer loop
-      vertex 18.0867 -16.6499 1
-      vertex 17.9101 -16.9445 6
-      vertex 17.9101 -16.9445 1
-    endloop
-  endfacet
-  facet normal 0.903939 -0.427661 0
-    outer loop
-      vertex 18.0867 -16.6499 6
-      vertex 18.2336 -16.3394 1
-      vertex 18.2336 -16.3394 6
-    endloop
-  endfacet
-  facet normal 0.903939 -0.427661 0
-    outer loop
-      vertex 18.2336 -16.3394 1
-      vertex 18.0867 -16.6499 6
-      vertex 18.0867 -16.6499 1
+      vertex 16.016 -11.6507 6
+      vertex 16.3394 -11.7664 1
+      vertex 16.016 -11.6507 1
     endloop
   endfacet
   facet normal 0.970074 -0.24281 0
@@ -9533,60 +8441,46 @@ solid OpenSCAD_Model
       vertex 18.3493 -16.016 1
     endloop
   endfacet
-  facet normal 0.989172 -0.14676 0
+  facet normal -0.857698 0.514153 0
     outer loop
-      vertex 18.4327 -15.6828 6
-      vertex 18.4831 -15.3431 1
-      vertex 18.4831 -15.3431 6
+      vertex 11.9133 -13.3501 1
+      vertex 12.0899 -13.0555 6
+      vertex 12.0899 -13.0555 1
     endloop
   endfacet
-  facet normal 0.989172 -0.14676 0
+  facet normal -0.857698 0.514153 0
     outer loop
-      vertex 18.4831 -15.3431 1
-      vertex 18.4327 -15.6828 6
-      vertex 18.4327 -15.6828 1
+      vertex 12.0899 -13.0555 6
+      vertex 11.9133 -13.3501 1
+      vertex 11.9133 -13.3501 6
     endloop
   endfacet
-  facet normal 0.336853 -0.941557 0
+  facet normal 0.903939 -0.427661 0
     outer loop
-      vertex 16.016 -18.3493 1
-      vertex 16.3394 -18.2336 6
-      vertex 16.016 -18.3493 6
+      vertex 18.0867 -16.6499 6
+      vertex 18.2336 -16.3394 1
+      vertex 18.2336 -16.3394 6
     endloop
   endfacet
-  facet normal 0.336853 -0.941557 0
+  facet normal 0.903939 -0.427661 0
     outer loop
-      vertex 16.3394 -18.2336 6
-      vertex 16.016 -18.3493 1
-      vertex 16.3394 -18.2336 1
+      vertex 18.2336 -16.3394 1
+      vertex 18.0867 -16.6499 6
+      vertex 18.0867 -16.6499 1
     endloop
   endfacet
-  facet normal 0.595659 -0.803237 0
+  facet normal 0.803237 0.595659 0
     outer loop
-      vertex 16.9445 -17.9101 1
-      vertex 17.2204 -17.7055 6
-      vertex 16.9445 -17.9101 6
+      vertex 17.9101 -13.0555 6
+      vertex 17.7055 -12.7796 1
+      vertex 17.7055 -12.7796 6
     endloop
   endfacet
-  facet normal 0.595659 -0.803237 0
+  facet normal 0.803237 0.595659 0
     outer loop
-      vertex 17.2204 -17.7055 6
-      vertex 16.9445 -17.9101 1
-      vertex 17.2204 -17.7055 1
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex 17.4749 -17.4749 6
-      vertex 17.7055 -17.2204 1
-      vertex 17.7055 -17.2204 6
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex 17.7055 -17.2204 1
-      vertex 17.4749 -17.4749 6
-      vertex 17.4749 -17.4749 1
+      vertex 17.7055 -12.7796 1
+      vertex 17.9101 -13.0555 6
+      vertex 17.9101 -13.0555 1
     endloop
   endfacet
   facet normal 0.0491971 -0.998789 0
@@ -9603,228 +8497,32 @@ solid OpenSCAD_Model
       vertex 15.3431 -18.4831 1
     endloop
   endfacet
-  facet normal -0.903939 0.427661 0
+  facet normal -0.0491971 -0.998789 0
     outer loop
-      vertex 11.7664 -13.6606 1
-      vertex 11.9133 -13.3501 6
-      vertex 11.9133 -13.3501 1
+      vertex 14.6569 -18.4831 1
+      vertex 15 -18.5 6
+      vertex 14.6569 -18.4831 6
     endloop
   endfacet
-  facet normal -0.903939 0.427661 0
+  facet normal -0.0491971 -0.998789 -0
     outer loop
-      vertex 11.9133 -13.3501 6
-      vertex 11.7664 -13.6606 1
-      vertex 11.7664 -13.6606 6
+      vertex 15 -18.5 6
+      vertex 14.6569 -18.4831 1
+      vertex 15 -18.5 1
     endloop
   endfacet
-  facet normal -0.803237 0.595659 0
+  facet normal 0.998789 -0.0491971 0
     outer loop
-      vertex 12.0899 -13.0555 1
-      vertex 12.2945 -12.7796 6
-      vertex 12.2945 -12.7796 1
-    endloop
-  endfacet
-  facet normal -0.803237 0.595659 0
-    outer loop
-      vertex 12.2945 -12.7796 6
-      vertex 12.0899 -13.0555 1
-      vertex 12.0899 -13.0555 6
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex 11.5673 -15.6828 1
-      vertex 11.5169 -15.3431 6
-      vertex 11.5169 -15.3431 1
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex 11.5169 -15.3431 6
-      vertex 11.5673 -15.6828 1
-      vertex 11.5673 -15.6828 6
-    endloop
-  endfacet
-  facet normal -0.803237 -0.595659 0
-    outer loop
-      vertex 12.2945 -17.2204 1
-      vertex 12.0899 -16.9445 6
-      vertex 12.0899 -16.9445 1
-    endloop
-  endfacet
-  facet normal -0.803237 -0.595659 0
-    outer loop
-      vertex 12.0899 -16.9445 6
-      vertex 12.2945 -17.2204 1
-      vertex 12.2945 -17.2204 6
-    endloop
-  endfacet
-  facet normal -0.427661 -0.903939 0
-    outer loop
-      vertex 13.3501 -18.0867 1
-      vertex 13.6606 -18.2336 6
-      vertex 13.3501 -18.0867 6
-    endloop
-  endfacet
-  facet normal -0.427661 -0.903939 -0
-    outer loop
-      vertex 13.6606 -18.2336 6
-      vertex 13.3501 -18.0867 1
-      vertex 13.6606 -18.2336 1
-    endloop
-  endfacet
-  facet normal -0.595659 -0.803237 0
-    outer loop
-      vertex 12.7796 -17.7055 1
-      vertex 13.0555 -17.9101 6
-      vertex 12.7796 -17.7055 6
-    endloop
-  endfacet
-  facet normal -0.595659 -0.803237 -0
-    outer loop
-      vertex 13.0555 -17.9101 6
-      vertex 12.7796 -17.7055 1
-      vertex 13.0555 -17.9101 1
-    endloop
-  endfacet
-  facet normal -0.336853 -0.941557 0
-    outer loop
-      vertex 13.6606 -18.2336 1
-      vertex 13.984 -18.3493 6
-      vertex 13.6606 -18.2336 6
-    endloop
-  endfacet
-  facet normal -0.336853 -0.941557 -0
-    outer loop
-      vertex 13.984 -18.3493 6
-      vertex 13.6606 -18.2336 1
-      vertex 13.984 -18.3493 1
-    endloop
-  endfacet
-  facet normal -0.427661 0.903939 0
-    outer loop
-      vertex 13.6606 -11.7664 1
-      vertex 13.3501 -11.9133 6
-      vertex 13.6606 -11.7664 6
-    endloop
-  endfacet
-  facet normal -0.427661 0.903939 0
-    outer loop
-      vertex 13.3501 -11.9133 6
-      vertex 13.6606 -11.7664 1
-      vertex 13.3501 -11.9133 1
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 -0
-    outer loop
-      vertex 16.6499 -11.9133 1
-      vertex 16.3394 -11.7664 6
-      vertex 16.6499 -11.9133 6
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 0
-    outer loop
-      vertex 16.3394 -11.7664 6
-      vertex 16.6499 -11.9133 1
-      vertex 16.3394 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0.595659 0.803237 -0
-    outer loop
-      vertex 17.2204 -12.2945 1
-      vertex 16.9445 -12.0899 6
-      vertex 17.2204 -12.2945 6
-    endloop
-  endfacet
-  facet normal 0.595659 0.803237 0
-    outer loop
-      vertex 16.9445 -12.0899 6
-      vertex 17.2204 -12.2945 1
-      vertex 16.9445 -12.0899 1
-    endloop
-  endfacet
-  facet normal 0.803237 0.595659 0
-    outer loop
-      vertex 17.9101 -13.0555 6
-      vertex 17.7055 -12.7796 1
-      vertex 17.7055 -12.7796 6
-    endloop
-  endfacet
-  facet normal 0.803237 0.595659 0
-    outer loop
-      vertex 17.7055 -12.7796 1
-      vertex 17.9101 -13.0555 6
-      vertex 17.9101 -13.0555 1
-    endloop
-  endfacet
-  facet normal 0.857698 0.514153 0
-    outer loop
-      vertex 18.0867 -13.3501 6
-      vertex 17.9101 -13.0555 1
-      vertex 17.9101 -13.0555 6
-    endloop
-  endfacet
-  facet normal 0.857698 0.514153 0
-    outer loop
-      vertex 17.9101 -13.0555 1
-      vertex 18.0867 -13.3501 6
-      vertex 18.0867 -13.3501 1
-    endloop
-  endfacet
-  facet normal 0.989172 0.14676 0
-    outer loop
-      vertex 18.4831 -14.6569 6
-      vertex 18.4327 -14.3172 1
-      vertex 18.4327 -14.3172 6
-    endloop
-  endfacet
-  facet normal 0.989172 0.14676 0
-    outer loop
-      vertex 18.4327 -14.3172 1
-      vertex 18.4831 -14.6569 6
-      vertex 18.4831 -14.6569 1
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex 18.5 -15 6
-      vertex 18.4831 -14.6569 1
-      vertex 18.4831 -14.6569 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex 18.4831 -14.6569 1
-      vertex 18.5 -15 6
+      vertex 18.4831 -15.3431 6
       vertex 18.5 -15 1
+      vertex 18.5 -15 6
     endloop
   endfacet
-  facet normal 0.514153 -0.857698 0
+  facet normal 0.998789 -0.0491971 0
     outer loop
-      vertex 16.6499 -18.0867 1
-      vertex 16.9445 -17.9101 6
-      vertex 16.6499 -18.0867 6
-    endloop
-  endfacet
-  facet normal 0.514153 -0.857698 0
-    outer loop
-      vertex 16.9445 -17.9101 6
-      vertex 16.6499 -18.0867 1
-      vertex 16.9445 -17.9101 1
-    endloop
-  endfacet
-  facet normal -0.989172 0.14676 0
-    outer loop
-      vertex 11.5169 -14.6569 1
-      vertex 11.5673 -14.3172 6
-      vertex 11.5673 -14.3172 1
-    endloop
-  endfacet
-  facet normal -0.989172 0.14676 0
-    outer loop
-      vertex 11.5673 -14.3172 6
-      vertex 11.5169 -14.6569 1
-      vertex 11.5169 -14.6569 6
+      vertex 18.5 -15 1
+      vertex 18.4831 -15.3431 6
+      vertex 18.4831 -15.3431 1
     endloop
   endfacet
   facet normal -0.970074 0.24281 0
@@ -9841,1012 +8539,60 @@ solid OpenSCAD_Model
       vertex 11.5673 -14.3172 6
     endloop
   endfacet
-  facet normal -0.998789 -0.0491971 0
+  facet normal -0.671454 0.741046 0
     outer loop
-      vertex 11.5169 -15.3431 1
-      vertex 11.5 -15 6
-      vertex 11.5 -15 1
-    endloop
-  endfacet
-  facet normal -0.998789 -0.0491971 0
-    outer loop
-      vertex 11.5 -15 6
-      vertex 11.5169 -15.3431 1
-      vertex 11.5169 -15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.25 -15 6
-      vertex 18.5 -15 6
-      vertex 18.4831 -14.6569 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.244 -14.8775 6
-      vertex 18.4831 -14.6569 6
-      vertex 18.4327 -14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 -15 6
-      vertex 16.25 -15 6
-      vertex 18.4831 -15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.226 -14.7561 6
-      vertex 18.4327 -14.3172 6
-      vertex 18.3493 -13.984 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.244 -15.1225 6
-      vertex 18.4831 -15.3431 6
-      vertex 16.25 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1962 -14.6371 6
-      vertex 18.3493 -13.984 6
-      vertex 18.2336 -13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4831 -15.3431 6
-      vertex 16.244 -15.1225 6
-      vertex 18.4327 -15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1549 -14.5216 6
-      vertex 18.2336 -13.6606 6
-      vertex 18.0867 -13.3501 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.226 -15.2439 6
-      vertex 18.4327 -15.6828 6
-      vertex 16.244 -15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1024 -14.4108 6
-      vertex 18.0867 -13.3501 6
-      vertex 17.9101 -13.0555 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4327 -15.6828 6
-      vertex 16.226 -15.2439 6
-      vertex 18.3493 -16.016 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0393 -14.3055 6
-      vertex 17.9101 -13.0555 6
-      vertex 17.7055 -12.7796 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1962 -15.3629 6
-      vertex 18.3493 -16.016 6
-      vertex 16.226 -15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.9663 -14.207 6
-      vertex 17.7055 -12.7796 6
-      vertex 17.4749 -12.5251 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3493 -16.016 6
-      vertex 16.1962 -15.3629 6
-      vertex 18.2336 -16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.8839 -14.1161 6
-      vertex 17.4749 -12.5251 6
-      vertex 17.2204 -12.2945 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1549 -15.4784 6
-      vertex 18.2336 -16.3394 6
-      vertex 16.1962 -15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.793 -14.0337 6
-      vertex 17.2204 -12.2945 6
-      vertex 16.9445 -12.0899 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2336 -16.3394 6
-      vertex 16.1549 -15.4784 6
-      vertex 18.0867 -16.6499 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6945 -13.9607 6
-      vertex 16.9445 -12.0899 6
-      vertex 16.6499 -11.9133 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1024 -15.5892 6
-      vertex 18.0867 -16.6499 6
-      vertex 16.1549 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.5892 -13.8976 6
-      vertex 16.6499 -11.9133 6
-      vertex 16.3394 -11.7664 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0867 -16.6499 6
-      vertex 16.1024 -15.5892 6
-      vertex 17.9101 -16.9445 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.0393 -15.6945 6
-      vertex 17.9101 -16.9445 6
-      vertex 16.1024 -15.5892 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4831 -14.6569 6
-      vertex 16.244 -14.8775 6
-      vertex 16.25 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4327 -14.3172 6
-      vertex 16.226 -14.7561 6
-      vertex 16.244 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.3493 -13.984 6
-      vertex 16.1962 -14.6371 6
-      vertex 16.226 -14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2336 -13.6606 6
-      vertex 16.1549 -14.5216 6
-      vertex 16.1962 -14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0867 -13.3501 6
-      vertex 16.1024 -14.4108 6
-      vertex 16.1549 -14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9101 -13.0555 6
-      vertex 16.0393 -14.3055 6
-      vertex 16.1024 -14.4108 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.4784 -13.8451 6
-      vertex 16.3394 -11.7664 6
-      vertex 16.016 -11.6507 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7055 -12.7796 6
-      vertex 15.9663 -14.207 6
-      vertex 16.0393 -14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.4749 -12.5251 6
-      vertex 15.8839 -14.1161 6
-      vertex 15.9663 -14.207 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.2204 -12.2945 6
-      vertex 15.793 -14.0337 6
-      vertex 15.8839 -14.1161 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 -12.0899 6
-      vertex 15.6945 -13.9607 6
-      vertex 15.793 -14.0337 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.3629 -13.8038 6
-      vertex 16.016 -11.6507 6
-      vertex 15.6828 -11.5673 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.6499 -11.9133 6
-      vertex 15.5892 -13.8976 6
-      vertex 15.6945 -13.9607 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3394 -11.7664 6
-      vertex 15.4784 -13.8451 6
-      vertex 15.5892 -13.8976 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.016 -11.6507 6
-      vertex 15.3629 -13.8038 6
-      vertex 15.4784 -13.8451 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.2439 -13.774 6
-      vertex 15.6828 -11.5673 6
-      vertex 15.3431 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6828 -11.5673 6
-      vertex 15.2439 -13.774 6
-      vertex 15.3629 -13.8038 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.3431 -11.5169 6
-      vertex 15.1225 -13.756 6
-      vertex 15.2439 -13.774 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 -11.5 6
-      vertex 15.1225 -13.756 6
-      vertex 15.3431 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 -11.5 6
-      vertex 15 -13.75 6
-      vertex 15.1225 -13.756 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 -11.5 6
-      vertex 14.8775 -13.756 6
-      vertex 15 -13.75 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.6569 -11.5169 6
-      vertex 14.8775 -13.756 6
-      vertex 15 -11.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8775 -13.756 6
-      vertex 14.6569 -11.5169 6
-      vertex 14.7561 -13.774 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.3172 -11.5673 6
-      vertex 14.7561 -13.774 6
-      vertex 14.6569 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.7561 -13.774 6
-      vertex 14.3172 -11.5673 6
-      vertex 14.6371 -13.8038 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.984 -11.6507 6
-      vertex 14.6371 -13.8038 6
-      vertex 14.3172 -11.5673 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6371 -13.8038 6
-      vertex 13.984 -11.6507 6
-      vertex 14.5216 -13.8451 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.6606 -11.7664 6
-      vertex 14.5216 -13.8451 6
-      vertex 13.984 -11.6507 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.5216 -13.8451 6
-      vertex 13.6606 -11.7664 6
-      vertex 14.4108 -13.8976 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.3501 -11.9133 6
-      vertex 14.4108 -13.8976 6
-      vertex 13.6606 -11.7664 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4108 -13.8976 6
-      vertex 13.3501 -11.9133 6
-      vertex 14.3055 -13.9607 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0555 -12.0899 6
-      vertex 14.3055 -13.9607 6
-      vertex 13.3501 -11.9133 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3055 -13.9607 6
-      vertex 13.0555 -12.0899 6
-      vertex 14.207 -14.0337 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.7796 -12.2945 6
-      vertex 14.207 -14.0337 6
-      vertex 13.0555 -12.0899 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.207 -14.0337 6
-      vertex 12.7796 -12.2945 6
-      vertex 14.1161 -14.1161 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
+      vertex 12.7796 -12.2945 1
       vertex 12.5251 -12.5251 6
-      vertex 14.1161 -14.1161 6
       vertex 12.7796 -12.2945 6
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.671454 0.741046 0
     outer loop
-      vertex 14.1161 -14.1161 6
       vertex 12.5251 -12.5251 6
-      vertex 14.0337 -14.207 6
+      vertex 12.7796 -12.2945 1
+      vertex 12.5251 -12.5251 1
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.514153 -0.857698 0
     outer loop
-      vertex 12.2945 -12.7796 6
-      vertex 14.0337 -14.207 6
-      vertex 12.5251 -12.5251 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.0899 -13.0555 6
-      vertex 13.9607 -14.3055 6
-      vertex 12.2945 -12.7796 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0337 -14.207 6
-      vertex 12.2945 -12.7796 6
-      vertex 13.9607 -14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.9101 -16.9445 6
-      vertex 16.0393 -15.6945 6
-      vertex 17.7055 -17.2204 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.9663 -15.793 6
-      vertex 17.7055 -17.2204 6
-      vertex 16.0393 -15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.7055 -17.2204 6
-      vertex 15.9663 -15.793 6
-      vertex 17.4749 -17.4749 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.8839 -15.8839 6
-      vertex 17.4749 -17.4749 6
-      vertex 15.9663 -15.793 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.4749 -17.4749 6
-      vertex 15.8839 -15.8839 6
-      vertex 17.2204 -17.7055 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.793 -15.9663 6
-      vertex 17.2204 -17.7055 6
-      vertex 15.8839 -15.8839 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.2204 -17.7055 6
-      vertex 15.793 -15.9663 6
+      vertex 16.6499 -18.0867 1
       vertex 16.9445 -17.9101 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.6945 -16.0393 6
-      vertex 16.9445 -17.9101 6
-      vertex 15.793 -15.9663 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.9445 -17.9101 6
-      vertex 15.6945 -16.0393 6
       vertex 16.6499 -18.0867 6
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.514153 -0.857698 0
     outer loop
-      vertex 15.5892 -16.1024 6
-      vertex 16.6499 -18.0867 6
-      vertex 15.6945 -16.0393 6
+      vertex 16.9445 -17.9101 6
+      vertex 16.6499 -18.0867 1
+      vertex 16.9445 -17.9101 1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0491971 0.998789 0
     outer loop
-      vertex 16.6499 -18.0867 6
-      vertex 15.5892 -16.1024 6
-      vertex 16.3394 -18.2336 6
+      vertex 15 -11.5 1
+      vertex 14.6569 -11.5169 6
+      vertex 15 -11.5 6
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.0491971 0.998789 0
     outer loop
-      vertex 15.4784 -16.1549 6
-      vertex 16.3394 -18.2336 6
-      vertex 15.5892 -16.1024 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.3394 -18.2336 6
-      vertex 15.4784 -16.1549 6
-      vertex 16.016 -18.3493 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.3629 -16.1962 6
-      vertex 16.016 -18.3493 6
-      vertex 15.4784 -16.1549 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.016 -18.3493 6
-      vertex 15.3629 -16.1962 6
-      vertex 15.6828 -18.4327 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.2439 -16.226 6
-      vertex 15.6828 -18.4327 6
-      vertex 15.3629 -16.1962 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6828 -18.4327 6
-      vertex 15.2439 -16.226 6
-      vertex 15.3431 -18.4831 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.1225 -16.244 6
-      vertex 15.3431 -18.4831 6
-      vertex 15.2439 -16.226 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15 -16.25 6
-      vertex 15.3431 -18.4831 6
-      vertex 15.1225 -16.244 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15 -16.25 6
-      vertex 15 -18.5 6
-      vertex 15.3431 -18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8775 -16.244 6
-      vertex 15 -18.5 6
-      vertex 15 -16.25 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6569 -18.4831 6
-      vertex 14.8775 -16.244 6
-      vertex 14.7561 -16.226 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.8775 -16.244 6
-      vertex 14.6569 -18.4831 6
-      vertex 15 -18.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3172 -18.4327 6
-      vertex 14.7561 -16.226 6
-      vertex 14.6371 -16.1962 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.984 -18.3493 6
-      vertex 14.6371 -16.1962 6
-      vertex 14.5216 -16.1549 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6606 -18.2336 6
-      vertex 14.5216 -16.1549 6
-      vertex 14.4108 -16.1024 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.7561 -16.226 6
-      vertex 14.3172 -18.4327 6
-      vertex 14.6569 -18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.3501 -18.0867 6
-      vertex 14.4108 -16.1024 6
-      vertex 14.3055 -16.0393 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.0555 -17.9101 6
-      vertex 14.3055 -16.0393 6
-      vertex 14.207 -15.9663 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7796 -17.7055 6
-      vertex 14.207 -15.9663 6
-      vertex 14.1161 -15.8839 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5251 -17.4749 6
-      vertex 14.1161 -15.8839 6
-      vertex 14.0337 -15.793 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.6371 -16.1962 6
-      vertex 13.984 -18.3493 6
-      vertex 14.3172 -18.4327 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2945 -17.2204 6
-      vertex 14.0337 -15.793 6
-      vertex 13.9607 -15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.0899 -16.9445 6
-      vertex 13.9607 -15.6945 6
-      vertex 13.8976 -15.5892 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.9133 -16.6499 6
-      vertex 13.8976 -15.5892 6
-      vertex 13.8451 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7664 -16.3394 6
-      vertex 13.8451 -15.4784 6
-      vertex 13.8038 -15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6507 -16.016 6
-      vertex 13.8038 -15.3629 6
-      vertex 13.774 -15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5673 -15.6828 6
-      vertex 13.774 -15.2439 6
-      vertex 13.756 -15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.5216 -16.1549 6
-      vertex 13.6606 -18.2336 6
-      vertex 13.984 -18.3493 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5169 -15.3431 6
-      vertex 13.756 -15.1225 6
-      vertex 13.75 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.9607 -14.3055 6
-      vertex 12.0899 -13.0555 6
-      vertex 13.8976 -14.4108 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.9133 -13.3501 6
-      vertex 13.8976 -14.4108 6
-      vertex 12.0899 -13.0555 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4108 -16.1024 6
-      vertex 13.3501 -18.0867 6
-      vertex 13.6606 -18.2336 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8976 -14.4108 6
-      vertex 11.9133 -13.3501 6
-      vertex 13.8451 -14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3055 -16.0393 6
-      vertex 13.0555 -17.9101 6
-      vertex 13.3501 -18.0867 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.7664 -13.6606 6
-      vertex 13.8451 -14.5216 6
-      vertex 11.9133 -13.3501 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.207 -15.9663 6
-      vertex 12.7796 -17.7055 6
-      vertex 13.0555 -17.9101 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8451 -14.5216 6
-      vertex 11.7664 -13.6606 6
-      vertex 13.8038 -14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.1161 -15.8839 6
-      vertex 12.5251 -17.4749 6
-      vertex 12.7796 -17.7055 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.6507 -13.984 6
-      vertex 13.8038 -14.6371 6
-      vertex 11.7664 -13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0337 -15.793 6
-      vertex 12.2945 -17.2204 6
-      vertex 12.5251 -17.4749 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8038 -14.6371 6
-      vertex 11.6507 -13.984 6
-      vertex 13.774 -14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.9607 -15.6945 6
-      vertex 12.0899 -16.9445 6
-      vertex 12.2945 -17.2204 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.5673 -14.3172 6
-      vertex 13.774 -14.7561 6
-      vertex 11.6507 -13.984 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8976 -15.5892 6
-      vertex 11.9133 -16.6499 6
-      vertex 12.0899 -16.9445 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.774 -14.7561 6
-      vertex 11.5673 -14.3172 6
-      vertex 13.756 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8451 -15.4784 6
-      vertex 11.7664 -16.3394 6
-      vertex 11.9133 -16.6499 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.5169 -14.6569 6
-      vertex 13.756 -14.8775 6
-      vertex 11.5673 -14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.8038 -15.3629 6
-      vertex 11.6507 -16.016 6
-      vertex 11.7664 -16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.756 -14.8775 6
-      vertex 11.5169 -14.6569 6
-      vertex 13.75 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.774 -15.2439 6
-      vertex 11.5673 -15.6828 6
-      vertex 11.6507 -16.016 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5 -15 6
-      vertex 13.75 -15 6
-      vertex 11.5169 -14.6569 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.756 -15.1225 6
-      vertex 11.5169 -15.3431 6
-      vertex 11.5673 -15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.75 -15 6
-      vertex 11.5 -15 6
-      vertex 11.5169 -15.3431 6
-    endloop
-  endfacet
-  facet normal -0.970074 -0.24281 0
-    outer loop
-      vertex 11.6507 -16.016 1
-      vertex 11.5673 -15.6828 6
-      vertex 11.5673 -15.6828 1
-    endloop
-  endfacet
-  facet normal -0.970074 -0.24281 0
-    outer loop
-      vertex 11.5673 -15.6828 6
-      vertex 11.6507 -16.016 1
-      vertex 11.6507 -16.016 6
-    endloop
-  endfacet
-  facet normal -0.857698 -0.514153 0
-    outer loop
-      vertex 12.0899 -16.9445 1
-      vertex 11.9133 -16.6499 6
-      vertex 11.9133 -16.6499 1
-    endloop
-  endfacet
-  facet normal -0.857698 -0.514153 0
-    outer loop
-      vertex 11.9133 -16.6499 6
-      vertex 12.0899 -16.9445 1
-      vertex 12.0899 -16.9445 6
-    endloop
-  endfacet
-  facet normal -0.941557 -0.336853 0
-    outer loop
-      vertex 11.7664 -16.3394 1
-      vertex 11.6507 -16.016 6
-      vertex 11.6507 -16.016 1
-    endloop
-  endfacet
-  facet normal -0.941557 -0.336853 0
-    outer loop
-      vertex 11.6507 -16.016 6
-      vertex 11.7664 -16.3394 1
-      vertex 11.7664 -16.3394 6
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex 12.5251 -17.4749 1
-      vertex 12.2945 -17.2204 6
-      vertex 12.2945 -17.2204 1
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex 12.2945 -17.2204 6
-      vertex 12.5251 -17.4749 1
-      vertex 12.5251 -17.4749 6
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex 13.3501 -11.9133 1
-      vertex 13.0555 -12.0899 6
-      vertex 13.3501 -11.9133 6
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex 13.0555 -12.0899 6
-      vertex 13.3501 -11.9133 1
-      vertex 13.0555 -12.0899 1
-    endloop
-  endfacet
-  facet normal -0.24281 0.970074 0
-    outer loop
-      vertex 14.3172 -11.5673 1
-      vertex 13.984 -11.6507 6
-      vertex 14.3172 -11.5673 6
-    endloop
-  endfacet
-  facet normal -0.24281 0.970074 0
-    outer loop
-      vertex 13.984 -11.6507 6
-      vertex 14.3172 -11.5673 1
-      vertex 13.984 -11.6507 1
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
+      vertex 14.6569 -11.5169 6
+      vertex 15 -11.5 1
       vertex 14.6569 -11.5169 1
-      vertex 14.3172 -11.5673 6
-      vertex 14.6569 -11.5169 6
     endloop
   endfacet
-  facet normal -0.14676 0.989172 0
+  facet normal 0.427661 0.903939 -0
     outer loop
-      vertex 14.3172 -11.5673 6
-      vertex 14.6569 -11.5169 1
-      vertex 14.3172 -11.5673 1
+      vertex 16.6499 -11.9133 1
+      vertex 16.3394 -11.7664 6
+      vertex 16.6499 -11.9133 6
+    endloop
+  endfacet
+  facet normal 0.427661 0.903939 0
+    outer loop
+      vertex 16.3394 -11.7664 6
+      vertex 16.6499 -11.9133 1
+      vertex 16.3394 -11.7664 1
     endloop
   endfacet
   facet normal 0.24281 0.970074 -0
@@ -10863,130 +8609,1040 @@ solid OpenSCAD_Model
       vertex 15.6828 -11.5673 1
     endloop
   endfacet
-  facet normal 0.336853 0.941557 -0
+  facet normal 0.595659 0.803237 -0
     outer loop
-      vertex 16.3394 -11.7664 1
-      vertex 16.016 -11.6507 6
+      vertex 17.2204 -12.2945 1
+      vertex 16.9445 -12.0899 6
+      vertex 17.2204 -12.2945 6
+    endloop
+  endfacet
+  facet normal 0.595659 0.803237 0
+    outer loop
+      vertex 16.9445 -12.0899 6
+      vertex 17.2204 -12.2945 1
+      vertex 16.9445 -12.0899 1
+    endloop
+  endfacet
+  facet normal 0.741046 -0.671454 0
+    outer loop
+      vertex 17.4749 -17.4749 6
+      vertex 17.7055 -17.2204 1
+      vertex 17.7055 -17.2204 6
+    endloop
+  endfacet
+  facet normal 0.741046 -0.671454 0
+    outer loop
+      vertex 17.7055 -17.2204 1
+      vertex 17.4749 -17.4749 6
+      vertex 17.4749 -17.4749 1
+    endloop
+  endfacet
+  facet normal -0.941557 0.336853 0
+    outer loop
+      vertex 11.6507 -13.984 1
+      vertex 11.7664 -13.6606 6
+      vertex 11.7664 -13.6606 1
+    endloop
+  endfacet
+  facet normal -0.941557 0.336853 0
+    outer loop
+      vertex 11.7664 -13.6606 6
+      vertex 11.6507 -13.984 1
+      vertex 11.6507 -13.984 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.25 -15 6
+      vertex 18.5 -15 6
+      vertex 18.4831 -14.6569 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.244 -14.8775 6
+      vertex 18.4831 -14.6569 6
+      vertex 18.4327 -14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 -15 6
+      vertex 16.25 -15 6
+      vertex 18.4831 -15.3431 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.226 -14.7561 6
+      vertex 18.4327 -14.3172 6
+      vertex 18.3493 -13.984 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.244 -15.1225 6
+      vertex 18.4831 -15.3431 6
+      vertex 16.25 -15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1962 -14.6371 6
+      vertex 18.3493 -13.984 6
+      vertex 18.2336 -13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4831 -15.3431 6
+      vertex 16.244 -15.1225 6
+      vertex 18.4327 -15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1549 -14.5216 6
+      vertex 18.2336 -13.6606 6
+      vertex 18.0867 -13.3501 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.226 -15.2439 6
+      vertex 18.4327 -15.6828 6
+      vertex 16.244 -15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1024 -14.4108 6
+      vertex 18.0867 -13.3501 6
+      vertex 17.9101 -13.0555 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4327 -15.6828 6
+      vertex 16.226 -15.2439 6
+      vertex 18.3493 -16.016 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0393 -14.3055 6
+      vertex 17.9101 -13.0555 6
+      vertex 17.7055 -12.7796 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.1962 -15.3629 6
+      vertex 18.3493 -16.016 6
+      vertex 16.226 -15.2439 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.9663 -14.207 6
+      vertex 17.7055 -12.7796 6
+      vertex 17.4749 -12.5251 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3493 -16.016 6
+      vertex 16.1962 -15.3629 6
+      vertex 18.2336 -16.3394 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8839 -14.1161 6
+      vertex 17.4749 -12.5251 6
+      vertex 17.2204 -12.2945 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.1549 -15.4784 6
+      vertex 18.2336 -16.3394 6
+      vertex 16.1962 -15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.793 -14.0337 6
+      vertex 17.2204 -12.2945 6
+      vertex 16.9445 -12.0899 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2336 -16.3394 6
+      vertex 16.1549 -15.4784 6
+      vertex 18.0867 -16.6499 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6945 -13.9607 6
+      vertex 16.9445 -12.0899 6
+      vertex 16.6499 -11.9133 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.1024 -15.5892 6
+      vertex 18.0867 -16.6499 6
+      vertex 16.1549 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5892 -13.8976 6
+      vertex 16.6499 -11.9133 6
       vertex 16.3394 -11.7664 6
     endloop
   endfacet
-  facet normal 0.336853 0.941557 0
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0867 -16.6499 6
+      vertex 16.1024 -15.5892 6
+      vertex 17.9101 -16.9445 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.0393 -15.6945 6
+      vertex 17.9101 -16.9445 6
+      vertex 16.1024 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4831 -14.6569 6
+      vertex 16.244 -14.8775 6
+      vertex 16.25 -15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4327 -14.3172 6
+      vertex 16.226 -14.7561 6
+      vertex 16.244 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3493 -13.984 6
+      vertex 16.1962 -14.6371 6
+      vertex 16.226 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2336 -13.6606 6
+      vertex 16.1549 -14.5216 6
+      vertex 16.1962 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0867 -13.3501 6
+      vertex 16.1024 -14.4108 6
+      vertex 16.1549 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9101 -13.0555 6
+      vertex 16.0393 -14.3055 6
+      vertex 16.1024 -14.4108 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4784 -13.8451 6
+      vertex 16.3394 -11.7664 6
+      vertex 16.016 -11.6507 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7055 -12.7796 6
+      vertex 15.9663 -14.207 6
+      vertex 16.0393 -14.3055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4749 -12.5251 6
+      vertex 15.8839 -14.1161 6
+      vertex 15.9663 -14.207 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2204 -12.2945 6
+      vertex 15.793 -14.0337 6
+      vertex 15.8839 -14.1161 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 -12.0899 6
+      vertex 15.6945 -13.9607 6
+      vertex 15.793 -14.0337 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3629 -13.8038 6
+      vertex 16.016 -11.6507 6
+      vertex 15.6828 -11.5673 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6499 -11.9133 6
+      vertex 15.5892 -13.8976 6
+      vertex 15.6945 -13.9607 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3394 -11.7664 6
+      vertex 15.4784 -13.8451 6
+      vertex 15.5892 -13.8976 6
+    endloop
+  endfacet
+  facet normal 0 0 1
     outer loop
       vertex 16.016 -11.6507 6
-      vertex 16.3394 -11.7664 1
-      vertex 16.016 -11.6507 1
+      vertex 15.3629 -13.8038 6
+      vertex 15.4784 -13.8451 6
     endloop
   endfacet
-  facet normal -0.0491971 0.998789 0
+  facet normal 0 0 1
     outer loop
-      vertex 15 -11.5 1
-      vertex 14.6569 -11.5169 6
-      vertex 15 -11.5 6
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex 14.6569 -11.5169 6
-      vertex 15 -11.5 1
-      vertex 14.6569 -11.5169 1
-    endloop
-  endfacet
-  facet normal 0.0491971 0.998789 -0
-    outer loop
-      vertex 15.3431 -11.5169 1
-      vertex 15 -11.5 6
+      vertex 15.2439 -13.774 6
+      vertex 15.6828 -11.5673 6
       vertex 15.3431 -11.5169 6
     endloop
   endfacet
-  facet normal 0.0491971 0.998789 0
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6828 -11.5673 6
+      vertex 15.2439 -13.774 6
+      vertex 15.3629 -13.8038 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3431 -11.5169 6
+      vertex 15.1225 -13.756 6
+      vertex 15.2439 -13.774 6
+    endloop
+  endfacet
+  facet normal 0 0 1
     outer loop
       vertex 15 -11.5 6
-      vertex 15.3431 -11.5169 1
-      vertex 15 -11.5 1
+      vertex 15.1225 -13.756 6
+      vertex 15.3431 -11.5169 6
     endloop
   endfacet
-  facet normal -0.741046 0.671454 0
+  facet normal 0 0 1
     outer loop
-      vertex 12.2945 -12.7796 1
-      vertex 12.5251 -12.5251 6
-      vertex 12.5251 -12.5251 1
+      vertex 15 -11.5 6
+      vertex 15 -13.75 6
+      vertex 15.1225 -13.756 6
     endloop
   endfacet
-  facet normal -0.741046 0.671454 0
+  facet normal 0 0 1
     outer loop
-      vertex 12.5251 -12.5251 6
-      vertex 12.2945 -12.7796 1
-      vertex 12.2945 -12.7796 6
+      vertex 15 -11.5 6
+      vertex 14.8775 -13.756 6
+      vertex 15 -13.75 6
     endloop
   endfacet
-  facet normal -0.671454 0.741046 0
+  facet normal -0 0 1
     outer loop
-      vertex 12.7796 -12.2945 1
+      vertex 14.6569 -11.5169 6
+      vertex 14.8775 -13.756 6
+      vertex 15 -11.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8775 -13.756 6
+      vertex 14.6569 -11.5169 6
+      vertex 14.7561 -13.774 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.3172 -11.5673 6
+      vertex 14.7561 -13.774 6
+      vertex 14.6569 -11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.7561 -13.774 6
+      vertex 14.3172 -11.5673 6
+      vertex 14.6371 -13.8038 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.984 -11.6507 6
+      vertex 14.6371 -13.8038 6
+      vertex 14.3172 -11.5673 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6371 -13.8038 6
+      vertex 13.984 -11.6507 6
+      vertex 14.5216 -13.8451 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.6606 -11.7664 6
+      vertex 14.5216 -13.8451 6
+      vertex 13.984 -11.6507 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5216 -13.8451 6
+      vertex 13.6606 -11.7664 6
+      vertex 14.4108 -13.8976 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.3501 -11.9133 6
+      vertex 14.4108 -13.8976 6
+      vertex 13.6606 -11.7664 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4108 -13.8976 6
+      vertex 13.3501 -11.9133 6
+      vertex 14.3055 -13.9607 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.0555 -12.0899 6
+      vertex 14.3055 -13.9607 6
+      vertex 13.3501 -11.9133 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3055 -13.9607 6
+      vertex 13.0555 -12.0899 6
+      vertex 14.207 -14.0337 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.7796 -12.2945 6
+      vertex 14.207 -14.0337 6
+      vertex 13.0555 -12.0899 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.207 -14.0337 6
+      vertex 12.7796 -12.2945 6
+      vertex 14.1161 -14.1161 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
       vertex 12.5251 -12.5251 6
+      vertex 14.1161 -14.1161 6
       vertex 12.7796 -12.2945 6
     endloop
   endfacet
-  facet normal -0.671454 0.741046 0
+  facet normal 0 0 1
     outer loop
+      vertex 14.1161 -14.1161 6
       vertex 12.5251 -12.5251 6
-      vertex 12.7796 -12.2945 1
-      vertex 12.5251 -12.5251 1
+      vertex 14.0337 -14.207 6
     endloop
   endfacet
-  facet normal -0.903939 -0.427661 0
+  facet normal -0 0 1
     outer loop
-      vertex 11.9133 -16.6499 1
-      vertex 11.7664 -16.3394 6
-      vertex 11.7664 -16.3394 1
+      vertex 12.2945 -12.7796 6
+      vertex 14.0337 -14.207 6
+      vertex 12.5251 -12.5251 6
     endloop
   endfacet
-  facet normal -0.903939 -0.427661 0
+  facet normal -0 0 1
     outer loop
-      vertex 11.7664 -16.3394 6
-      vertex 11.9133 -16.6499 1
-      vertex 11.9133 -16.6499 6
+      vertex 12.0899 -13.0555 6
+      vertex 13.9607 -14.3055 6
+      vertex 12.2945 -12.7796 6
     endloop
   endfacet
-  facet normal -0.671454 -0.741046 0
+  facet normal 0 0 1
     outer loop
-      vertex 12.5251 -17.4749 1
-      vertex 12.7796 -17.7055 6
-      vertex 12.5251 -17.4749 6
+      vertex 14.0337 -14.207 6
+      vertex 12.2945 -12.7796 6
+      vertex 13.9607 -14.3055 6
     endloop
   endfacet
-  facet normal -0.671454 -0.741046 -0
+  facet normal 0 0 1
     outer loop
-      vertex 12.7796 -17.7055 6
-      vertex 12.5251 -17.4749 1
-      vertex 12.7796 -17.7055 1
+      vertex 17.9101 -16.9445 6
+      vertex 16.0393 -15.6945 6
+      vertex 17.7055 -17.2204 6
     endloop
   endfacet
-  facet normal -0.24281 -0.970074 0
+  facet normal -0 0 1
     outer loop
-      vertex 13.984 -18.3493 1
+      vertex 15.9663 -15.793 6
+      vertex 17.7055 -17.2204 6
+      vertex 16.0393 -15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7055 -17.2204 6
+      vertex 15.9663 -15.793 6
+      vertex 17.4749 -17.4749 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.8839 -15.8839 6
+      vertex 17.4749 -17.4749 6
+      vertex 15.9663 -15.793 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.4749 -17.4749 6
+      vertex 15.8839 -15.8839 6
+      vertex 17.2204 -17.7055 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.793 -15.9663 6
+      vertex 17.2204 -17.7055 6
+      vertex 15.8839 -15.8839 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.2204 -17.7055 6
+      vertex 15.793 -15.9663 6
+      vertex 16.9445 -17.9101 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.6945 -16.0393 6
+      vertex 16.9445 -17.9101 6
+      vertex 15.793 -15.9663 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.9445 -17.9101 6
+      vertex 15.6945 -16.0393 6
+      vertex 16.6499 -18.0867 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.5892 -16.1024 6
+      vertex 16.6499 -18.0867 6
+      vertex 15.6945 -16.0393 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6499 -18.0867 6
+      vertex 15.5892 -16.1024 6
+      vertex 16.3394 -18.2336 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.4784 -16.1549 6
+      vertex 16.3394 -18.2336 6
+      vertex 15.5892 -16.1024 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.3394 -18.2336 6
+      vertex 15.4784 -16.1549 6
+      vertex 16.016 -18.3493 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.3629 -16.1962 6
+      vertex 16.016 -18.3493 6
+      vertex 15.4784 -16.1549 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.016 -18.3493 6
+      vertex 15.3629 -16.1962 6
+      vertex 15.6828 -18.4327 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.2439 -16.226 6
+      vertex 15.6828 -18.4327 6
+      vertex 15.3629 -16.1962 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6828 -18.4327 6
+      vertex 15.2439 -16.226 6
+      vertex 15.3431 -18.4831 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.1225 -16.244 6
+      vertex 15.3431 -18.4831 6
+      vertex 15.2439 -16.226 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15 -16.25 6
+      vertex 15.3431 -18.4831 6
+      vertex 15.1225 -16.244 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15 -16.25 6
+      vertex 15 -18.5 6
+      vertex 15.3431 -18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8775 -16.244 6
+      vertex 15 -18.5 6
+      vertex 15 -16.25 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6569 -18.4831 6
+      vertex 14.8775 -16.244 6
+      vertex 14.7561 -16.226 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.8775 -16.244 6
+      vertex 14.6569 -18.4831 6
+      vertex 15 -18.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex 14.3172 -18.4327 6
+      vertex 14.7561 -16.226 6
+      vertex 14.6371 -16.1962 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.984 -18.3493 6
+      vertex 14.6371 -16.1962 6
+      vertex 14.5216 -16.1549 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6606 -18.2336 6
+      vertex 14.5216 -16.1549 6
+      vertex 14.4108 -16.1024 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.7561 -16.226 6
+      vertex 14.3172 -18.4327 6
+      vertex 14.6569 -18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.3501 -18.0867 6
+      vertex 14.4108 -16.1024 6
+      vertex 14.3055 -16.0393 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0555 -17.9101 6
+      vertex 14.3055 -16.0393 6
+      vertex 14.207 -15.9663 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7796 -17.7055 6
+      vertex 14.207 -15.9663 6
+      vertex 14.1161 -15.8839 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.5251 -17.4749 6
+      vertex 14.1161 -15.8839 6
+      vertex 14.0337 -15.793 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.6371 -16.1962 6
+      vertex 13.984 -18.3493 6
+      vertex 14.3172 -18.4327 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2945 -17.2204 6
+      vertex 14.0337 -15.793 6
+      vertex 13.9607 -15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.0899 -16.9445 6
+      vertex 13.9607 -15.6945 6
+      vertex 13.8976 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.9133 -16.6499 6
+      vertex 13.8976 -15.5892 6
+      vertex 13.8451 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7664 -16.3394 6
+      vertex 13.8451 -15.4784 6
+      vertex 13.8038 -15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6507 -16.016 6
+      vertex 13.8038 -15.3629 6
+      vertex 13.774 -15.2439 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5673 -15.6828 6
+      vertex 13.774 -15.2439 6
+      vertex 13.756 -15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.5216 -16.1549 6
+      vertex 13.6606 -18.2336 6
       vertex 13.984 -18.3493 6
     endloop
   endfacet
-  facet normal -0.24281 -0.970074 -0
+  facet normal 0 0 1
     outer loop
-      vertex 14.3172 -18.4327 6
-      vertex 13.984 -18.3493 1
-      vertex 14.3172 -18.4327 1
+      vertex 11.5169 -15.3431 6
+      vertex 13.756 -15.1225 6
+      vertex 13.75 -15 6
     endloop
   endfacet
-  facet normal -0.514153 -0.857698 0
+  facet normal 0 0 1
     outer loop
-      vertex 13.0555 -17.9101 1
+      vertex 13.9607 -14.3055 6
+      vertex 12.0899 -13.0555 6
+      vertex 13.8976 -14.4108 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.9133 -13.3501 6
+      vertex 13.8976 -14.4108 6
+      vertex 12.0899 -13.0555 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4108 -16.1024 6
       vertex 13.3501 -18.0867 6
+      vertex 13.6606 -18.2336 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8976 -14.4108 6
+      vertex 11.9133 -13.3501 6
+      vertex 13.8451 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3055 -16.0393 6
+      vertex 13.0555 -17.9101 6
+      vertex 13.3501 -18.0867 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7664 -13.6606 6
+      vertex 13.8451 -14.5216 6
+      vertex 11.9133 -13.3501 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.207 -15.9663 6
+      vertex 12.7796 -17.7055 6
       vertex 13.0555 -17.9101 6
     endloop
   endfacet
-  facet normal -0.514153 -0.857698 -0
+  facet normal 0 0 1
     outer loop
-      vertex 13.3501 -18.0867 6
-      vertex 13.0555 -17.9101 1
-      vertex 13.3501 -18.0867 1
+      vertex 13.8451 -14.5216 6
+      vertex 11.7664 -13.6606 6
+      vertex 13.8038 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1161 -15.8839 6
+      vertex 12.5251 -17.4749 6
+      vertex 12.7796 -17.7055 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.6507 -13.984 6
+      vertex 13.8038 -14.6371 6
+      vertex 11.7664 -13.6606 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0337 -15.793 6
+      vertex 12.2945 -17.2204 6
+      vertex 12.5251 -17.4749 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8038 -14.6371 6
+      vertex 11.6507 -13.984 6
+      vertex 13.774 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.9607 -15.6945 6
+      vertex 12.0899 -16.9445 6
+      vertex 12.2945 -17.2204 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.5673 -14.3172 6
+      vertex 13.774 -14.7561 6
+      vertex 11.6507 -13.984 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8976 -15.5892 6
+      vertex 11.9133 -16.6499 6
+      vertex 12.0899 -16.9445 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.774 -14.7561 6
+      vertex 11.5673 -14.3172 6
+      vertex 13.756 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8451 -15.4784 6
+      vertex 11.7664 -16.3394 6
+      vertex 11.9133 -16.6499 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.5169 -14.6569 6
+      vertex 13.756 -14.8775 6
+      vertex 11.5673 -14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8038 -15.3629 6
+      vertex 11.6507 -16.016 6
+      vertex 11.7664 -16.3394 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.756 -14.8775 6
+      vertex 11.5169 -14.6569 6
+      vertex 13.75 -15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.774 -15.2439 6
+      vertex 11.5673 -15.6828 6
+      vertex 11.6507 -16.016 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5 -15 6
+      vertex 13.75 -15 6
+      vertex 11.5169 -14.6569 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.756 -15.1225 6
+      vertex 11.5169 -15.3431 6
+      vertex 11.5673 -15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.75 -15 6
+      vertex 11.5 -15 6
+      vertex 11.5169 -15.3431 6
+    endloop
+  endfacet
+  facet normal 0.998789 0.0491971 0
+    outer loop
+      vertex 18.5 -15 6
+      vertex 18.4831 -14.6569 1
+      vertex 18.4831 -14.6569 6
+    endloop
+  endfacet
+  facet normal 0.998789 0.0491971 0
+    outer loop
+      vertex 18.4831 -14.6569 1
+      vertex 18.5 -15 6
+      vertex 18.5 -15 1
+    endloop
+  endfacet
+  facet normal -0.336853 0.941557 0
+    outer loop
+      vertex 13.984 -11.6507 1
+      vertex 13.6606 -11.7664 6
+      vertex 13.984 -11.6507 6
+    endloop
+  endfacet
+  facet normal -0.336853 0.941557 0
+    outer loop
+      vertex 13.6606 -11.7664 6
+      vertex 13.984 -11.6507 1
+      vertex 13.6606 -11.7664 1
+    endloop
+  endfacet
+  facet normal 0.941557 0.336853 0
+    outer loop
+      vertex 18.3493 -13.984 6
+      vertex 18.2336 -13.6606 1
+      vertex 18.2336 -13.6606 6
+    endloop
+  endfacet
+  facet normal 0.941557 0.336853 0
+    outer loop
+      vertex 18.2336 -13.6606 1
+      vertex 18.3493 -13.984 6
+      vertex 18.3493 -13.984 1
+    endloop
+  endfacet
+  facet normal -0.14676 0.989172 0
+    outer loop
+      vertex 14.6569 -11.5169 1
+      vertex 14.3172 -11.5673 6
+      vertex 14.6569 -11.5169 6
+    endloop
+  endfacet
+  facet normal -0.14676 0.989172 0
+    outer loop
+      vertex 14.3172 -11.5673 6
+      vertex 14.6569 -11.5169 1
+      vertex 14.3172 -11.5673 1
+    endloop
+  endfacet
+  facet normal 0.336853 -0.941557 0
+    outer loop
+      vertex 16.016 -18.3493 1
+      vertex 16.3394 -18.2336 6
+      vertex 16.016 -18.3493 6
+    endloop
+  endfacet
+  facet normal 0.336853 -0.941557 0
+    outer loop
+      vertex 16.3394 -18.2336 6
+      vertex 16.016 -18.3493 1
+      vertex 16.3394 -18.2336 1
+    endloop
+  endfacet
+  facet normal -0.427661 0.903939 0
+    outer loop
+      vertex 13.6606 -11.7664 1
+      vertex 13.3501 -11.9133 6
+      vertex 13.6606 -11.7664 6
+    endloop
+  endfacet
+  facet normal -0.427661 0.903939 0
+    outer loop
+      vertex 13.3501 -11.9133 6
+      vertex 13.6606 -11.7664 1
+      vertex 13.3501 -11.9133 1
+    endloop
+  endfacet
+  facet normal 0.595659 -0.803237 0
+    outer loop
+      vertex 16.9445 -17.9101 1
+      vertex 17.2204 -17.7055 6
+      vertex 16.9445 -17.9101 6
+    endloop
+  endfacet
+  facet normal 0.595659 -0.803237 0
+    outer loop
+      vertex 17.2204 -17.7055 6
+      vertex 16.9445 -17.9101 1
+      vertex 17.2204 -17.7055 1
     endloop
   endfacet
   facet normal 0.427661 -0.903939 0
@@ -11003,1558 +9659,536 @@ solid OpenSCAD_Model
       vertex 16.6499 -18.0867 1
     endloop
   endfacet
-  facet normal -0.998789 -0.0491971 0
-    outer loop
-      vertex -18.4831 -15.3431 1
-      vertex -18.5 -15 6
-      vertex -18.5 -15 1
-    endloop
-  endfacet
-  facet normal -0.998789 -0.0491971 0
-    outer loop
-      vertex -18.5 -15 6
-      vertex -18.4831 -15.3431 1
-      vertex -18.4831 -15.3431 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex -11.5 -15 6
-      vertex -11.5169 -14.6569 1
-      vertex -11.5169 -14.6569 6
-    endloop
-  endfacet
-  facet normal 0.998789 0.0491971 0
-    outer loop
-      vertex -11.5169 -14.6569 1
-      vertex -11.5 -15 6
-      vertex -11.5 -15 1
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex -15 -11.5 1
-      vertex -15.3431 -11.5169 6
-      vertex -15 -11.5 6
-    endloop
-  endfacet
-  facet normal -0.0491971 0.998789 0
-    outer loop
-      vertex -15.3431 -11.5169 6
-      vertex -15 -11.5 1
-      vertex -15.3431 -11.5169 1
-    endloop
-  endfacet
-  facet normal 0.671454 0.741046 -0
-    outer loop
-      vertex -12.5251 -12.5251 1
-      vertex -12.7796 -12.2945 6
-      vertex -12.5251 -12.5251 6
-    endloop
-  endfacet
-  facet normal 0.671454 0.741046 0
-    outer loop
-      vertex -12.7796 -12.2945 6
-      vertex -12.5251 -12.5251 1
-      vertex -12.7796 -12.2945 1
-    endloop
-  endfacet
-  facet normal -0.741046 0.671454 0
-    outer loop
-      vertex -17.7055 -12.7796 1
-      vertex -17.4749 -12.5251 6
-      vertex -17.4749 -12.5251 1
-    endloop
-  endfacet
-  facet normal -0.741046 0.671454 0
-    outer loop
-      vertex -17.4749 -12.5251 6
-      vertex -17.7055 -12.7796 1
-      vertex -17.7055 -12.7796 6
-    endloop
-  endfacet
-  facet normal -0.671454 -0.741046 0
-    outer loop
-      vertex -17.4749 -17.4749 1
-      vertex -17.2204 -17.7055 6
-      vertex -17.4749 -17.4749 6
-    endloop
-  endfacet
-  facet normal -0.671454 -0.741046 -0
-    outer loop
-      vertex -17.2204 -17.7055 6
-      vertex -17.4749 -17.4749 1
-      vertex -17.2204 -17.7055 1
-    endloop
-  endfacet
-  facet normal -0.336853 -0.941557 0
-    outer loop
-      vertex -16.3394 -18.2336 1
-      vertex -16.016 -18.3493 6
-      vertex -16.3394 -18.2336 6
-    endloop
-  endfacet
-  facet normal -0.336853 -0.941557 -0
-    outer loop
-      vertex -16.016 -18.3493 6
-      vertex -16.3394 -18.2336 1
-      vertex -16.016 -18.3493 1
-    endloop
-  endfacet
-  facet normal 0.903939 -0.427661 0
-    outer loop
-      vertex -11.9133 -16.6499 6
-      vertex -11.7664 -16.3394 1
-      vertex -11.7664 -16.3394 6
-    endloop
-  endfacet
-  facet normal 0.903939 -0.427661 0
-    outer loop
-      vertex -11.7664 -16.3394 1
-      vertex -11.9133 -16.6499 6
-      vertex -11.9133 -16.6499 1
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex -12.5251 -17.4749 6
-      vertex -12.2945 -17.2204 1
-      vertex -12.2945 -17.2204 6
-    endloop
-  endfacet
-  facet normal 0.741046 -0.671454 0
-    outer loop
-      vertex -12.2945 -17.2204 1
-      vertex -12.5251 -17.4749 6
-      vertex -12.5251 -17.4749 1
-    endloop
-  endfacet
-  facet normal -0.903939 0.427661 0
-    outer loop
-      vertex -18.2336 -13.6606 1
-      vertex -18.0867 -13.3501 6
-      vertex -18.0867 -13.3501 1
-    endloop
-  endfacet
-  facet normal -0.903939 0.427661 0
-    outer loop
-      vertex -18.0867 -13.3501 6
-      vertex -18.2336 -13.6606 1
-      vertex -18.2336 -13.6606 6
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex -16.016 -11.6507 1
-      vertex -16.3394 -11.7664 6
-      vertex -16.016 -11.6507 6
-    endloop
-  endfacet
-  facet normal -0.336853 0.941557 0
-    outer loop
-      vertex -16.3394 -11.7664 6
-      vertex -16.016 -11.6507 1
-      vertex -16.3394 -11.7664 1
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex -18.0867 -13.3501 1
-      vertex -17.9101 -13.0555 6
-      vertex -17.9101 -13.0555 1
-    endloop
-  endfacet
-  facet normal -0.857698 0.514153 0
-    outer loop
-      vertex -17.9101 -13.0555 6
-      vertex -18.0867 -13.3501 1
-      vertex -18.0867 -13.3501 6
-    endloop
-  endfacet
-  facet normal 0.336853 0.941557 -0
-    outer loop
-      vertex -13.6606 -11.7664 1
-      vertex -13.984 -11.6507 6
-      vertex -13.6606 -11.7664 6
-    endloop
-  endfacet
-  facet normal 0.336853 0.941557 0
-    outer loop
-      vertex -13.984 -11.6507 6
-      vertex -13.6606 -11.7664 1
-      vertex -13.984 -11.6507 1
-    endloop
-  endfacet
-  facet normal 0.24281 0.970074 -0
-    outer loop
-      vertex -13.984 -11.6507 1
-      vertex -14.3172 -11.5673 6
-      vertex -13.984 -11.6507 6
-    endloop
-  endfacet
-  facet normal 0.24281 0.970074 0
-    outer loop
-      vertex -14.3172 -11.5673 6
-      vertex -13.984 -11.6507 1
-      vertex -14.3172 -11.5673 1
-    endloop
-  endfacet
-  facet normal 0.970074 0.24281 0
-    outer loop
-      vertex -11.5673 -14.3172 6
-      vertex -11.6507 -13.984 1
-      vertex -11.6507 -13.984 6
-    endloop
-  endfacet
-  facet normal 0.970074 0.24281 0
-    outer loop
-      vertex -11.6507 -13.984 1
-      vertex -11.5673 -14.3172 6
-      vertex -11.5673 -14.3172 1
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex -18.4327 -15.6828 1
-      vertex -18.4831 -15.3431 6
-      vertex -18.4831 -15.3431 1
-    endloop
-  endfacet
-  facet normal -0.989172 -0.14676 0
-    outer loop
-      vertex -18.4831 -15.3431 6
-      vertex -18.4327 -15.6828 1
-      vertex -18.4327 -15.6828 6
-    endloop
-  endfacet
-  facet normal -0.941557 -0.336853 0
-    outer loop
-      vertex -18.2336 -16.3394 1
-      vertex -18.3493 -16.016 6
-      vertex -18.3493 -16.016 1
-    endloop
-  endfacet
-  facet normal -0.941557 -0.336853 0
-    outer loop
-      vertex -18.3493 -16.016 6
-      vertex -18.2336 -16.3394 1
-      vertex -18.2336 -16.3394 6
-    endloop
-  endfacet
-  facet normal -0.803237 -0.595659 0
-    outer loop
-      vertex -17.7055 -17.2204 1
-      vertex -17.9101 -16.9445 6
-      vertex -17.9101 -16.9445 1
-    endloop
-  endfacet
-  facet normal -0.803237 -0.595659 0
-    outer loop
-      vertex -17.9101 -16.9445 6
-      vertex -17.7055 -17.2204 1
-      vertex -17.7055 -17.2204 6
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex -17.4749 -17.4749 1
-      vertex -17.7055 -17.2204 6
-      vertex -17.7055 -17.2204 1
-    endloop
-  endfacet
-  facet normal -0.741046 -0.671454 0
-    outer loop
-      vertex -17.7055 -17.2204 6
-      vertex -17.4749 -17.4749 1
-      vertex -17.4749 -17.4749 6
-    endloop
-  endfacet
-  facet normal -0.857698 -0.514153 0
-    outer loop
-      vertex -17.9101 -16.9445 1
-      vertex -18.0867 -16.6499 6
-      vertex -18.0867 -16.6499 1
-    endloop
-  endfacet
-  facet normal -0.857698 -0.514153 0
-    outer loop
-      vertex -18.0867 -16.6499 6
-      vertex -17.9101 -16.9445 1
-      vertex -17.9101 -16.9445 6
-    endloop
-  endfacet
-  facet normal -0.14676 -0.989172 0
-    outer loop
-      vertex -15.6828 -18.4327 1
-      vertex -15.3431 -18.4831 6
-      vertex -15.6828 -18.4327 6
-    endloop
-  endfacet
-  facet normal -0.14676 -0.989172 -0
-    outer loop
-      vertex -15.3431 -18.4831 6
-      vertex -15.6828 -18.4327 1
-      vertex -15.3431 -18.4831 1
-    endloop
-  endfacet
-  facet normal -0.24281 -0.970074 0
-    outer loop
-      vertex -16.016 -18.3493 1
-      vertex -15.6828 -18.4327 6
-      vertex -16.016 -18.3493 6
-    endloop
-  endfacet
-  facet normal -0.24281 -0.970074 -0
-    outer loop
-      vertex -15.6828 -18.4327 6
-      vertex -16.016 -18.3493 1
-      vertex -15.6828 -18.4327 1
-    endloop
-  endfacet
-  facet normal -0.0491971 -0.998789 0
-    outer loop
-      vertex -15.3431 -18.4831 1
-      vertex -15 -18.5 6
-      vertex -15.3431 -18.4831 6
-    endloop
-  endfacet
-  facet normal -0.0491971 -0.998789 -0
-    outer loop
-      vertex -15 -18.5 6
-      vertex -15.3431 -18.4831 1
-      vertex -15 -18.5 1
-    endloop
-  endfacet
   facet normal -0.514153 -0.857698 0
     outer loop
-      vertex -16.9445 -17.9101 1
-      vertex -16.6499 -18.0867 6
-      vertex -16.9445 -17.9101 6
+      vertex 13.0555 -17.9101 1
+      vertex 13.3501 -18.0867 6
+      vertex 13.0555 -17.9101 6
     endloop
   endfacet
   facet normal -0.514153 -0.857698 -0
     outer loop
-      vertex -16.6499 -18.0867 6
-      vertex -16.9445 -17.9101 1
-      vertex -16.6499 -18.0867 1
+      vertex 13.3501 -18.0867 6
+      vertex 13.0555 -17.9101 1
+      vertex 13.3501 -18.0867 1
     endloop
   endfacet
-  facet normal -0.427661 -0.903939 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex -16.6499 -18.0867 1
-      vertex -16.3394 -18.2336 6
-      vertex -16.6499 -18.0867 6
+      vertex 15.6828 -18.4327 1
+      vertex 16.016 -18.3493 6
+      vertex 15.6828 -18.4327 6
     endloop
   endfacet
-  facet normal -0.427661 -0.903939 -0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex -16.3394 -18.2336 6
-      vertex -16.6499 -18.0867 1
-      vertex -16.3394 -18.2336 1
+      vertex 16.016 -18.3493 6
+      vertex 15.6828 -18.4327 1
+      vertex 16.016 -18.3493 1
+    endloop
+  endfacet
+  facet normal 0.903939 0.427661 0
+    outer loop
+      vertex 18.2336 -13.6606 6
+      vertex 18.0867 -13.3501 1
+      vertex 18.0867 -13.3501 6
+    endloop
+  endfacet
+  facet normal 0.903939 0.427661 0
+    outer loop
+      vertex 18.0867 -13.3501 1
+      vertex 18.2336 -13.6606 6
+      vertex 18.2336 -13.6606 1
+    endloop
+  endfacet
+  facet normal -0.741046 0.671454 0
+    outer loop
+      vertex 12.2945 -12.7796 1
+      vertex 12.5251 -12.5251 6
+      vertex 12.5251 -12.5251 1
+    endloop
+  endfacet
+  facet normal -0.741046 0.671454 0
+    outer loop
+      vertex 12.5251 -12.5251 6
+      vertex 12.2945 -12.7796 1
+      vertex 12.2945 -12.7796 6
+    endloop
+  endfacet
+  facet normal 0.0491971 0.998789 -0
+    outer loop
+      vertex 15.3431 -11.5169 1
+      vertex 15 -11.5 6
+      vertex 15.3431 -11.5169 6
+    endloop
+  endfacet
+  facet normal 0.0491971 0.998789 0
+    outer loop
+      vertex 15 -11.5 6
+      vertex 15.3431 -11.5169 1
+      vertex 15 -11.5 1
+    endloop
+  endfacet
+  facet normal -0.14676 -0.989172 0
+    outer loop
+      vertex 14.3172 -18.4327 1
+      vertex 14.6569 -18.4831 6
+      vertex 14.3172 -18.4327 6
+    endloop
+  endfacet
+  facet normal -0.14676 -0.989172 -0
+    outer loop
+      vertex 14.6569 -18.4831 6
+      vertex 14.3172 -18.4327 1
+      vertex 14.6569 -18.4831 1
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491971 0
+    outer loop
+      vertex 11.5169 -15.3431 1
+      vertex 11.5 -15 6
+      vertex 11.5 -15 1
+    endloop
+  endfacet
+  facet normal -0.998789 -0.0491971 0
+    outer loop
+      vertex 11.5 -15 6
+      vertex 11.5169 -15.3431 1
+      vertex 11.5169 -15.3431 6
     endloop
   endfacet
   facet normal -0.595659 -0.803237 0
     outer loop
-      vertex -17.2204 -17.7055 1
-      vertex -16.9445 -17.9101 6
-      vertex -17.2204 -17.7055 6
+      vertex 12.7796 -17.7055 1
+      vertex 13.0555 -17.9101 6
+      vertex 12.7796 -17.7055 6
     endloop
   endfacet
   facet normal -0.595659 -0.803237 -0
     outer loop
-      vertex -16.9445 -17.9101 6
-      vertex -17.2204 -17.7055 1
-      vertex -16.9445 -17.9101 1
-    endloop
-  endfacet
-  facet normal 0.803237 -0.595659 0
-    outer loop
-      vertex -12.2945 -17.2204 6
-      vertex -12.0899 -16.9445 1
-      vertex -12.0899 -16.9445 6
-    endloop
-  endfacet
-  facet normal 0.803237 -0.595659 0
-    outer loop
-      vertex -12.0899 -16.9445 1
-      vertex -12.2945 -17.2204 6
-      vertex -12.2945 -17.2204 1
-    endloop
-  endfacet
-  facet normal 0.857698 -0.514153 0
-    outer loop
-      vertex -12.0899 -16.9445 6
-      vertex -11.9133 -16.6499 1
-      vertex -11.9133 -16.6499 6
-    endloop
-  endfacet
-  facet normal 0.857698 -0.514153 0
-    outer loop
-      vertex -11.9133 -16.6499 1
-      vertex -12.0899 -16.9445 6
-      vertex -12.0899 -16.9445 1
-    endloop
-  endfacet
-  facet normal 0.989172 -0.14676 0
-    outer loop
-      vertex -11.5673 -15.6828 6
-      vertex -11.5169 -15.3431 1
-      vertex -11.5169 -15.3431 6
-    endloop
-  endfacet
-  facet normal 0.989172 -0.14676 0
-    outer loop
-      vertex -11.5169 -15.3431 1
-      vertex -11.5673 -15.6828 6
-      vertex -11.5673 -15.6828 1
-    endloop
-  endfacet
-  facet normal 0.970074 -0.24281 0
-    outer loop
-      vertex -11.6507 -16.016 6
-      vertex -11.5673 -15.6828 1
-      vertex -11.5673 -15.6828 6
-    endloop
-  endfacet
-  facet normal 0.970074 -0.24281 0
-    outer loop
-      vertex -11.5673 -15.6828 1
-      vertex -11.6507 -16.016 6
-      vertex -11.6507 -16.016 1
-    endloop
-  endfacet
-  facet normal 0.998789 -0.0491971 0
-    outer loop
-      vertex -11.5169 -15.3431 6
-      vertex -11.5 -15 1
-      vertex -11.5 -15 6
-    endloop
-  endfacet
-  facet normal 0.998789 -0.0491971 0
-    outer loop
-      vertex -11.5 -15 1
-      vertex -11.5169 -15.3431 6
-      vertex -11.5169 -15.3431 1
-    endloop
-  endfacet
-  facet normal 0.595659 -0.803237 0
-    outer loop
-      vertex -13.0555 -17.9101 1
-      vertex -12.7796 -17.7055 6
-      vertex -13.0555 -17.9101 6
-    endloop
-  endfacet
-  facet normal 0.595659 -0.803237 0
-    outer loop
-      vertex -12.7796 -17.7055 6
-      vertex -13.0555 -17.9101 1
-      vertex -12.7796 -17.7055 1
-    endloop
-  endfacet
-  facet normal 0.514153 -0.857698 0
-    outer loop
-      vertex -13.3501 -18.0867 1
-      vertex -13.0555 -17.9101 6
-      vertex -13.3501 -18.0867 6
-    endloop
-  endfacet
-  facet normal 0.514153 -0.857698 0
-    outer loop
-      vertex -13.0555 -17.9101 6
-      vertex -13.3501 -18.0867 1
-      vertex -13.0555 -17.9101 1
+      vertex 13.0555 -17.9101 6
+      vertex 12.7796 -17.7055 1
+      vertex 13.0555 -17.9101 1
     endloop
   endfacet
   facet normal 0.671454 -0.741046 0
     outer loop
-      vertex -12.7796 -17.7055 1
-      vertex -12.5251 -17.4749 6
-      vertex -12.7796 -17.7055 6
+      vertex 17.2204 -17.7055 1
+      vertex 17.4749 -17.4749 6
+      vertex 17.2204 -17.7055 6
     endloop
   endfacet
   facet normal 0.671454 -0.741046 0
     outer loop
-      vertex -12.5251 -17.4749 6
-      vertex -12.7796 -17.7055 1
-      vertex -12.5251 -17.4749 1
+      vertex 17.4749 -17.4749 6
+      vertex 17.2204 -17.7055 1
+      vertex 17.4749 -17.4749 1
     endloop
   endfacet
-  facet normal 0.336853 -0.941557 0
+  facet normal 0.941557 -0.336853 0
     outer loop
-      vertex -13.984 -18.3493 1
-      vertex -13.6606 -18.2336 6
-      vertex -13.984 -18.3493 6
+      vertex 18.2336 -16.3394 6
+      vertex 18.3493 -16.016 1
+      vertex 18.3493 -16.016 6
     endloop
   endfacet
-  facet normal 0.336853 -0.941557 0
+  facet normal 0.941557 -0.336853 0
     outer loop
-      vertex -13.6606 -18.2336 6
-      vertex -13.984 -18.3493 1
-      vertex -13.6606 -18.2336 1
+      vertex 18.3493 -16.016 1
+      vertex 18.2336 -16.3394 6
+      vertex 18.2336 -16.3394 1
     endloop
   endfacet
-  facet normal 0.427661 -0.903939 0
+  facet normal 0.989172 -0.14676 0
     outer loop
-      vertex -13.6606 -18.2336 1
-      vertex -13.3501 -18.0867 6
-      vertex -13.6606 -18.2336 6
+      vertex 18.4327 -15.6828 6
+      vertex 18.4831 -15.3431 1
+      vertex 18.4831 -15.3431 6
     endloop
   endfacet
-  facet normal 0.427661 -0.903939 0
+  facet normal 0.989172 -0.14676 0
     outer loop
-      vertex -13.3501 -18.0867 6
-      vertex -13.6606 -18.2336 1
-      vertex -13.3501 -18.0867 1
-    endloop
-  endfacet
-  facet normal 0.14676 -0.989172 0
-    outer loop
-      vertex -14.6569 -18.4831 1
-      vertex -14.3172 -18.4327 6
-      vertex -14.6569 -18.4831 6
-    endloop
-  endfacet
-  facet normal 0.14676 -0.989172 0
-    outer loop
-      vertex -14.3172 -18.4327 6
-      vertex -14.6569 -18.4831 1
-      vertex -14.3172 -18.4327 1
-    endloop
-  endfacet
-  facet normal -0.998789 0.0491971 0
-    outer loop
-      vertex -18.5 -15 1
-      vertex -18.4831 -14.6569 6
-      vertex -18.4831 -14.6569 1
-    endloop
-  endfacet
-  facet normal -0.998789 0.0491971 0
-    outer loop
-      vertex -18.4831 -14.6569 6
-      vertex -18.5 -15 1
-      vertex -18.5 -15 6
-    endloop
-  endfacet
-  facet normal -0.24281 0.970074 0
-    outer loop
-      vertex -15.6828 -11.5673 1
-      vertex -16.016 -11.6507 6
-      vertex -15.6828 -11.5673 6
-    endloop
-  endfacet
-  facet normal -0.24281 0.970074 0
-    outer loop
-      vertex -16.016 -11.6507 6
-      vertex -15.6828 -11.5673 1
-      vertex -16.016 -11.6507 1
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
-      vertex -15.3431 -11.5169 1
-      vertex -15.6828 -11.5673 6
-      vertex -15.3431 -11.5169 6
-    endloop
-  endfacet
-  facet normal -0.14676 0.989172 0
-    outer loop
-      vertex -15.6828 -11.5673 6
-      vertex -15.3431 -11.5169 1
-      vertex -15.6828 -11.5673 1
-    endloop
-  endfacet
-  facet normal -0.427661 0.903939 0
-    outer loop
-      vertex -16.3394 -11.7664 1
-      vertex -16.6499 -11.9133 6
-      vertex -16.3394 -11.7664 6
-    endloop
-  endfacet
-  facet normal -0.427661 0.903939 0
-    outer loop
-      vertex -16.6499 -11.9133 6
-      vertex -16.3394 -11.7664 1
-      vertex -16.6499 -11.9133 1
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex -16.6499 -11.9133 1
-      vertex -16.9445 -12.0899 6
-      vertex -16.6499 -11.9133 6
-    endloop
-  endfacet
-  facet normal -0.514153 0.857698 0
-    outer loop
-      vertex -16.9445 -12.0899 6
-      vertex -16.6499 -11.9133 1
-      vertex -16.9445 -12.0899 1
-    endloop
-  endfacet
-  facet normal -0.595659 0.803237 0
-    outer loop
-      vertex -16.9445 -12.0899 1
-      vertex -17.2204 -12.2945 6
-      vertex -16.9445 -12.0899 6
-    endloop
-  endfacet
-  facet normal -0.595659 0.803237 0
-    outer loop
-      vertex -17.2204 -12.2945 6
-      vertex -16.9445 -12.0899 1
-      vertex -17.2204 -12.2945 1
-    endloop
-  endfacet
-  facet normal -0.803237 0.595659 0
-    outer loop
-      vertex -17.9101 -13.0555 1
-      vertex -17.7055 -12.7796 6
-      vertex -17.7055 -12.7796 1
-    endloop
-  endfacet
-  facet normal -0.803237 0.595659 0
-    outer loop
-      vertex -17.7055 -12.7796 6
-      vertex -17.9101 -13.0555 1
-      vertex -17.9101 -13.0555 6
-    endloop
-  endfacet
-  facet normal -0.941557 0.336853 0
-    outer loop
-      vertex -18.3493 -13.984 1
-      vertex -18.2336 -13.6606 6
-      vertex -18.2336 -13.6606 1
-    endloop
-  endfacet
-  facet normal -0.941557 0.336853 0
-    outer loop
-      vertex -18.2336 -13.6606 6
-      vertex -18.3493 -13.984 1
-      vertex -18.3493 -13.984 6
-    endloop
-  endfacet
-  facet normal -0.970074 0.24281 0
-    outer loop
-      vertex -18.4327 -14.3172 1
-      vertex -18.3493 -13.984 6
-      vertex -18.3493 -13.984 1
-    endloop
-  endfacet
-  facet normal -0.970074 0.24281 0
-    outer loop
-      vertex -18.3493 -13.984 6
-      vertex -18.4327 -14.3172 1
-      vertex -18.4327 -14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.75 -15 6
-      vertex -11.5 -15 6
-      vertex -11.5169 -14.6569 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.756 -14.8775 6
-      vertex -11.5169 -14.6569 6
-      vertex -11.5673 -14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5 -15 6
-      vertex -13.75 -15 6
-      vertex -11.5169 -15.3431 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.774 -14.7561 6
-      vertex -11.5673 -14.3172 6
-      vertex -11.6507 -13.984 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.756 -15.1225 6
-      vertex -11.5169 -15.3431 6
-      vertex -13.75 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.8038 -14.6371 6
-      vertex -11.6507 -13.984 6
-      vertex -11.7664 -13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 -15.3431 6
-      vertex -13.756 -15.1225 6
-      vertex -11.5673 -15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.8451 -14.5216 6
-      vertex -11.7664 -13.6606 6
-      vertex -11.9133 -13.3501 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.774 -15.2439 6
-      vertex -11.5673 -15.6828 6
-      vertex -13.756 -15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.8976 -14.4108 6
-      vertex -11.9133 -13.3501 6
-      vertex -12.0899 -13.0555 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 -15.6828 6
-      vertex -13.774 -15.2439 6
-      vertex -11.6507 -16.016 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.9607 -14.3055 6
-      vertex -12.0899 -13.0555 6
-      vertex -12.2945 -12.7796 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8038 -15.3629 6
-      vertex -11.6507 -16.016 6
-      vertex -13.774 -15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.0337 -14.207 6
-      vertex -12.2945 -12.7796 6
-      vertex -12.5251 -12.5251 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 -16.016 6
-      vertex -13.8038 -15.3629 6
-      vertex -11.7664 -16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.1161 -14.1161 6
-      vertex -12.5251 -12.5251 6
-      vertex -12.7796 -12.2945 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8451 -15.4784 6
-      vertex -11.7664 -16.3394 6
-      vertex -13.8038 -15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.207 -14.0337 6
-      vertex -12.7796 -12.2945 6
-      vertex -13.0555 -12.0899 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7664 -16.3394 6
-      vertex -13.8451 -15.4784 6
-      vertex -11.9133 -16.6499 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3055 -13.9607 6
-      vertex -13.0555 -12.0899 6
-      vertex -13.3501 -11.9133 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.8976 -15.5892 6
-      vertex -11.9133 -16.6499 6
-      vertex -13.8451 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.4108 -13.8976 6
-      vertex -13.3501 -11.9133 6
-      vertex -13.6606 -11.7664 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.9133 -16.6499 6
-      vertex -13.8976 -15.5892 6
-      vertex -12.0899 -16.9445 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -13.9607 -15.6945 6
-      vertex -12.0899 -16.9445 6
-      vertex -13.8976 -15.5892 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5169 -14.6569 6
-      vertex -13.756 -14.8775 6
-      vertex -13.75 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.5673 -14.3172 6
-      vertex -13.774 -14.7561 6
-      vertex -13.756 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.6507 -13.984 6
-      vertex -13.8038 -14.6371 6
-      vertex -13.774 -14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.7664 -13.6606 6
-      vertex -13.8451 -14.5216 6
-      vertex -13.8038 -14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -11.9133 -13.3501 6
-      vertex -13.8976 -14.4108 6
-      vertex -13.8451 -14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0899 -13.0555 6
-      vertex -13.9607 -14.3055 6
-      vertex -13.8976 -14.4108 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.5216 -13.8451 6
-      vertex -13.6606 -11.7664 6
-      vertex -13.984 -11.6507 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2945 -12.7796 6
-      vertex -14.0337 -14.207 6
-      vertex -13.9607 -14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5251 -12.5251 6
-      vertex -14.1161 -14.1161 6
-      vertex -14.0337 -14.207 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.7796 -12.2945 6
-      vertex -14.207 -14.0337 6
-      vertex -14.1161 -14.1161 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0555 -12.0899 6
-      vertex -14.3055 -13.9607 6
-      vertex -14.207 -14.0337 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6371 -13.8038 6
-      vertex -13.984 -11.6507 6
-      vertex -14.3172 -11.5673 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.3501 -11.9133 6
-      vertex -14.4108 -13.8976 6
-      vertex -14.3055 -13.9607 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.6606 -11.7664 6
-      vertex -14.5216 -13.8451 6
-      vertex -14.4108 -13.8976 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.984 -11.6507 6
-      vertex -14.6371 -13.8038 6
-      vertex -14.5216 -13.8451 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.7561 -13.774 6
-      vertex -14.3172 -11.5673 6
-      vertex -14.6569 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3172 -11.5673 6
-      vertex -14.7561 -13.774 6
-      vertex -14.6371 -13.8038 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.6569 -11.5169 6
-      vertex -14.8775 -13.756 6
-      vertex -14.7561 -13.774 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 -11.5 6
-      vertex -14.8775 -13.756 6
-      vertex -14.6569 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 -11.5 6
-      vertex -15 -13.75 6
-      vertex -14.8775 -13.756 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 -11.5 6
-      vertex -15.1225 -13.756 6
-      vertex -15 -13.75 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.3431 -11.5169 6
-      vertex -15.1225 -13.756 6
-      vertex -15 -11.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1225 -13.756 6
-      vertex -15.3431 -11.5169 6
-      vertex -15.2439 -13.774 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15.6828 -11.5673 6
-      vertex -15.2439 -13.774 6
-      vertex -15.3431 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.2439 -13.774 6
-      vertex -15.6828 -11.5673 6
-      vertex -15.3629 -13.8038 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.016 -11.6507 6
-      vertex -15.3629 -13.8038 6
-      vertex -15.6828 -11.5673 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3629 -13.8038 6
-      vertex -16.016 -11.6507 6
-      vertex -15.4784 -13.8451 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.3394 -11.7664 6
-      vertex -15.4784 -13.8451 6
-      vertex -16.016 -11.6507 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.4784 -13.8451 6
-      vertex -16.3394 -11.7664 6
-      vertex -15.5892 -13.8976 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.6499 -11.9133 6
-      vertex -15.5892 -13.8976 6
-      vertex -16.3394 -11.7664 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.5892 -13.8976 6
-      vertex -16.6499 -11.9133 6
-      vertex -15.6945 -13.9607 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -16.9445 -12.0899 6
-      vertex -15.6945 -13.9607 6
-      vertex -16.6499 -11.9133 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6945 -13.9607 6
-      vertex -16.9445 -12.0899 6
-      vertex -15.793 -14.0337 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.2204 -12.2945 6
-      vertex -15.793 -14.0337 6
-      vertex -16.9445 -12.0899 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.793 -14.0337 6
-      vertex -17.2204 -12.2945 6
-      vertex -15.8839 -14.1161 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.4749 -12.5251 6
-      vertex -15.8839 -14.1161 6
-      vertex -17.2204 -12.2945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8839 -14.1161 6
-      vertex -17.4749 -12.5251 6
-      vertex -15.9663 -14.207 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.7055 -12.7796 6
-      vertex -15.9663 -14.207 6
-      vertex -17.4749 -12.5251 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -17.9101 -13.0555 6
-      vertex -16.0393 -14.3055 6
-      vertex -17.7055 -12.7796 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9663 -14.207 6
-      vertex -17.7055 -12.7796 6
-      vertex -16.0393 -14.3055 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.0899 -16.9445 6
-      vertex -13.9607 -15.6945 6
-      vertex -12.2945 -17.2204 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.0337 -15.793 6
-      vertex -12.2945 -17.2204 6
-      vertex -13.9607 -15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.2945 -17.2204 6
-      vertex -14.0337 -15.793 6
-      vertex -12.5251 -17.4749 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.1161 -15.8839 6
-      vertex -12.5251 -17.4749 6
-      vertex -14.0337 -15.793 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.5251 -17.4749 6
-      vertex -14.1161 -15.8839 6
-      vertex -12.7796 -17.7055 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.207 -15.9663 6
-      vertex -12.7796 -17.7055 6
-      vertex -14.1161 -15.8839 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.7796 -17.7055 6
-      vertex -14.207 -15.9663 6
-      vertex -13.0555 -17.9101 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.3055 -16.0393 6
-      vertex -13.0555 -17.9101 6
-      vertex -14.207 -15.9663 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.0555 -17.9101 6
-      vertex -14.3055 -16.0393 6
-      vertex -13.3501 -18.0867 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.4108 -16.1024 6
-      vertex -13.3501 -18.0867 6
-      vertex -14.3055 -16.0393 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.3501 -18.0867 6
-      vertex -14.4108 -16.1024 6
-      vertex -13.6606 -18.2336 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.5216 -16.1549 6
-      vertex -13.6606 -18.2336 6
-      vertex -14.4108 -16.1024 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.6606 -18.2336 6
-      vertex -14.5216 -16.1549 6
-      vertex -13.984 -18.3493 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.6371 -16.1962 6
-      vertex -13.984 -18.3493 6
-      vertex -14.5216 -16.1549 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -13.984 -18.3493 6
-      vertex -14.6371 -16.1962 6
-      vertex -14.3172 -18.4327 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.7561 -16.226 6
-      vertex -14.3172 -18.4327 6
-      vertex -14.6371 -16.1962 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -14.3172 -18.4327 6
-      vertex -14.7561 -16.226 6
-      vertex -14.6569 -18.4831 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -14.8775 -16.244 6
-      vertex -14.6569 -18.4831 6
-      vertex -14.7561 -16.226 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -15 -16.25 6
-      vertex -14.6569 -18.4831 6
-      vertex -14.8775 -16.244 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15 -16.25 6
-      vertex -15 -18.5 6
-      vertex -14.6569 -18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1225 -16.244 6
-      vertex -15 -18.5 6
-      vertex -15 -16.25 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3431 -18.4831 6
-      vertex -15.1225 -16.244 6
-      vertex -15.2439 -16.226 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.1225 -16.244 6
-      vertex -15.3431 -18.4831 6
-      vertex -15 -18.5 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6828 -18.4327 6
-      vertex -15.2439 -16.226 6
-      vertex -15.3629 -16.1962 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.016 -18.3493 6
-      vertex -15.3629 -16.1962 6
-      vertex -15.4784 -16.1549 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.3394 -18.2336 6
-      vertex -15.4784 -16.1549 6
-      vertex -15.5892 -16.1024 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.2439 -16.226 6
-      vertex -15.6828 -18.4327 6
-      vertex -15.3431 -18.4831 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.6499 -18.0867 6
-      vertex -15.5892 -16.1024 6
-      vertex -15.6945 -16.0393 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.9445 -17.9101 6
-      vertex -15.6945 -16.0393 6
-      vertex -15.793 -15.9663 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.2204 -17.7055 6
-      vertex -15.793 -15.9663 6
-      vertex -15.8839 -15.8839 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.4749 -17.4749 6
-      vertex -15.8839 -15.8839 6
-      vertex -15.9663 -15.793 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.3629 -16.1962 6
-      vertex -16.016 -18.3493 6
-      vertex -15.6828 -18.4327 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.7055 -17.2204 6
-      vertex -15.9663 -15.793 6
-      vertex -16.0393 -15.6945 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -17.9101 -16.9445 6
-      vertex -16.0393 -15.6945 6
-      vertex -16.1024 -15.5892 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.0867 -16.6499 6
-      vertex -16.1024 -15.5892 6
-      vertex -16.1549 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.2336 -16.3394 6
-      vertex -16.1549 -15.4784 6
-      vertex -16.1962 -15.3629 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.3493 -16.016 6
-      vertex -16.1962 -15.3629 6
-      vertex -16.226 -15.2439 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4327 -15.6828 6
-      vertex -16.226 -15.2439 6
-      vertex -16.244 -15.1225 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.4784 -16.1549 6
-      vertex -16.3394 -18.2336 6
-      vertex -16.016 -18.3493 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.4831 -15.3431 6
-      vertex -16.244 -15.1225 6
-      vertex -16.25 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0393 -14.3055 6
-      vertex -17.9101 -13.0555 6
-      vertex -16.1024 -14.4108 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.0867 -13.3501 6
-      vertex -16.1024 -14.4108 6
-      vertex -17.9101 -13.0555 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.5892 -16.1024 6
-      vertex -16.6499 -18.0867 6
-      vertex -16.3394 -18.2336 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1024 -14.4108 6
-      vertex -18.0867 -13.3501 6
-      vertex -16.1549 -14.5216 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.6945 -16.0393 6
-      vertex -16.9445 -17.9101 6
-      vertex -16.6499 -18.0867 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.2336 -13.6606 6
-      vertex -16.1549 -14.5216 6
-      vertex -18.0867 -13.3501 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.793 -15.9663 6
-      vertex -17.2204 -17.7055 6
-      vertex -16.9445 -17.9101 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1549 -14.5216 6
-      vertex -18.2336 -13.6606 6
-      vertex -16.1962 -14.6371 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.8839 -15.8839 6
-      vertex -17.4749 -17.4749 6
-      vertex -17.2204 -17.7055 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.3493 -13.984 6
-      vertex -16.1962 -14.6371 6
-      vertex -18.2336 -13.6606 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -15.9663 -15.793 6
-      vertex -17.7055 -17.2204 6
-      vertex -17.4749 -17.4749 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1962 -14.6371 6
-      vertex -18.3493 -13.984 6
-      vertex -16.226 -14.7561 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0393 -15.6945 6
-      vertex -17.9101 -16.9445 6
-      vertex -17.7055 -17.2204 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.4327 -14.3172 6
-      vertex -16.226 -14.7561 6
-      vertex -18.3493 -13.984 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1024 -15.5892 6
-      vertex -18.0867 -16.6499 6
-      vertex -17.9101 -16.9445 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.226 -14.7561 6
-      vertex -18.4327 -14.3172 6
-      vertex -16.244 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1549 -15.4784 6
-      vertex -18.2336 -16.3394 6
-      vertex -18.0867 -16.6499 6
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -18.4831 -14.6569 6
-      vertex -16.244 -14.8775 6
-      vertex -18.4327 -14.3172 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.1962 -15.3629 6
-      vertex -18.3493 -16.016 6
-      vertex -18.2336 -16.3394 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.244 -14.8775 6
-      vertex -18.4831 -14.6569 6
-      vertex -16.25 -15 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.226 -15.2439 6
-      vertex -18.4327 -15.6828 6
-      vertex -18.3493 -16.016 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18.5 -15 6
-      vertex -16.25 -15 6
-      vertex -18.4831 -14.6569 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.244 -15.1225 6
-      vertex -18.4831 -15.3431 6
-      vertex -18.4327 -15.6828 6
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.25 -15 6
-      vertex -18.5 -15 6
-      vertex -18.4831 -15.3431 6
+      vertex 18.4831 -15.3431 1
+      vertex 18.4327 -15.6828 6
+      vertex 18.4327 -15.6828 1
     endloop
   endfacet
   facet normal 0.14676 0.989172 -0
     outer loop
-      vertex -14.3172 -11.5673 1
-      vertex -14.6569 -11.5169 6
-      vertex -14.3172 -11.5673 6
+      vertex 15.6828 -11.5673 1
+      vertex 15.3431 -11.5169 6
+      vertex 15.6828 -11.5673 6
     endloop
   endfacet
   facet normal 0.14676 0.989172 0
     outer loop
-      vertex -14.6569 -11.5169 6
-      vertex -14.3172 -11.5673 1
-      vertex -14.6569 -11.5169 1
+      vertex 15.3431 -11.5169 6
+      vertex 15.6828 -11.5673 1
+      vertex 15.3431 -11.5169 1
+    endloop
+  endfacet
+  facet normal 0.970074 0.24281 0
+    outer loop
+      vertex 18.4327 -14.3172 6
+      vertex 18.3493 -13.984 1
+      vertex 18.3493 -13.984 6
+    endloop
+  endfacet
+  facet normal 0.970074 0.24281 0
+    outer loop
+      vertex 18.3493 -13.984 1
+      vertex 18.4327 -14.3172 6
+      vertex 18.4327 -14.3172 1
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex 11.5673 -15.6828 1
+      vertex 11.5169 -15.3431 6
+      vertex 11.5169 -15.3431 1
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex 11.5169 -15.3431 6
+      vertex 11.5673 -15.6828 1
+      vertex 11.5673 -15.6828 6
+    endloop
+  endfacet
+  facet normal -0.941557 -0.336853 0
+    outer loop
+      vertex 11.7664 -16.3394 1
+      vertex 11.6507 -16.016 6
+      vertex 11.6507 -16.016 1
+    endloop
+  endfacet
+  facet normal -0.941557 -0.336853 0
+    outer loop
+      vertex 11.6507 -16.016 6
+      vertex 11.7664 -16.3394 1
+      vertex 11.7664 -16.3394 6
+    endloop
+  endfacet
+  facet normal 0.857698 0.514153 0
+    outer loop
+      vertex 18.0867 -13.3501 6
+      vertex 17.9101 -13.0555 1
+      vertex 17.9101 -13.0555 6
+    endloop
+  endfacet
+  facet normal 0.857698 0.514153 0
+    outer loop
+      vertex 17.9101 -13.0555 1
+      vertex 18.0867 -13.3501 6
+      vertex 18.0867 -13.3501 1
+    endloop
+  endfacet
+  facet normal -0.857698 -0.514153 0
+    outer loop
+      vertex 12.0899 -16.9445 1
+      vertex 11.9133 -16.6499 6
+      vertex 11.9133 -16.6499 1
+    endloop
+  endfacet
+  facet normal -0.857698 -0.514153 0
+    outer loop
+      vertex 11.9133 -16.6499 6
+      vertex 12.0899 -16.9445 1
+      vertex 12.0899 -16.9445 6
+    endloop
+  endfacet
+  facet normal -0.427661 -0.903939 0
+    outer loop
+      vertex 13.3501 -18.0867 1
+      vertex 13.6606 -18.2336 6
+      vertex 13.3501 -18.0867 6
+    endloop
+  endfacet
+  facet normal -0.427661 -0.903939 -0
+    outer loop
+      vertex 13.6606 -18.2336 6
+      vertex 13.3501 -18.0867 1
+      vertex 13.6606 -18.2336 1
+    endloop
+  endfacet
+  facet normal 0.741046 0.671454 0
+    outer loop
+      vertex 17.7055 -12.7796 6
+      vertex 17.4749 -12.5251 1
+      vertex 17.4749 -12.5251 6
+    endloop
+  endfacet
+  facet normal 0.741046 0.671454 0
+    outer loop
+      vertex 17.4749 -12.5251 1
+      vertex 17.7055 -12.7796 6
+      vertex 17.7055 -12.7796 1
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex 15.3431 -18.4831 1
+      vertex 15.6828 -18.4327 6
+      vertex 15.3431 -18.4831 6
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex 15.6828 -18.4327 6
+      vertex 15.3431 -18.4831 1
+      vertex 15.6828 -18.4327 1
+    endloop
+  endfacet
+  facet normal -0.803237 -0.595659 0
+    outer loop
+      vertex 12.2945 -17.2204 1
+      vertex 12.0899 -16.9445 6
+      vertex 12.0899 -16.9445 1
+    endloop
+  endfacet
+  facet normal -0.803237 -0.595659 0
+    outer loop
+      vertex 12.0899 -16.9445 6
+      vertex 12.2945 -17.2204 1
+      vertex 12.2945 -17.2204 6
+    endloop
+  endfacet
+  facet normal -0.903939 0.427661 0
+    outer loop
+      vertex 11.7664 -13.6606 1
+      vertex 11.9133 -13.3501 6
+      vertex 11.9133 -13.3501 1
+    endloop
+  endfacet
+  facet normal -0.903939 0.427661 0
+    outer loop
+      vertex 11.9133 -13.3501 6
+      vertex 11.7664 -13.6606 1
+      vertex 11.7664 -13.6606 6
+    endloop
+  endfacet
+  facet normal -0.998789 0.0491971 0
+    outer loop
+      vertex 11.5 -15 1
+      vertex 11.5169 -14.6569 6
+      vertex 11.5169 -14.6569 1
+    endloop
+  endfacet
+  facet normal -0.998789 0.0491971 0
+    outer loop
+      vertex 11.5169 -14.6569 6
+      vertex 11.5 -15 1
+      vertex 11.5 -15 6
+    endloop
+  endfacet
+  facet normal 0.514153 0.857698 -0
+    outer loop
+      vertex 16.9445 -12.0899 1
+      vertex 16.6499 -11.9133 6
+      vertex 16.9445 -12.0899 6
+    endloop
+  endfacet
+  facet normal 0.514153 0.857698 0
+    outer loop
+      vertex 16.6499 -11.9133 6
+      vertex 16.9445 -12.0899 1
+      vertex 16.6499 -11.9133 1
+    endloop
+  endfacet
+  facet normal -0.671454 -0.741046 0
+    outer loop
+      vertex 12.5251 -17.4749 1
+      vertex 12.7796 -17.7055 6
+      vertex 12.5251 -17.4749 6
+    endloop
+  endfacet
+  facet normal -0.671454 -0.741046 -0
+    outer loop
+      vertex 12.7796 -17.7055 6
+      vertex 12.5251 -17.4749 1
+      vertex 12.7796 -17.7055 1
+    endloop
+  endfacet
+  facet normal 0.857698 -0.514153 0
+    outer loop
+      vertex 17.9101 -16.9445 6
+      vertex 18.0867 -16.6499 1
+      vertex 18.0867 -16.6499 6
+    endloop
+  endfacet
+  facet normal 0.857698 -0.514153 0
+    outer loop
+      vertex 18.0867 -16.6499 1
+      vertex 17.9101 -16.9445 6
+      vertex 17.9101 -16.9445 1
+    endloop
+  endfacet
+  facet normal -0.24281 0.970074 0
+    outer loop
+      vertex 14.3172 -11.5673 1
+      vertex 13.984 -11.6507 6
+      vertex 14.3172 -11.5673 6
+    endloop
+  endfacet
+  facet normal -0.24281 0.970074 0
+    outer loop
+      vertex 13.984 -11.6507 6
+      vertex 14.3172 -11.5673 1
+      vertex 13.984 -11.6507 1
+    endloop
+  endfacet
+  facet normal 0.989172 0.14676 0
+    outer loop
+      vertex 18.4831 -14.6569 6
+      vertex 18.4327 -14.3172 1
+      vertex 18.4327 -14.3172 6
+    endloop
+  endfacet
+  facet normal 0.989172 0.14676 0
+    outer loop
+      vertex 18.4327 -14.3172 1
+      vertex 18.4831 -14.6569 6
+      vertex 18.4831 -14.6569 1
+    endloop
+  endfacet
+  facet normal -0.595659 0.803237 0
+    outer loop
+      vertex 13.0555 -12.0899 1
+      vertex 12.7796 -12.2945 6
+      vertex 13.0555 -12.0899 6
+    endloop
+  endfacet
+  facet normal -0.595659 0.803237 0
+    outer loop
+      vertex 12.7796 -12.2945 6
+      vertex 13.0555 -12.0899 1
+      vertex 12.7796 -12.2945 1
+    endloop
+  endfacet
+  facet normal -0.903939 -0.427661 0
+    outer loop
+      vertex 11.9133 -16.6499 1
+      vertex 11.7664 -16.3394 6
+      vertex 11.7664 -16.3394 1
+    endloop
+  endfacet
+  facet normal -0.903939 -0.427661 0
+    outer loop
+      vertex 11.7664 -16.3394 6
+      vertex 11.9133 -16.6499 1
+      vertex 11.9133 -16.6499 6
+    endloop
+  endfacet
+  facet normal -0.741046 -0.671454 0
+    outer loop
+      vertex 12.5251 -17.4749 1
+      vertex 12.2945 -17.2204 6
+      vertex 12.2945 -17.2204 1
+    endloop
+  endfacet
+  facet normal -0.741046 -0.671454 0
+    outer loop
+      vertex 12.2945 -17.2204 6
+      vertex 12.5251 -17.4749 1
+      vertex 12.5251 -17.4749 6
+    endloop
+  endfacet
+  facet normal -0.989172 0.14676 0
+    outer loop
+      vertex 11.5169 -14.6569 1
+      vertex 11.5673 -14.3172 6
+      vertex 11.5673 -14.3172 1
+    endloop
+  endfacet
+  facet normal -0.989172 0.14676 0
+    outer loop
+      vertex 11.5673 -14.3172 6
+      vertex 11.5169 -14.6569 1
+      vertex 11.5169 -14.6569 6
+    endloop
+  endfacet
+  facet normal -0.803237 0.595659 0
+    outer loop
+      vertex 12.0899 -13.0555 1
+      vertex 12.2945 -12.7796 6
+      vertex 12.2945 -12.7796 1
+    endloop
+  endfacet
+  facet normal -0.803237 0.595659 0
+    outer loop
+      vertex 12.2945 -12.7796 6
+      vertex 12.0899 -13.0555 1
+      vertex 12.0899 -13.0555 6
+    endloop
+  endfacet
+  facet normal -0.24281 -0.970074 0
+    outer loop
+      vertex 13.984 -18.3493 1
+      vertex 14.3172 -18.4327 6
+      vertex 13.984 -18.3493 6
+    endloop
+  endfacet
+  facet normal -0.24281 -0.970074 -0
+    outer loop
+      vertex 14.3172 -18.4327 6
+      vertex 13.984 -18.3493 1
+      vertex 14.3172 -18.4327 1
+    endloop
+  endfacet
+  facet normal -0.336853 -0.941557 0
+    outer loop
+      vertex 13.6606 -18.2336 1
+      vertex 13.984 -18.3493 6
+      vertex 13.6606 -18.2336 6
+    endloop
+  endfacet
+  facet normal -0.336853 -0.941557 -0
+    outer loop
+      vertex 13.984 -18.3493 6
+      vertex 13.6606 -18.2336 1
+      vertex 13.984 -18.3493 1
+    endloop
+  endfacet
+  facet normal -0.514153 0.857698 0
+    outer loop
+      vertex 13.3501 -11.9133 1
+      vertex 13.0555 -12.0899 6
+      vertex 13.3501 -11.9133 6
+    endloop
+  endfacet
+  facet normal -0.514153 0.857698 0
+    outer loop
+      vertex 13.0555 -12.0899 6
+      vertex 13.3501 -11.9133 1
+      vertex 13.0555 -12.0899 1
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 0
+    outer loop
+      vertex 17.7055 -17.2204 6
+      vertex 17.9101 -16.9445 1
+      vertex 17.9101 -16.9445 6
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 0
+    outer loop
+      vertex 17.9101 -16.9445 1
+      vertex 17.7055 -17.2204 6
+      vertex 17.7055 -17.2204 1
+    endloop
+  endfacet
+  facet normal -0.970074 -0.24281 0
+    outer loop
+      vertex 11.6507 -16.016 1
+      vertex 11.5673 -15.6828 6
+      vertex 11.5673 -15.6828 1
+    endloop
+  endfacet
+  facet normal -0.970074 -0.24281 0
+    outer loop
+      vertex 11.5673 -15.6828 6
+      vertex 11.6507 -16.016 1
+      vertex 11.6507 -16.016 6
     endloop
   endfacet
   facet normal 0.595659 0.803237 -0
@@ -12571,48 +10205,6 @@ solid OpenSCAD_Model
       vertex -13.0555 -12.0899 1
     endloop
   endfacet
-  facet normal 0.514153 0.857698 -0
-    outer loop
-      vertex -13.0555 -12.0899 1
-      vertex -13.3501 -11.9133 6
-      vertex -13.0555 -12.0899 6
-    endloop
-  endfacet
-  facet normal 0.514153 0.857698 0
-    outer loop
-      vertex -13.3501 -11.9133 6
-      vertex -13.0555 -12.0899 1
-      vertex -13.3501 -11.9133 1
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 -0
-    outer loop
-      vertex -13.3501 -11.9133 1
-      vertex -13.6606 -11.7664 6
-      vertex -13.3501 -11.9133 6
-    endloop
-  endfacet
-  facet normal 0.427661 0.903939 0
-    outer loop
-      vertex -13.6606 -11.7664 6
-      vertex -13.3501 -11.9133 1
-      vertex -13.6606 -11.7664 1
-    endloop
-  endfacet
-  facet normal 0.0491971 0.998789 -0
-    outer loop
-      vertex -14.6569 -11.5169 1
-      vertex -15 -11.5 6
-      vertex -14.6569 -11.5169 6
-    endloop
-  endfacet
-  facet normal 0.0491971 0.998789 0
-    outer loop
-      vertex -15 -11.5 6
-      vertex -14.6569 -11.5169 1
-      vertex -15 -11.5 1
-    endloop
-  endfacet
   facet normal 0.803237 0.595659 0
     outer loop
       vertex -12.0899 -13.0555 6
@@ -12627,116 +10219,46 @@ solid OpenSCAD_Model
       vertex -12.0899 -13.0555 1
     endloop
   endfacet
-  facet normal 0.903939 0.427661 0
+  facet normal -0.998789 -0.0491971 0
     outer loop
-      vertex -11.7664 -13.6606 6
-      vertex -11.9133 -13.3501 1
-      vertex -11.9133 -13.3501 6
+      vertex -18.4831 -15.3431 1
+      vertex -18.5 -15 6
+      vertex -18.5 -15 1
     endloop
   endfacet
-  facet normal 0.903939 0.427661 0
+  facet normal -0.998789 -0.0491971 0
     outer loop
-      vertex -11.9133 -13.3501 1
-      vertex -11.7664 -13.6606 6
-      vertex -11.7664 -13.6606 1
+      vertex -18.5 -15 6
+      vertex -18.4831 -15.3431 1
+      vertex -18.4831 -15.3431 6
     endloop
   endfacet
-  facet normal 0.989172 0.14676 0
+  facet normal 0.24281 0.970074 -0
     outer loop
-      vertex -11.5169 -14.6569 6
-      vertex -11.5673 -14.3172 1
-      vertex -11.5673 -14.3172 6
+      vertex -13.984 -11.6507 1
+      vertex -14.3172 -11.5673 6
+      vertex -13.984 -11.6507 6
     endloop
   endfacet
-  facet normal 0.989172 0.14676 0
+  facet normal 0.24281 0.970074 0
     outer loop
-      vertex -11.5673 -14.3172 1
-      vertex -11.5169 -14.6569 6
-      vertex -11.5169 -14.6569 1
+      vertex -14.3172 -11.5673 6
+      vertex -13.984 -11.6507 1
+      vertex -14.3172 -11.5673 1
     endloop
   endfacet
-  facet normal -0.970074 -0.24281 0
+  facet normal -0.336853 -0.941557 0
     outer loop
-      vertex -18.3493 -16.016 1
-      vertex -18.4327 -15.6828 6
-      vertex -18.4327 -15.6828 1
+      vertex -16.3394 -18.2336 1
+      vertex -16.016 -18.3493 6
+      vertex -16.3394 -18.2336 6
     endloop
   endfacet
-  facet normal -0.970074 -0.24281 0
+  facet normal -0.336853 -0.941557 -0
     outer loop
-      vertex -18.4327 -15.6828 6
-      vertex -18.3493 -16.016 1
-      vertex -18.3493 -16.016 6
-    endloop
-  endfacet
-  facet normal -0.903939 -0.427661 0
-    outer loop
-      vertex -18.0867 -16.6499 1
-      vertex -18.2336 -16.3394 6
-      vertex -18.2336 -16.3394 1
-    endloop
-  endfacet
-  facet normal -0.903939 -0.427661 0
-    outer loop
-      vertex -18.2336 -16.3394 6
-      vertex -18.0867 -16.6499 1
-      vertex -18.0867 -16.6499 6
-    endloop
-  endfacet
-  facet normal 0.0491971 -0.998789 0
-    outer loop
-      vertex -15 -18.5 1
-      vertex -14.6569 -18.4831 6
-      vertex -15 -18.5 6
-    endloop
-  endfacet
-  facet normal 0.0491971 -0.998789 0
-    outer loop
-      vertex -14.6569 -18.4831 6
-      vertex -15 -18.5 1
-      vertex -14.6569 -18.4831 1
-    endloop
-  endfacet
-  facet normal 0.941557 -0.336853 0
-    outer loop
-      vertex -11.7664 -16.3394 6
-      vertex -11.6507 -16.016 1
-      vertex -11.6507 -16.016 6
-    endloop
-  endfacet
-  facet normal 0.941557 -0.336853 0
-    outer loop
-      vertex -11.6507 -16.016 1
-      vertex -11.7664 -16.3394 6
-      vertex -11.7664 -16.3394 1
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex -14.3172 -18.4327 1
-      vertex -13.984 -18.3493 6
-      vertex -14.3172 -18.4327 6
-    endloop
-  endfacet
-  facet normal 0.24281 -0.970074 0
-    outer loop
-      vertex -13.984 -18.3493 6
-      vertex -14.3172 -18.4327 1
-      vertex -13.984 -18.3493 1
-    endloop
-  endfacet
-  facet normal -0.671454 0.741046 0
-    outer loop
-      vertex -17.2204 -12.2945 1
-      vertex -17.4749 -12.5251 6
-      vertex -17.2204 -12.2945 6
-    endloop
-  endfacet
-  facet normal -0.671454 0.741046 0
-    outer loop
-      vertex -17.4749 -12.5251 6
-      vertex -17.2204 -12.2945 1
-      vertex -17.4749 -12.5251 1
+      vertex -16.016 -18.3493 6
+      vertex -16.3394 -18.2336 1
+      vertex -16.016 -18.3493 1
     endloop
   endfacet
   facet normal -0.989172 0.14676 0
@@ -12753,32 +10275,130 @@ solid OpenSCAD_Model
       vertex -18.4831 -14.6569 6
     endloop
   endfacet
-  facet normal 0.741046 0.671454 0
+  facet normal -0.941557 0.336853 0
     outer loop
-      vertex -12.2945 -12.7796 6
-      vertex -12.5251 -12.5251 1
-      vertex -12.5251 -12.5251 6
+      vertex -18.3493 -13.984 1
+      vertex -18.2336 -13.6606 6
+      vertex -18.2336 -13.6606 1
     endloop
   endfacet
-  facet normal 0.741046 0.671454 0
+  facet normal -0.941557 0.336853 0
     outer loop
-      vertex -12.5251 -12.5251 1
-      vertex -12.2945 -12.7796 6
-      vertex -12.2945 -12.7796 1
+      vertex -18.2336 -13.6606 6
+      vertex -18.3493 -13.984 1
+      vertex -18.3493 -13.984 6
     endloop
   endfacet
-  facet normal 0.857698 0.514153 0
+  facet normal -0.514153 -0.857698 0
     outer loop
-      vertex -11.9133 -13.3501 6
-      vertex -12.0899 -13.0555 1
-      vertex -12.0899 -13.0555 6
+      vertex -16.9445 -17.9101 1
+      vertex -16.6499 -18.0867 6
+      vertex -16.9445 -17.9101 6
     endloop
   endfacet
-  facet normal 0.857698 0.514153 0
+  facet normal -0.514153 -0.857698 -0
     outer loop
-      vertex -12.0899 -13.0555 1
-      vertex -11.9133 -13.3501 6
-      vertex -11.9133 -13.3501 1
+      vertex -16.6499 -18.0867 6
+      vertex -16.9445 -17.9101 1
+      vertex -16.6499 -18.0867 1
+    endloop
+  endfacet
+  facet normal -0.803237 -0.595659 0
+    outer loop
+      vertex -17.7055 -17.2204 1
+      vertex -17.9101 -16.9445 6
+      vertex -17.9101 -16.9445 1
+    endloop
+  endfacet
+  facet normal -0.803237 -0.595659 0
+    outer loop
+      vertex -17.9101 -16.9445 6
+      vertex -17.7055 -17.2204 1
+      vertex -17.7055 -17.2204 6
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex -18.4327 -15.6828 1
+      vertex -18.4831 -15.3431 6
+      vertex -18.4831 -15.3431 1
+    endloop
+  endfacet
+  facet normal -0.989172 -0.14676 0
+    outer loop
+      vertex -18.4831 -15.3431 6
+      vertex -18.4327 -15.6828 1
+      vertex -18.4327 -15.6828 6
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 0
+    outer loop
+      vertex -12.2945 -17.2204 6
+      vertex -12.0899 -16.9445 1
+      vertex -12.0899 -16.9445 6
+    endloop
+  endfacet
+  facet normal 0.803237 -0.595659 0
+    outer loop
+      vertex -12.0899 -16.9445 1
+      vertex -12.2945 -17.2204 6
+      vertex -12.2945 -17.2204 1
+    endloop
+  endfacet
+  facet normal -0.970074 -0.24281 0
+    outer loop
+      vertex -18.3493 -16.016 1
+      vertex -18.4327 -15.6828 6
+      vertex -18.4327 -15.6828 1
+    endloop
+  endfacet
+  facet normal -0.970074 -0.24281 0
+    outer loop
+      vertex -18.4327 -15.6828 6
+      vertex -18.3493 -16.016 1
+      vertex -18.3493 -16.016 6
+    endloop
+  endfacet
+  facet normal 0.903939 -0.427661 0
+    outer loop
+      vertex -11.9133 -16.6499 6
+      vertex -11.7664 -16.3394 1
+      vertex -11.7664 -16.3394 6
+    endloop
+  endfacet
+  facet normal 0.903939 -0.427661 0
+    outer loop
+      vertex -11.7664 -16.3394 1
+      vertex -11.9133 -16.6499 6
+      vertex -11.9133 -16.6499 1
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex -14.6569 -18.4831 1
+      vertex -14.3172 -18.4327 6
+      vertex -14.6569 -18.4831 6
+    endloop
+  endfacet
+  facet normal 0.14676 -0.989172 0
+    outer loop
+      vertex -14.3172 -18.4327 6
+      vertex -14.6569 -18.4831 1
+      vertex -14.3172 -18.4327 1
+    endloop
+  endfacet
+  facet normal -0.595659 -0.803237 0
+    outer loop
+      vertex -17.2204 -17.7055 1
+      vertex -16.9445 -17.9101 6
+      vertex -17.2204 -17.7055 6
+    endloop
+  endfacet
+  facet normal -0.595659 -0.803237 -0
+    outer loop
+      vertex -16.9445 -17.9101 6
+      vertex -17.2204 -17.7055 1
+      vertex -16.9445 -17.9101 1
     endloop
   endfacet
   facet normal 0.941557 0.336853 0
@@ -12795,3621 +10415,1633 @@ solid OpenSCAD_Model
       vertex -11.6507 -13.984 1
     endloop
   endfacet
-  facet normal -0.595423 -0.803413 0
+  facet normal 0.427661 -0.903939 0
     outer loop
-      vertex 15.6945 16.0393 -1
-      vertex 15.793 15.9663 6
-      vertex 15.6945 16.0393 6
+      vertex -13.6606 -18.2336 1
+      vertex -13.3501 -18.0867 6
+      vertex -13.6606 -18.2336 6
     endloop
   endfacet
-  facet normal -0.595423 -0.803413 -0
+  facet normal 0.427661 -0.903939 0
     outer loop
-      vertex 15.793 15.9663 6
-      vertex 15.6945 16.0393 -1
-      vertex 15.793 15.9663 -1
+      vertex -13.3501 -18.0867 6
+      vertex -13.6606 -18.2336 1
+      vertex -13.3501 -18.0867 1
     endloop
   endfacet
-  facet normal 0.428192 -0.903688 0
+  facet normal -0.427661 -0.903939 0
     outer loop
-      vertex 14.4108 16.1024 -1
-      vertex 14.5216 16.1549 6
-      vertex 14.4108 16.1024 6
+      vertex -16.6499 -18.0867 1
+      vertex -16.3394 -18.2336 6
+      vertex -16.6499 -18.0867 6
     endloop
   endfacet
-  facet normal 0.428192 -0.903688 0
+  facet normal -0.427661 -0.903939 -0
     outer loop
-      vertex 14.5216 16.1549 6
-      vertex 14.4108 16.1024 -1
-      vertex 14.5216 16.1549 -1
+      vertex -16.3394 -18.2336 6
+      vertex -16.6499 -18.0867 1
+      vertex -16.3394 -18.2336 1
     endloop
   endfacet
-  facet normal 0.941613 -0.336698 0
+  facet normal 0.903939 0.427661 0
     outer loop
-      vertex 13.8038 15.3629 6
-      vertex 13.8451 15.4784 -1
-      vertex 13.8451 15.4784 6
+      vertex -11.7664 -13.6606 6
+      vertex -11.9133 -13.3501 1
+      vertex -11.9133 -13.3501 6
     endloop
   endfacet
-  facet normal 0.941613 -0.336698 0
+  facet normal 0.903939 0.427661 0
     outer loop
-      vertex 13.8451 15.4784 -1
-      vertex 13.8038 15.3629 6
-      vertex 13.8038 15.3629 -1
+      vertex -11.9133 -13.3501 1
+      vertex -11.7664 -13.6606 6
+      vertex -11.7664 -13.6606 1
     endloop
   endfacet
-  facet normal -0.998803 0.0489209 0
+  facet normal 0.671454 0.741046 -0
     outer loop
-      vertex 16.244 14.8775 -1
-      vertex 16.25 15 6
-      vertex 16.25 15 -1
+      vertex -12.5251 -12.5251 1
+      vertex -12.7796 -12.2945 6
+      vertex -12.5251 -12.5251 6
     endloop
   endfacet
-  facet normal -0.998803 0.0489209 0
+  facet normal 0.671454 0.741046 0
     outer loop
-      vertex 16.25 15 6
-      vertex 16.244 14.8775 -1
-      vertex 16.244 14.8775 6
+      vertex -12.7796 -12.2945 6
+      vertex -12.5251 -12.5251 1
+      vertex -12.7796 -12.2945 1
     endloop
   endfacet
-  facet normal -0.903688 -0.428192 0
+  facet normal -0.595659 0.803237 0
     outer loop
-      vertex 16.1549 15.4784 -1
-      vertex 16.1024 15.5892 6
-      vertex 16.1024 15.5892 -1
+      vertex -16.9445 -12.0899 1
+      vertex -17.2204 -12.2945 6
+      vertex -16.9445 -12.0899 6
     endloop
   endfacet
-  facet normal -0.903688 -0.428192 0
+  facet normal -0.595659 0.803237 0
     outer loop
-      vertex 16.1024 15.5892 6
-      vertex 16.1549 15.4784 -1
-      vertex 16.1549 15.4784 6
+      vertex -17.2204 -12.2945 6
+      vertex -16.9445 -12.0899 1
+      vertex -17.2204 -12.2945 1
     endloop
   endfacet
-  facet normal -0.85778 -0.514016 0
+  facet normal -0.803237 0.595659 0
     outer loop
-      vertex 16.1024 15.5892 -1
-      vertex 16.0393 15.6945 6
-      vertex 16.0393 15.6945 -1
+      vertex -17.9101 -13.0555 1
+      vertex -17.7055 -12.7796 6
+      vertex -17.7055 -12.7796 1
     endloop
   endfacet
-  facet normal -0.85778 -0.514016 0
+  facet normal -0.803237 0.595659 0
     outer loop
-      vertex 16.0393 15.6945 6
-      vertex 16.1024 15.5892 -1
-      vertex 16.1024 15.5892 6
+      vertex -17.7055 -12.7796 6
+      vertex -17.9101 -13.0555 1
+      vertex -17.9101 -13.0555 6
     endloop
   endfacet
-  facet normal -0.336698 -0.941613 0
+  facet normal 0.336853 0.941557 -0
     outer loop
-      vertex 15.3629 16.1962 -1
-      vertex 15.4784 16.1549 6
-      vertex 15.3629 16.1962 6
+      vertex -13.6606 -11.7664 1
+      vertex -13.984 -11.6507 6
+      vertex -13.6606 -11.7664 6
     endloop
   endfacet
-  facet normal -0.336698 -0.941613 -0
+  facet normal 0.336853 0.941557 0
     outer loop
-      vertex 15.4784 16.1549 6
-      vertex 15.3629 16.1962 -1
-      vertex 15.4784 16.1549 -1
+      vertex -13.984 -11.6507 6
+      vertex -13.6606 -11.7664 1
+      vertex -13.984 -11.6507 1
     endloop
   endfacet
-  facet normal 0.803413 -0.595423 0
+  facet normal -0.24281 0.970074 0
     outer loop
-      vertex 13.9607 15.6945 6
-      vertex 14.0337 15.793 -1
-      vertex 14.0337 15.793 6
+      vertex -15.6828 -11.5673 1
+      vertex -16.016 -11.6507 6
+      vertex -15.6828 -11.5673 6
     endloop
   endfacet
-  facet normal 0.803413 -0.595423 0
+  facet normal -0.24281 0.970074 0
     outer loop
-      vertex 14.0337 15.793 -1
-      vertex 13.9607 15.6945 6
-      vertex 13.9607 15.6945 -1
+      vertex -16.016 -11.6507 6
+      vertex -15.6828 -11.5673 1
+      vertex -16.016 -11.6507 1
     endloop
   endfacet
-  facet normal 0.242919 -0.970047 0
+  facet normal -0.941557 -0.336853 0
     outer loop
-      vertex 14.6371 16.1962 -1
-      vertex 14.7561 16.226 6
-      vertex 14.6371 16.1962 6
+      vertex -18.2336 -16.3394 1
+      vertex -18.3493 -16.016 6
+      vertex -18.3493 -16.016 1
     endloop
   endfacet
-  facet normal 0.242919 -0.970047 0
+  facet normal -0.941557 -0.336853 0
     outer loop
-      vertex 14.7561 16.226 6
-      vertex 14.6371 16.1962 -1
-      vertex 14.7561 16.226 -1
+      vertex -18.3493 -16.016 6
+      vertex -18.2336 -16.3394 1
+      vertex -18.2336 -16.3394 6
     endloop
   endfacet
-  facet normal -0.803413 0.595423 0
+  facet normal -0.24281 -0.970074 0
     outer loop
-      vertex 15.9663 14.207 -1
-      vertex 16.0393 14.3055 6
-      vertex 16.0393 14.3055 -1
+      vertex -16.016 -18.3493 1
+      vertex -15.6828 -18.4327 6
+      vertex -16.016 -18.3493 6
     endloop
   endfacet
-  facet normal -0.803413 0.595423 0
+  facet normal -0.24281 -0.970074 -0
     outer loop
-      vertex 16.0393 14.3055 6
-      vertex 15.9663 14.207 -1
-      vertex 15.9663 14.207 6
+      vertex -15.6828 -18.4327 6
+      vertex -16.016 -18.3493 1
+      vertex -15.6828 -18.4327 1
     endloop
   endfacet
-  facet normal -0.941613 0.336698 0
+  facet normal 0.336853 -0.941557 0
     outer loop
-      vertex 16.1549 14.5216 -1
-      vertex 16.1962 14.6371 6
-      vertex 16.1962 14.6371 -1
+      vertex -13.984 -18.3493 1
+      vertex -13.6606 -18.2336 6
+      vertex -13.984 -18.3493 6
     endloop
   endfacet
-  facet normal -0.941613 0.336698 0
+  facet normal 0.336853 -0.941557 0
     outer loop
-      vertex 16.1962 14.6371 6
-      vertex 16.1549 14.5216 -1
-      vertex 16.1549 14.5216 6
+      vertex -13.6606 -18.2336 6
+      vertex -13.984 -18.3493 1
+      vertex -13.6606 -18.2336 1
     endloop
   endfacet
-  facet normal 0.0489209 0.998803 -0
+  facet normal 0.671454 -0.741046 0
     outer loop
-      vertex 15 13.75 -1
-      vertex 14.8775 13.756 6
-      vertex 15 13.75 6
+      vertex -12.7796 -17.7055 1
+      vertex -12.5251 -17.4749 6
+      vertex -12.7796 -17.7055 6
     endloop
   endfacet
-  facet normal 0.0489209 0.998803 0
+  facet normal 0.671454 -0.741046 0
     outer loop
-      vertex 14.8775 13.756 6
-      vertex 15 13.75 -1
-      vertex 14.8775 13.756 -1
+      vertex -12.5251 -17.4749 6
+      vertex -12.7796 -17.7055 1
+      vertex -12.5251 -17.4749 1
     endloop
   endfacet
-  facet normal 0.595423 0.803413 -0
+  facet normal -0.998789 0.0491971 0
     outer loop
-      vertex 14.3055 13.9607 -1
-      vertex 14.207 14.0337 6
-      vertex 14.3055 13.9607 6
+      vertex -18.5 -15 1
+      vertex -18.4831 -14.6569 6
+      vertex -18.4831 -14.6569 1
     endloop
   endfacet
-  facet normal 0.595423 0.803413 0
+  facet normal -0.998789 0.0491971 0
     outer loop
-      vertex 14.207 14.0337 6
-      vertex 14.3055 13.9607 -1
-      vertex 14.207 14.0337 -1
+      vertex -18.4831 -14.6569 6
+      vertex -18.5 -15 1
+      vertex -18.5 -15 6
     endloop
   endfacet
-  facet normal -0.970047 -0.242919 0
+  facet normal -0.857698 0.514153 0
     outer loop
-      vertex 16.226 15.2439 -1
-      vertex 16.1962 15.3629 6
-      vertex 16.1962 15.3629 -1
+      vertex -18.0867 -13.3501 1
+      vertex -17.9101 -13.0555 6
+      vertex -17.9101 -13.0555 1
     endloop
   endfacet
-  facet normal -0.970047 -0.242919 0
+  facet normal -0.857698 0.514153 0
     outer loop
-      vertex 16.1962 15.3629 6
-      vertex 16.226 15.2439 -1
-      vertex 16.226 15.2439 6
+      vertex -17.9101 -13.0555 6
+      vertex -18.0867 -13.3501 1
+      vertex -18.0867 -13.3501 6
     endloop
   endfacet
-  facet normal -0.941613 -0.336698 0
+  facet normal -0.514153 0.857698 0
     outer loop
-      vertex 16.1962 15.3629 -1
-      vertex 16.1549 15.4784 6
-      vertex 16.1549 15.4784 -1
+      vertex -16.6499 -11.9133 1
+      vertex -16.9445 -12.0899 6
+      vertex -16.6499 -11.9133 6
     endloop
   endfacet
-  facet normal -0.941613 -0.336698 0
+  facet normal -0.514153 0.857698 0
     outer loop
-      vertex 16.1549 15.4784 6
-      vertex 16.1962 15.3629 -1
-      vertex 16.1962 15.3629 6
+      vertex -16.9445 -12.0899 6
+      vertex -16.6499 -11.9133 1
+      vertex -16.9445 -12.0899 1
     endloop
   endfacet
-  facet normal -0.740898 -0.671617 0
+  facet normal -0.903939 -0.427661 0
     outer loop
-      vertex 15.9663 15.793 -1
-      vertex 15.8839 15.8839 6
-      vertex 15.8839 15.8839 -1
+      vertex -18.0867 -16.6499 1
+      vertex -18.2336 -16.3394 6
+      vertex -18.2336 -16.3394 1
     endloop
   endfacet
-  facet normal -0.740898 -0.671617 0
+  facet normal -0.903939 -0.427661 0
     outer loop
-      vertex 15.8839 15.8839 6
-      vertex 15.9663 15.793 -1
-      vertex 15.9663 15.793 6
+      vertex -18.2336 -16.3394 6
+      vertex -18.0867 -16.6499 1
+      vertex -18.0867 -16.6499 6
     endloop
   endfacet
-  facet normal -0.803413 -0.595423 0
+  facet normal -0.857698 -0.514153 0
     outer loop
-      vertex 16.0393 15.6945 -1
-      vertex 15.9663 15.793 6
-      vertex 15.9663 15.793 -1
+      vertex -17.9101 -16.9445 1
+      vertex -18.0867 -16.6499 6
+      vertex -18.0867 -16.6499 1
     endloop
   endfacet
-  facet normal -0.803413 -0.595423 0
+  facet normal -0.857698 -0.514153 0
     outer loop
-      vertex 15.9663 15.793 6
-      vertex 16.0393 15.6945 -1
-      vertex 16.0393 15.6945 6
+      vertex -18.0867 -16.6499 6
+      vertex -17.9101 -16.9445 1
+      vertex -17.9101 -16.9445 6
     endloop
   endfacet
-  facet normal -0.671617 -0.740898 0
+  facet normal 0.595659 -0.803237 0
     outer loop
-      vertex 15.793 15.9663 -1
-      vertex 15.8839 15.8839 6
-      vertex 15.793 15.9663 6
+      vertex -13.0555 -17.9101 1
+      vertex -12.7796 -17.7055 6
+      vertex -13.0555 -17.9101 6
     endloop
   endfacet
-  facet normal -0.671617 -0.740898 -0
+  facet normal 0.595659 -0.803237 0
     outer loop
-      vertex 15.8839 15.8839 6
-      vertex 15.793 15.9663 -1
-      vertex 15.8839 15.8839 -1
+      vertex -12.7796 -17.7055 6
+      vertex -13.0555 -17.9101 1
+      vertex -12.7796 -17.7055 1
     endloop
   endfacet
-  facet normal -0.514016 -0.85778 0
+  facet normal 0.970074 0.24281 0
     outer loop
-      vertex 15.5892 16.1024 -1
-      vertex 15.6945 16.0393 6
-      vertex 15.5892 16.1024 6
+      vertex -11.5673 -14.3172 6
+      vertex -11.6507 -13.984 1
+      vertex -11.6507 -13.984 6
     endloop
   endfacet
-  facet normal -0.514016 -0.85778 -0
+  facet normal 0.970074 0.24281 0
     outer loop
-      vertex 15.6945 16.0393 6
-      vertex 15.5892 16.1024 -1
-      vertex 15.6945 16.0393 -1
+      vertex -11.6507 -13.984 1
+      vertex -11.5673 -14.3172 6
+      vertex -11.5673 -14.3172 1
     endloop
   endfacet
-  facet normal 0.0489209 -0.998803 0
+  facet normal 0.989172 0.14676 0
     outer loop
-      vertex 14.8775 16.244 -1
-      vertex 15 16.25 6
-      vertex 14.8775 16.244 6
+      vertex -11.5169 -14.6569 6
+      vertex -11.5673 -14.3172 1
+      vertex -11.5673 -14.3172 6
     endloop
   endfacet
-  facet normal 0.0489209 -0.998803 0
+  facet normal 0.989172 0.14676 0
     outer loop
-      vertex 15 16.25 6
-      vertex 14.8775 16.244 -1
-      vertex 15 16.25 -1
+      vertex -11.5673 -14.3172 1
+      vertex -11.5169 -14.6569 6
+      vertex -11.5169 -14.6569 1
     endloop
   endfacet
-  facet normal -0.428192 -0.903688 0
+  facet normal -0.741046 0.671454 0
     outer loop
-      vertex 15.4784 16.1549 -1
-      vertex 15.5892 16.1024 6
-      vertex 15.4784 16.1549 6
+      vertex -17.7055 -12.7796 1
+      vertex -17.4749 -12.5251 6
+      vertex -17.4749 -12.5251 1
     endloop
   endfacet
-  facet normal -0.428192 -0.903688 -0
+  facet normal -0.741046 0.671454 0
     outer loop
-      vertex 15.5892 16.1024 6
-      vertex 15.4784 16.1549 -1
-      vertex 15.5892 16.1024 -1
+      vertex -17.4749 -12.5251 6
+      vertex -17.7055 -12.7796 1
+      vertex -17.7055 -12.7796 6
     endloop
   endfacet
-  facet normal -0.242919 -0.970047 0
+  facet normal 0.0491971 -0.998789 0
     outer loop
-      vertex 15.2439 16.226 -1
-      vertex 15.3629 16.1962 6
-      vertex 15.2439 16.226 6
+      vertex -15 -18.5 1
+      vertex -14.6569 -18.4831 6
+      vertex -15 -18.5 6
     endloop
   endfacet
-  facet normal -0.242919 -0.970047 -0
+  facet normal 0.0491971 -0.998789 0
     outer loop
-      vertex 15.3629 16.1962 6
-      vertex 15.2439 16.226 -1
-      vertex 15.3629 16.1962 -1
+      vertex -14.6569 -18.4831 6
+      vertex -15 -18.5 1
+      vertex -14.6569 -18.4831 1
     endloop
   endfacet
-  facet normal -0.146667 -0.989186 0
+  facet normal -0.970074 0.24281 0
     outer loop
-      vertex 15.1225 16.244 -1
-      vertex 15.2439 16.226 6
-      vertex 15.1225 16.244 6
+      vertex -18.4327 -14.3172 1
+      vertex -18.3493 -13.984 6
+      vertex -18.3493 -13.984 1
     endloop
   endfacet
-  facet normal -0.146667 -0.989186 -0
+  facet normal -0.970074 0.24281 0
     outer loop
-      vertex 15.2439 16.226 6
-      vertex 15.1225 16.244 -1
-      vertex 15.2439 16.226 -1
+      vertex -18.3493 -13.984 6
+      vertex -18.4327 -14.3172 1
+      vertex -18.4327 -14.3172 6
     endloop
   endfacet
-  facet normal 0.998803 0.0489209 0
+  facet normal 0.857698 0.514153 0
     outer loop
-      vertex 13.756 14.8775 6
-      vertex 13.75 15 -1
-      vertex 13.75 15 6
+      vertex -11.9133 -13.3501 6
+      vertex -12.0899 -13.0555 1
+      vertex -12.0899 -13.0555 6
     endloop
   endfacet
-  facet normal 0.998803 0.0489209 0
+  facet normal 0.857698 0.514153 0
     outer loop
-      vertex 13.75 15 -1
-      vertex 13.756 14.8775 6
-      vertex 13.756 14.8775 -1
+      vertex -12.0899 -13.0555 1
+      vertex -11.9133 -13.3501 6
+      vertex -11.9133 -13.3501 1
     endloop
   endfacet
-  facet normal 0.970047 -0.242919 0
+  facet normal -0.14676 0.989172 0
     outer loop
-      vertex 13.774 15.2439 6
-      vertex 13.8038 15.3629 -1
-      vertex 13.8038 15.3629 6
+      vertex -15.3431 -11.5169 1
+      vertex -15.6828 -11.5673 6
+      vertex -15.3431 -11.5169 6
     endloop
   endfacet
-  facet normal 0.970047 -0.242919 0
+  facet normal -0.14676 0.989172 0
     outer loop
-      vertex 13.8038 15.3629 -1
-      vertex 13.774 15.2439 6
-      vertex 13.774 15.2439 -1
+      vertex -15.6828 -11.5673 6
+      vertex -15.3431 -11.5169 1
+      vertex -15.6828 -11.5673 1
     endloop
   endfacet
-  facet normal 0.989186 -0.146667 0
+  facet normal 0.0491971 0.998789 -0
     outer loop
-      vertex 13.756 15.1225 6
-      vertex 13.774 15.2439 -1
-      vertex 13.774 15.2439 6
+      vertex -14.6569 -11.5169 1
+      vertex -15 -11.5 6
+      vertex -14.6569 -11.5169 6
     endloop
   endfacet
-  facet normal 0.989186 -0.146667 0
+  facet normal 0.0491971 0.998789 0
     outer loop
-      vertex 13.774 15.2439 -1
-      vertex 13.756 15.1225 6
-      vertex 13.756 15.1225 -1
+      vertex -15 -11.5 6
+      vertex -14.6569 -11.5169 1
+      vertex -15 -11.5 1
     endloop
   endfacet
-  facet normal 0.903688 -0.428192 0
+  facet normal -0.671454 -0.741046 0
     outer loop
-      vertex 13.8451 15.4784 6
-      vertex 13.8976 15.5892 -1
-      vertex 13.8976 15.5892 6
+      vertex -17.4749 -17.4749 1
+      vertex -17.2204 -17.7055 6
+      vertex -17.4749 -17.4749 6
     endloop
   endfacet
-  facet normal 0.903688 -0.428192 0
+  facet normal -0.671454 -0.741046 -0
     outer loop
-      vertex 13.8976 15.5892 -1
-      vertex 13.8451 15.4784 6
-      vertex 13.8451 15.4784 -1
+      vertex -17.2204 -17.7055 6
+      vertex -17.4749 -17.4749 1
+      vertex -17.2204 -17.7055 1
     endloop
   endfacet
-  facet normal 0.85778 -0.514016 0
+  facet normal 0.998789 -0.0491971 0
     outer loop
-      vertex 13.8976 15.5892 6
-      vertex 13.9607 15.6945 -1
-      vertex 13.9607 15.6945 6
+      vertex -11.5169 -15.3431 6
+      vertex -11.5 -15 1
+      vertex -11.5 -15 6
     endloop
   endfacet
-  facet normal 0.85778 -0.514016 0
+  facet normal 0.998789 -0.0491971 0
     outer loop
-      vertex 13.9607 15.6945 -1
-      vertex 13.8976 15.5892 6
-      vertex 13.8976 15.5892 -1
+      vertex -11.5 -15 1
+      vertex -11.5169 -15.3431 6
+      vertex -11.5169 -15.3431 1
     endloop
   endfacet
-  facet normal 0.336698 -0.941613 0
+  facet normal 0.741046 -0.671454 0
     outer loop
-      vertex 14.5216 16.1549 -1
-      vertex 14.6371 16.1962 6
-      vertex 14.5216 16.1549 6
+      vertex -12.5251 -17.4749 6
+      vertex -12.2945 -17.2204 1
+      vertex -12.2945 -17.2204 6
     endloop
   endfacet
-  facet normal 0.336698 -0.941613 0
+  facet normal 0.741046 -0.671454 0
     outer loop
-      vertex 14.6371 16.1962 6
-      vertex 14.5216 16.1549 -1
-      vertex 14.6371 16.1962 -1
+      vertex -12.2945 -17.2204 1
+      vertex -12.5251 -17.4749 6
+      vertex -12.5251 -17.4749 1
     endloop
   endfacet
-  facet normal 0.146667 -0.989186 0
+  facet normal -0.0491971 0.998789 0
     outer loop
-      vertex 14.7561 16.226 -1
-      vertex 14.8775 16.244 6
-      vertex 14.7561 16.226 6
+      vertex -15 -11.5 1
+      vertex -15.3431 -11.5169 6
+      vertex -15 -11.5 6
     endloop
   endfacet
-  facet normal 0.146667 -0.989186 0
+  facet normal -0.0491971 0.998789 0
     outer loop
-      vertex 14.8775 16.244 6
-      vertex 14.7561 16.226 -1
-      vertex 14.8775 16.244 -1
+      vertex -15.3431 -11.5169 6
+      vertex -15 -11.5 1
+      vertex -15.3431 -11.5169 1
     endloop
   endfacet
-  facet normal 0.595423 -0.803413 0
+  facet normal 0.14676 0.989172 -0
     outer loop
-      vertex 14.207 15.9663 -1
-      vertex 14.3055 16.0393 6
-      vertex 14.207 15.9663 6
+      vertex -14.3172 -11.5673 1
+      vertex -14.6569 -11.5169 6
+      vertex -14.3172 -11.5673 6
     endloop
   endfacet
-  facet normal 0.595423 -0.803413 0
+  facet normal 0.14676 0.989172 0
     outer loop
-      vertex 14.3055 16.0393 6
-      vertex 14.207 15.9663 -1
-      vertex 14.3055 16.0393 -1
+      vertex -14.6569 -11.5169 6
+      vertex -14.3172 -11.5673 1
+      vertex -14.6569 -11.5169 1
     endloop
   endfacet
-  facet normal 0.671617 -0.740898 0
+  facet normal 0.427661 0.903939 -0
     outer loop
-      vertex 14.1161 15.8839 -1
-      vertex 14.207 15.9663 6
-      vertex 14.1161 15.8839 6
+      vertex -13.3501 -11.9133 1
+      vertex -13.6606 -11.7664 6
+      vertex -13.3501 -11.9133 6
     endloop
   endfacet
-  facet normal 0.671617 -0.740898 0
+  facet normal 0.427661 0.903939 0
     outer loop
-      vertex 14.207 15.9663 6
-      vertex 14.1161 15.8839 -1
-      vertex 14.207 15.9663 -1
+      vertex -13.6606 -11.7664 6
+      vertex -13.3501 -11.9133 1
+      vertex -13.6606 -11.7664 1
     endloop
   endfacet
-  facet normal 0.514016 -0.85778 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex 14.3055 16.0393 -1
-      vertex 14.4108 16.1024 6
-      vertex 14.3055 16.0393 6
+      vertex -14.3172 -18.4327 1
+      vertex -13.984 -18.3493 6
+      vertex -14.3172 -18.4327 6
     endloop
   endfacet
-  facet normal 0.514016 -0.85778 0
+  facet normal 0.24281 -0.970074 0
     outer loop
-      vertex 14.4108 16.1024 6
-      vertex 14.3055 16.0393 -1
-      vertex 14.4108 16.1024 -1
+      vertex -13.984 -18.3493 6
+      vertex -14.3172 -18.4327 1
+      vertex -13.984 -18.3493 1
     endloop
   endfacet
-  facet normal 0.740898 -0.671617 0
+  facet normal 0.998789 0.0491971 0
     outer loop
-      vertex 14.0337 15.793 6
-      vertex 14.1161 15.8839 -1
-      vertex 14.1161 15.8839 6
+      vertex -11.5 -15 6
+      vertex -11.5169 -14.6569 1
+      vertex -11.5169 -14.6569 6
     endloop
   endfacet
-  facet normal 0.740898 -0.671617 0
+  facet normal 0.998789 0.0491971 0
     outer loop
-      vertex 14.1161 15.8839 -1
-      vertex 14.0337 15.793 6
-      vertex 14.0337 15.793 -1
+      vertex -11.5169 -14.6569 1
+      vertex -11.5 -15 6
+      vertex -11.5 -15 1
     endloop
   endfacet
-  facet normal -0.998803 -0.0489209 0
+  facet normal 0.514153 0.857698 -0
     outer loop
-      vertex 16.25 15 -1
-      vertex 16.244 15.1225 6
-      vertex 16.244 15.1225 -1
+      vertex -13.0555 -12.0899 1
+      vertex -13.3501 -11.9133 6
+      vertex -13.0555 -12.0899 6
     endloop
   endfacet
-  facet normal -0.998803 -0.0489209 0
+  facet normal 0.514153 0.857698 0
     outer loop
-      vertex 16.244 15.1225 6
-      vertex 16.25 15 -1
-      vertex 16.25 15 6
+      vertex -13.3501 -11.9133 6
+      vertex -13.0555 -12.0899 1
+      vertex -13.3501 -11.9133 1
     endloop
   endfacet
-  facet normal -0.146667 0.989186 0
+  facet normal -0.741046 -0.671454 0
     outer loop
-      vertex 15.2439 13.774 -1
-      vertex 15.1225 13.756 6
-      vertex 15.2439 13.774 6
+      vertex -17.4749 -17.4749 1
+      vertex -17.7055 -17.2204 6
+      vertex -17.7055 -17.2204 1
     endloop
   endfacet
-  facet normal -0.146667 0.989186 0
+  facet normal -0.741046 -0.671454 0
     outer loop
-      vertex 15.1225 13.756 6
-      vertex 15.2439 13.774 -1
-      vertex 15.1225 13.756 -1
+      vertex -17.7055 -17.2204 6
+      vertex -17.4749 -17.4749 1
+      vertex -17.4749 -17.4749 6
     endloop
   endfacet
-  facet normal -0.970047 0.242919 0
+  facet normal -0.671454 0.741046 0
     outer loop
-      vertex 16.1962 14.6371 -1
-      vertex 16.226 14.7561 6
-      vertex 16.226 14.7561 -1
+      vertex -17.2204 -12.2945 1
+      vertex -17.4749 -12.5251 6
+      vertex -17.2204 -12.2945 6
     endloop
   endfacet
-  facet normal -0.970047 0.242919 0
+  facet normal -0.671454 0.741046 0
     outer loop
-      vertex 16.226 14.7561 6
-      vertex 16.1962 14.6371 -1
-      vertex 16.1962 14.6371 6
+      vertex -17.4749 -12.5251 6
+      vertex -17.2204 -12.2945 1
+      vertex -17.4749 -12.5251 1
     endloop
   endfacet
-  facet normal -0.242919 0.970047 0
+  facet normal 0.741046 0.671454 0
     outer loop
-      vertex 15.3629 13.8038 -1
-      vertex 15.2439 13.774 6
-      vertex 15.3629 13.8038 6
+      vertex -12.2945 -12.7796 6
+      vertex -12.5251 -12.5251 1
+      vertex -12.5251 -12.5251 6
     endloop
   endfacet
-  facet normal -0.242919 0.970047 0
+  facet normal 0.741046 0.671454 0
     outer loop
-      vertex 15.2439 13.774 6
-      vertex 15.3629 13.8038 -1
-      vertex 15.2439 13.774 -1
+      vertex -12.5251 -12.5251 1
+      vertex -12.2945 -12.7796 6
+      vertex -12.2945 -12.7796 1
     endloop
   endfacet
-  facet normal -0.336698 0.941613 0
+  facet normal -0.14676 -0.989172 0
     outer loop
-      vertex 15.4784 13.8451 -1
-      vertex 15.3629 13.8038 6
-      vertex 15.4784 13.8451 6
+      vertex -15.6828 -18.4327 1
+      vertex -15.3431 -18.4831 6
+      vertex -15.6828 -18.4327 6
     endloop
   endfacet
-  facet normal -0.336698 0.941613 0
+  facet normal -0.14676 -0.989172 -0
     outer loop
-      vertex 15.3629 13.8038 6
-      vertex 15.4784 13.8451 -1
-      vertex 15.3629 13.8038 -1
+      vertex -15.3431 -18.4831 6
+      vertex -15.6828 -18.4327 1
+      vertex -15.3431 -18.4831 1
     endloop
   endfacet
-  facet normal -0.671617 0.740898 0
+  facet normal -0.427661 0.903939 0
     outer loop
-      vertex 15.8839 14.1161 -1
-      vertex 15.793 14.0337 6
-      vertex 15.8839 14.1161 6
+      vertex -16.3394 -11.7664 1
+      vertex -16.6499 -11.9133 6
+      vertex -16.3394 -11.7664 6
     endloop
   endfacet
-  facet normal -0.671617 0.740898 0
+  facet normal -0.427661 0.903939 0
     outer loop
-      vertex 15.793 14.0337 6
-      vertex 15.8839 14.1161 -1
-      vertex 15.793 14.0337 -1
+      vertex -16.6499 -11.9133 6
+      vertex -16.3394 -11.7664 1
+      vertex -16.6499 -11.9133 1
     endloop
   endfacet
-  facet normal -0.514016 0.85778 0
+  facet normal 0.989172 -0.14676 0
     outer loop
-      vertex 15.6945 13.9607 -1
-      vertex 15.5892 13.8976 6
-      vertex 15.6945 13.9607 6
+      vertex -11.5673 -15.6828 6
+      vertex -11.5169 -15.3431 1
+      vertex -11.5169 -15.3431 6
     endloop
   endfacet
-  facet normal -0.514016 0.85778 0
+  facet normal 0.989172 -0.14676 0
     outer loop
-      vertex 15.5892 13.8976 6
-      vertex 15.6945 13.9607 -1
-      vertex 15.5892 13.8976 -1
+      vertex -11.5169 -15.3431 1
+      vertex -11.5673 -15.6828 6
+      vertex -11.5673 -15.6828 1
     endloop
   endfacet
-  facet normal -0.0489209 0.998803 0
+  facet normal 0.970074 -0.24281 0
     outer loop
-      vertex 15.1225 13.756 -1
-      vertex 15 13.75 6
-      vertex 15.1225 13.756 6
+      vertex -11.6507 -16.016 6
+      vertex -11.5673 -15.6828 1
+      vertex -11.5673 -15.6828 6
     endloop
   endfacet
-  facet normal -0.0489209 0.998803 0
+  facet normal 0.970074 -0.24281 0
     outer loop
-      vertex 15 13.75 6
-      vertex 15.1225 13.756 -1
-      vertex 15 13.75 -1
+      vertex -11.5673 -15.6828 1
+      vertex -11.6507 -16.016 6
+      vertex -11.6507 -16.016 1
     endloop
   endfacet
-  facet normal 0.242919 0.970047 -0
+  facet normal -0.336853 0.941557 0
     outer loop
-      vertex 14.7561 13.774 -1
-      vertex 14.6371 13.8038 6
-      vertex 14.7561 13.774 6
+      vertex -16.016 -11.6507 1
+      vertex -16.3394 -11.7664 6
+      vertex -16.016 -11.6507 6
     endloop
   endfacet
-  facet normal 0.242919 0.970047 0
+  facet normal -0.336853 0.941557 0
     outer loop
-      vertex 14.6371 13.8038 6
-      vertex 14.7561 13.774 -1
-      vertex 14.6371 13.8038 -1
+      vertex -16.3394 -11.7664 6
+      vertex -16.016 -11.6507 1
+      vertex -16.3394 -11.7664 1
     endloop
   endfacet
-  facet normal 0.428192 0.903688 -0
+  facet normal -0.903939 0.427661 0
     outer loop
-      vertex 14.5216 13.8451 -1
-      vertex 14.4108 13.8976 6
-      vertex 14.5216 13.8451 6
+      vertex -18.2336 -13.6606 1
+      vertex -18.0867 -13.3501 6
+      vertex -18.0867 -13.3501 1
     endloop
   endfacet
-  facet normal 0.428192 0.903688 0
+  facet normal -0.903939 0.427661 0
     outer loop
-      vertex 14.4108 13.8976 6
-      vertex 14.5216 13.8451 -1
-      vertex 14.4108 13.8976 -1
+      vertex -18.0867 -13.3501 6
+      vertex -18.2336 -13.6606 1
+      vertex -18.2336 -13.6606 6
     endloop
   endfacet
-  facet normal 0.941613 0.336698 0
+  facet normal 0.514153 -0.857698 0
     outer loop
-      vertex 13.8451 14.5216 6
-      vertex 13.8038 14.6371 -1
-      vertex 13.8038 14.6371 6
+      vertex -13.3501 -18.0867 1
+      vertex -13.0555 -17.9101 6
+      vertex -13.3501 -18.0867 6
     endloop
   endfacet
-  facet normal 0.941613 0.336698 0
+  facet normal 0.514153 -0.857698 0
     outer loop
-      vertex 13.8038 14.6371 -1
-      vertex 13.8451 14.5216 6
-      vertex 13.8451 14.5216 -1
+      vertex -13.0555 -17.9101 6
+      vertex -13.3501 -18.0867 1
+      vertex -13.0555 -17.9101 1
     endloop
   endfacet
-  facet normal 0.989186 0.146667 0
+  facet normal -0.0491971 -0.998789 0
     outer loop
-      vertex 13.774 14.7561 6
-      vertex 13.756 14.8775 -1
-      vertex 13.756 14.8775 6
+      vertex -15.3431 -18.4831 1
+      vertex -15 -18.5 6
+      vertex -15.3431 -18.4831 6
     endloop
   endfacet
-  facet normal 0.989186 0.146667 0
+  facet normal -0.0491971 -0.998789 -0
     outer loop
-      vertex 13.756 14.8775 -1
-      vertex 13.774 14.7561 6
-      vertex 13.774 14.7561 -1
+      vertex -15 -18.5 6
+      vertex -15.3431 -18.4831 1
+      vertex -15 -18.5 1
     endloop
   endfacet
-  facet normal 0.740898 0.671617 0
+  facet normal 0.857698 -0.514153 0
     outer loop
-      vertex 14.1161 14.1161 6
-      vertex 14.0337 14.207 -1
-      vertex 14.0337 14.207 6
+      vertex -12.0899 -16.9445 6
+      vertex -11.9133 -16.6499 1
+      vertex -11.9133 -16.6499 6
     endloop
   endfacet
-  facet normal 0.740898 0.671617 0
+  facet normal 0.857698 -0.514153 0
     outer loop
-      vertex 14.0337 14.207 -1
-      vertex 14.1161 14.1161 6
-      vertex 14.1161 14.1161 -1
+      vertex -11.9133 -16.6499 1
+      vertex -12.0899 -16.9445 6
+      vertex -12.0899 -16.9445 1
     endloop
   endfacet
-  facet normal 0.85778 0.514016 0
+  facet normal 0.941557 -0.336853 0
     outer loop
-      vertex 13.9607 14.3055 6
-      vertex 13.8976 14.4108 -1
-      vertex 13.8976 14.4108 6
+      vertex -11.7664 -16.3394 6
+      vertex -11.6507 -16.016 1
+      vertex -11.6507 -16.016 6
     endloop
   endfacet
-  facet normal 0.85778 0.514016 0
+  facet normal 0.941557 -0.336853 0
     outer loop
-      vertex 13.8976 14.4108 -1
-      vertex 13.9607 14.3055 6
-      vertex 13.9607 14.3055 -1
+      vertex -11.6507 -16.016 1
+      vertex -11.7664 -16.3394 6
+      vertex -11.7664 -16.3394 1
     endloop
   endfacet
-  facet normal 0.671617 0.740898 -0
+  facet normal 0 0 1
     outer loop
-      vertex 14.207 14.0337 -1
-      vertex 14.1161 14.1161 6
-      vertex 14.207 14.0337 6
+      vertex -13.75 -15 6
+      vertex -11.5 -15 6
+      vertex -11.5169 -14.6569 6
     endloop
   endfacet
-  facet normal 0.671617 0.740898 0
-    outer loop
-      vertex 14.1161 14.1161 6
-      vertex 14.207 14.0337 -1
-      vertex 14.1161 14.1161 -1
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex 16.244 15.1225 -1
-      vertex 16.226 15.2439 6
-      vertex 16.226 15.2439 -1
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex 16.226 15.2439 6
-      vertex 16.244 15.1225 -1
-      vertex 16.244 15.1225 6
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 0
-    outer loop
-      vertex 15 16.25 -1
-      vertex 15.1225 16.244 6
-      vertex 15 16.25 6
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 -0
-    outer loop
-      vertex 15.1225 16.244 6
-      vertex 15 16.25 -1
-      vertex 15.1225 16.244 -1
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex 13.75 15 6
-      vertex 13.756 15.1225 -1
-      vertex 13.756 15.1225 6
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex 13.756 15.1225 -1
-      vertex 13.75 15 6
-      vertex 13.75 15 -1
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex 16.226 14.7561 -1
-      vertex 16.244 14.8775 6
-      vertex 16.244 14.8775 -1
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex 16.244 14.8775 6
-      vertex 16.226 14.7561 -1
-      vertex 16.226 14.7561 6
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex 16.1024 14.4108 -1
-      vertex 16.1549 14.5216 6
-      vertex 16.1549 14.5216 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex 16.1549 14.5216 6
-      vertex 16.1024 14.4108 -1
-      vertex 16.1024 14.4108 6
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex 16.0393 14.3055 -1
-      vertex 16.1024 14.4108 6
-      vertex 16.1024 14.4108 -1
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex 16.1024 14.4108 6
-      vertex 16.0393 14.3055 -1
-      vertex 16.0393 14.3055 6
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex 15.5892 13.8976 -1
-      vertex 15.4784 13.8451 6
-      vertex 15.5892 13.8976 6
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex 15.4784 13.8451 6
-      vertex 15.5892 13.8976 -1
-      vertex 15.4784 13.8451 -1
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex 15.8839 14.1161 -1
-      vertex 15.9663 14.207 6
-      vertex 15.9663 14.207 -1
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex 15.9663 14.207 6
-      vertex 15.8839 14.1161 -1
-      vertex 15.8839 14.1161 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex 15.793 14.0337 -1
-      vertex 15.6945 13.9607 6
-      vertex 15.793 14.0337 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex 15.6945 13.9607 6
-      vertex 15.793 14.0337 -1
-      vertex 15.6945 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 -0
-    outer loop
-      vertex 14.8775 13.756 -1
-      vertex 14.7561 13.774 6
-      vertex 14.8775 13.756 6
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 0
-    outer loop
-      vertex 14.7561 13.774 6
-      vertex 14.8775 13.756 -1
-      vertex 14.7561 13.774 -1
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 -0
-    outer loop
-      vertex 14.6371 13.8038 -1
-      vertex 14.5216 13.8451 6
-      vertex 14.6371 13.8038 6
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 0
-    outer loop
-      vertex 14.5216 13.8451 6
-      vertex 14.6371 13.8038 -1
-      vertex 14.5216 13.8451 -1
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 -0
-    outer loop
-      vertex 14.4108 13.8976 -1
-      vertex 14.3055 13.9607 6
-      vertex 14.4108 13.8976 6
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 0
-    outer loop
-      vertex 14.3055 13.9607 6
-      vertex 14.4108 13.8976 -1
-      vertex 14.3055 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex 13.8976 14.4108 6
-      vertex 13.8451 14.5216 -1
-      vertex 13.8451 14.5216 6
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex 13.8451 14.5216 -1
-      vertex 13.8976 14.4108 6
-      vertex 13.8976 14.4108 -1
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex 13.8038 14.6371 6
-      vertex 13.774 14.7561 -1
-      vertex 13.774 14.7561 6
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex 13.774 14.7561 -1
-      vertex 13.8038 14.6371 6
-      vertex 13.8038 14.6371 -1
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
-    outer loop
-      vertex 14.0337 14.207 6
-      vertex 13.9607 14.3055 -1
-      vertex 13.9607 14.3055 6
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
-    outer loop
-      vertex 13.9607 14.3055 -1
-      vertex 14.0337 14.207 6
-      vertex 14.0337 14.207 -1
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex -16.25 15 6
-      vertex -16.244 15.1225 -1
-      vertex -16.244 15.1225 6
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex -16.244 15.1225 -1
-      vertex -16.25 15 6
-      vertex -16.25 15 -1
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
-    outer loop
-      vertex -15.9663 14.207 6
-      vertex -16.0393 14.3055 -1
-      vertex -16.0393 14.3055 6
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
-    outer loop
-      vertex -16.0393 14.3055 -1
-      vertex -15.9663 14.207 6
-      vertex -15.9663 14.207 -1
-    endloop
-  endfacet
-  facet normal 0.941613 0.336698 0
-    outer loop
-      vertex -16.1549 14.5216 6
-      vertex -16.1962 14.6371 -1
-      vertex -16.1962 14.6371 6
-    endloop
-  endfacet
-  facet normal 0.941613 0.336698 0
-    outer loop
-      vertex -16.1962 14.6371 -1
-      vertex -16.1549 14.5216 6
-      vertex -16.1549 14.5216 -1
-    endloop
-  endfacet
-  facet normal 0.803413 -0.595423 0
-    outer loop
-      vertex -16.0393 15.6945 6
-      vertex -15.9663 15.793 -1
-      vertex -15.9663 15.793 6
-    endloop
-  endfacet
-  facet normal 0.803413 -0.595423 0
-    outer loop
-      vertex -15.9663 15.793 -1
-      vertex -16.0393 15.6945 6
-      vertex -16.0393 15.6945 -1
-    endloop
-  endfacet
-  facet normal -0.970047 0.242919 0
-    outer loop
-      vertex -13.8038 14.6371 -1
-      vertex -13.774 14.7561 6
-      vertex -13.774 14.7561 -1
-    endloop
-  endfacet
-  facet normal -0.970047 0.242919 0
-    outer loop
-      vertex -13.774 14.7561 6
-      vertex -13.8038 14.6371 -1
-      vertex -13.8038 14.6371 6
-    endloop
-  endfacet
-  facet normal -0.146667 -0.989186 0
-    outer loop
-      vertex -14.8775 16.244 -1
-      vertex -14.7561 16.226 6
-      vertex -14.8775 16.244 6
-    endloop
-  endfacet
-  facet normal -0.146667 -0.989186 -0
-    outer loop
-      vertex -14.7561 16.226 6
-      vertex -14.8775 16.244 -1
-      vertex -14.7561 16.226 -1
-    endloop
-  endfacet
-  facet normal 0.970047 -0.242919 0
-    outer loop
-      vertex -16.226 15.2439 6
-      vertex -16.1962 15.3629 -1
-      vertex -16.1962 15.3629 6
-    endloop
-  endfacet
-  facet normal 0.970047 -0.242919 0
-    outer loop
-      vertex -16.1962 15.3629 -1
-      vertex -16.226 15.2439 6
-      vertex -16.226 15.2439 -1
-    endloop
-  endfacet
-  facet normal -0.998803 -0.0489209 0
-    outer loop
-      vertex -13.75 15 -1
-      vertex -13.756 15.1225 6
-      vertex -13.756 15.1225 -1
-    endloop
-  endfacet
-  facet normal -0.998803 -0.0489209 0
-    outer loop
-      vertex -13.756 15.1225 6
-      vertex -13.75 15 -1
-      vertex -13.75 15 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex -14.207 14.0337 -1
-      vertex -14.3055 13.9607 6
-      vertex -14.207 14.0337 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex -14.3055 13.9607 6
-      vertex -14.207 14.0337 -1
-      vertex -14.3055 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0.428192 0.903688 -0
-    outer loop
-      vertex -15.4784 13.8451 -1
-      vertex -15.5892 13.8976 6
-      vertex -15.4784 13.8451 6
-    endloop
-  endfacet
-  facet normal 0.428192 0.903688 0
-    outer loop
-      vertex -15.5892 13.8976 6
-      vertex -15.4784 13.8451 -1
-      vertex -15.5892 13.8976 -1
-    endloop
-  endfacet
-  facet normal 0.989186 -0.146667 0
-    outer loop
-      vertex -16.244 15.1225 6
-      vertex -16.226 15.2439 -1
-      vertex -16.226 15.2439 6
-    endloop
-  endfacet
-  facet normal 0.989186 -0.146667 0
-    outer loop
-      vertex -16.226 15.2439 -1
-      vertex -16.244 15.1225 6
-      vertex -16.244 15.1225 -1
-    endloop
-  endfacet
-  facet normal 0.671617 -0.740898 0
-    outer loop
-      vertex -15.8839 15.8839 -1
-      vertex -15.793 15.9663 6
-      vertex -15.8839 15.8839 6
-    endloop
-  endfacet
-  facet normal 0.671617 -0.740898 0
-    outer loop
-      vertex -15.793 15.9663 6
-      vertex -15.8839 15.8839 -1
-      vertex -15.793 15.9663 -1
-    endloop
-  endfacet
-  facet normal 0.903688 -0.428192 0
-    outer loop
-      vertex -16.1549 15.4784 6
-      vertex -16.1024 15.5892 -1
-      vertex -16.1024 15.5892 6
-    endloop
-  endfacet
-  facet normal 0.903688 -0.428192 0
-    outer loop
-      vertex -16.1024 15.5892 -1
-      vertex -16.1549 15.4784 6
-      vertex -16.1549 15.4784 -1
-    endloop
-  endfacet
-  facet normal 0.336698 -0.941613 0
-    outer loop
-      vertex -15.4784 16.1549 -1
-      vertex -15.3629 16.1962 6
-      vertex -15.4784 16.1549 6
-    endloop
-  endfacet
-  facet normal 0.336698 -0.941613 0
-    outer loop
-      vertex -15.3629 16.1962 6
-      vertex -15.4784 16.1549 -1
-      vertex -15.3629 16.1962 -1
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489209 0
-    outer loop
-      vertex -13.756 14.8775 -1
-      vertex -13.75 15 6
-      vertex -13.75 15 -1
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489209 0
-    outer loop
-      vertex -13.75 15 6
-      vertex -13.756 14.8775 -1
-      vertex -13.756 14.8775 6
-    endloop
-  endfacet
-  facet normal -0.970047 -0.242919 0
-    outer loop
-      vertex -13.774 15.2439 -1
-      vertex -13.8038 15.3629 6
-      vertex -13.8038 15.3629 -1
-    endloop
-  endfacet
-  facet normal -0.970047 -0.242919 0
-    outer loop
-      vertex -13.8038 15.3629 6
-      vertex -13.774 15.2439 -1
-      vertex -13.774 15.2439 6
-    endloop
-  endfacet
-  facet normal 0.0489209 0.998803 -0
-    outer loop
-      vertex -15 13.75 -1
-      vertex -15.1225 13.756 6
-      vertex -15 13.75 6
-    endloop
-  endfacet
-  facet normal 0.0489209 0.998803 0
-    outer loop
-      vertex -15.1225 13.756 6
-      vertex -15 13.75 -1
-      vertex -15.1225 13.756 -1
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 -0
-    outer loop
-      vertex -15.5892 13.8976 -1
-      vertex -15.6945 13.9607 6
-      vertex -15.5892 13.8976 6
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 0
-    outer loop
-      vertex -15.6945 13.9607 6
-      vertex -15.5892 13.8976 -1
-      vertex -15.6945 13.9607 -1
-    endloop
-  endfacet
-  facet normal 0.671617 0.740898 -0
-    outer loop
-      vertex -15.793 14.0337 -1
-      vertex -15.8839 14.1161 6
-      vertex -15.793 14.0337 6
-    endloop
-  endfacet
-  facet normal 0.671617 0.740898 0
-    outer loop
-      vertex -15.8839 14.1161 6
-      vertex -15.793 14.0337 -1
-      vertex -15.8839 14.1161 -1
-    endloop
-  endfacet
-  facet normal 0.595423 0.803413 -0
-    outer loop
-      vertex -15.6945 13.9607 -1
-      vertex -15.793 14.0337 6
-      vertex -15.6945 13.9607 6
-    endloop
-  endfacet
-  facet normal 0.595423 0.803413 0
-    outer loop
-      vertex -15.793 14.0337 6
-      vertex -15.6945 13.9607 -1
-      vertex -15.793 14.0337 -1
-    endloop
-  endfacet
-  facet normal 0.85778 0.514016 0
-    outer loop
-      vertex -16.0393 14.3055 6
-      vertex -16.1024 14.4108 -1
-      vertex -16.1024 14.4108 6
-    endloop
-  endfacet
-  facet normal 0.85778 0.514016 0
-    outer loop
-      vertex -16.1024 14.4108 -1
-      vertex -16.0393 14.3055 6
-      vertex -16.0393 14.3055 -1
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex -16.1024 14.4108 6
-      vertex -16.1549 14.5216 -1
-      vertex -16.1549 14.5216 6
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex -16.1549 14.5216 -1
-      vertex -16.1024 14.4108 6
-      vertex -16.1024 14.4108 -1
-    endloop
-  endfacet
-  facet normal 0.989186 0.146667 0
-    outer loop
-      vertex -16.226 14.7561 6
-      vertex -16.244 14.8775 -1
-      vertex -16.244 14.8775 6
-    endloop
-  endfacet
-  facet normal 0.989186 0.146667 0
-    outer loop
-      vertex -16.244 14.8775 -1
-      vertex -16.226 14.7561 6
-      vertex -16.226 14.7561 -1
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489209 0
-    outer loop
-      vertex -16.244 14.8775 6
-      vertex -16.25 15 -1
-      vertex -16.25 15 6
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489209 0
-    outer loop
-      vertex -16.25 15 -1
-      vertex -16.244 14.8775 6
-      vertex -16.244 14.8775 -1
-    endloop
-  endfacet
-  facet normal 0.941613 -0.336698 0
-    outer loop
-      vertex -16.1962 15.3629 6
-      vertex -16.1549 15.4784 -1
-      vertex -16.1549 15.4784 6
-    endloop
-  endfacet
-  facet normal 0.941613 -0.336698 0
-    outer loop
-      vertex -16.1549 15.4784 -1
-      vertex -16.1962 15.3629 6
-      vertex -16.1962 15.3629 -1
-    endloop
-  endfacet
-  facet normal 0.85778 -0.514016 0
-    outer loop
-      vertex -16.1024 15.5892 6
-      vertex -16.0393 15.6945 -1
-      vertex -16.0393 15.6945 6
-    endloop
-  endfacet
-  facet normal 0.85778 -0.514016 0
-    outer loop
-      vertex -16.0393 15.6945 -1
-      vertex -16.1024 15.5892 6
-      vertex -16.1024 15.5892 -1
-    endloop
-  endfacet
-  facet normal 0.740898 -0.671617 0
-    outer loop
-      vertex -15.9663 15.793 6
-      vertex -15.8839 15.8839 -1
-      vertex -15.8839 15.8839 6
-    endloop
-  endfacet
-  facet normal 0.740898 -0.671617 0
-    outer loop
-      vertex -15.8839 15.8839 -1
-      vertex -15.9663 15.793 6
-      vertex -15.9663 15.793 -1
-    endloop
-  endfacet
-  facet normal 0.0489209 -0.998803 0
-    outer loop
-      vertex -15.1225 16.244 -1
-      vertex -15 16.25 6
-      vertex -15.1225 16.244 6
-    endloop
-  endfacet
-  facet normal 0.0489209 -0.998803 0
-    outer loop
-      vertex -15 16.25 6
-      vertex -15.1225 16.244 -1
-      vertex -15 16.25 -1
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 0
-    outer loop
-      vertex -15 16.25 -1
-      vertex -14.8775 16.244 6
-      vertex -15 16.25 6
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 -0
-    outer loop
-      vertex -14.8775 16.244 6
-      vertex -15 16.25 -1
-      vertex -14.8775 16.244 -1
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex -13.9607 14.3055 -1
-      vertex -13.8976 14.4108 6
-      vertex -13.8976 14.4108 -1
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex -13.8976 14.4108 6
-      vertex -13.9607 14.3055 -1
-      vertex -13.9607 14.3055 6
-    endloop
-  endfacet
-  facet normal -0.803413 0.595423 0
-    outer loop
-      vertex -14.0337 14.207 -1
-      vertex -13.9607 14.3055 6
-      vertex -13.9607 14.3055 -1
-    endloop
-  endfacet
-  facet normal -0.803413 0.595423 0
-    outer loop
-      vertex -13.9607 14.3055 6
-      vertex -14.0337 14.207 -1
-      vertex -14.0337 14.207 6
-    endloop
-  endfacet
-  facet normal -0.671617 0.740898 0
-    outer loop
-      vertex -14.1161 14.1161 -1
-      vertex -14.207 14.0337 6
-      vertex -14.1161 14.1161 6
-    endloop
-  endfacet
-  facet normal -0.671617 0.740898 0
-    outer loop
-      vertex -14.207 14.0337 6
-      vertex -14.1161 14.1161 -1
-      vertex -14.207 14.0337 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex -13.8976 14.4108 -1
-      vertex -13.8451 14.5216 6
-      vertex -13.8451 14.5216 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex -13.8451 14.5216 6
-      vertex -13.8976 14.4108 -1
-      vertex -13.8976 14.4108 6
-    endloop
-  endfacet
-  facet normal -0.941613 0.336698 0
-    outer loop
-      vertex -13.8451 14.5216 -1
-      vertex -13.8038 14.6371 6
-      vertex -13.8038 14.6371 -1
-    endloop
-  endfacet
-  facet normal -0.941613 0.336698 0
-    outer loop
-      vertex -13.8038 14.6371 6
-      vertex -13.8451 14.5216 -1
-      vertex -13.8451 14.5216 6
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex -13.756 15.1225 -1
-      vertex -13.774 15.2439 6
-      vertex -13.774 15.2439 -1
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex -13.774 15.2439 6
-      vertex -13.756 15.1225 -1
-      vertex -13.756 15.1225 6
-    endloop
-  endfacet
-  facet normal -0.803413 -0.595423 0
-    outer loop
-      vertex -13.9607 15.6945 -1
-      vertex -14.0337 15.793 6
-      vertex -14.0337 15.793 -1
-    endloop
-  endfacet
-  facet normal -0.803413 -0.595423 0
-    outer loop
-      vertex -14.0337 15.793 6
-      vertex -13.9607 15.6945 -1
-      vertex -13.9607 15.6945 6
-    endloop
-  endfacet
-  facet normal -0.428192 -0.903688 0
-    outer loop
-      vertex -14.5216 16.1549 -1
-      vertex -14.4108 16.1024 6
-      vertex -14.5216 16.1549 6
-    endloop
-  endfacet
-  facet normal -0.428192 -0.903688 -0
-    outer loop
-      vertex -14.4108 16.1024 6
-      vertex -14.5216 16.1549 -1
-      vertex -14.4108 16.1024 -1
-    endloop
-  endfacet
-  facet normal -0.595423 -0.803413 0
-    outer loop
-      vertex -14.3055 16.0393 -1
-      vertex -14.207 15.9663 6
-      vertex -14.3055 16.0393 6
-    endloop
-  endfacet
-  facet normal -0.595423 -0.803413 -0
-    outer loop
-      vertex -14.207 15.9663 6
-      vertex -14.3055 16.0393 -1
-      vertex -14.207 15.9663 -1
-    endloop
-  endfacet
-  facet normal -0.336698 -0.941613 0
-    outer loop
-      vertex -14.6371 16.1962 -1
-      vertex -14.5216 16.1549 6
-      vertex -14.6371 16.1962 6
-    endloop
-  endfacet
-  facet normal -0.336698 -0.941613 -0
-    outer loop
-      vertex -14.5216 16.1549 6
-      vertex -14.6371 16.1962 -1
-      vertex -14.5216 16.1549 -1
-    endloop
-  endfacet
-  facet normal -0.146667 0.989186 0
-    outer loop
-      vertex -14.7561 13.774 -1
-      vertex -14.8775 13.756 6
-      vertex -14.7561 13.774 6
-    endloop
-  endfacet
-  facet normal -0.146667 0.989186 0
-    outer loop
-      vertex -14.8775 13.756 6
-      vertex -14.7561 13.774 -1
-      vertex -14.8775 13.756 -1
-    endloop
-  endfacet
-  facet normal -0.242919 0.970047 0
-    outer loop
-      vertex -14.6371 13.8038 -1
-      vertex -14.7561 13.774 6
-      vertex -14.6371 13.8038 6
-    endloop
-  endfacet
-  facet normal -0.242919 0.970047 0
-    outer loop
-      vertex -14.7561 13.774 6
-      vertex -14.6371 13.8038 -1
-      vertex -14.7561 13.774 -1
-    endloop
-  endfacet
-  facet normal -0.514016 0.85778 0
-    outer loop
-      vertex -14.3055 13.9607 -1
-      vertex -14.4108 13.8976 6
-      vertex -14.3055 13.9607 6
-    endloop
-  endfacet
-  facet normal -0.514016 0.85778 0
-    outer loop
-      vertex -14.4108 13.8976 6
-      vertex -14.3055 13.9607 -1
-      vertex -14.4108 13.8976 -1
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex -14.4108 13.8976 -1
-      vertex -14.5216 13.8451 6
-      vertex -14.4108 13.8976 6
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex -14.5216 13.8451 6
-      vertex -14.4108 13.8976 -1
-      vertex -14.5216 13.8451 -1
-    endloop
-  endfacet
-  facet normal -0.336698 0.941613 0
-    outer loop
-      vertex -14.5216 13.8451 -1
-      vertex -14.6371 13.8038 6
-      vertex -14.5216 13.8451 6
-    endloop
-  endfacet
-  facet normal -0.336698 0.941613 0
-    outer loop
-      vertex -14.6371 13.8038 6
-      vertex -14.5216 13.8451 -1
-      vertex -14.6371 13.8038 -1
-    endloop
-  endfacet
-  facet normal 0.740898 0.671617 0
-    outer loop
-      vertex -15.8839 14.1161 6
-      vertex -15.9663 14.207 -1
-      vertex -15.9663 14.207 6
-    endloop
-  endfacet
-  facet normal 0.740898 0.671617 0
-    outer loop
-      vertex -15.9663 14.207 -1
-      vertex -15.8839 14.1161 6
-      vertex -15.8839 14.1161 -1
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex -16.1962 14.6371 6
-      vertex -16.226 14.7561 -1
-      vertex -16.226 14.7561 6
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex -16.226 14.7561 -1
-      vertex -16.1962 14.6371 6
-      vertex -16.1962 14.6371 -1
-    endloop
-  endfacet
-  facet normal 0.514016 -0.85778 0
-    outer loop
-      vertex -15.6945 16.0393 -1
-      vertex -15.5892 16.1024 6
-      vertex -15.6945 16.0393 6
-    endloop
-  endfacet
-  facet normal 0.514016 -0.85778 0
-    outer loop
-      vertex -15.5892 16.1024 6
-      vertex -15.6945 16.0393 -1
-      vertex -15.5892 16.1024 -1
-    endloop
-  endfacet
-  facet normal 0.242919 -0.970047 0
-    outer loop
-      vertex -15.3629 16.1962 -1
-      vertex -15.2439 16.226 6
-      vertex -15.3629 16.1962 6
-    endloop
-  endfacet
-  facet normal 0.242919 -0.970047 0
-    outer loop
-      vertex -15.2439 16.226 6
-      vertex -15.3629 16.1962 -1
-      vertex -15.2439 16.226 -1
-    endloop
-  endfacet
-  facet normal 0.146667 -0.989186 0
-    outer loop
-      vertex -15.2439 16.226 -1
-      vertex -15.1225 16.244 6
-      vertex -15.2439 16.226 6
-    endloop
-  endfacet
-  facet normal 0.146667 -0.989186 0
-    outer loop
-      vertex -15.1225 16.244 6
-      vertex -15.2439 16.226 -1
-      vertex -15.1225 16.244 -1
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex -14.1161 14.1161 -1
-      vertex -14.0337 14.207 6
-      vertex -14.0337 14.207 -1
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex -14.0337 14.207 6
-      vertex -14.1161 14.1161 -1
-      vertex -14.1161 14.1161 6
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex -13.774 14.7561 -1
-      vertex -13.756 14.8775 6
-      vertex -13.756 14.8775 -1
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex -13.756 14.8775 6
-      vertex -13.774 14.7561 -1
-      vertex -13.774 14.7561 6
-    endloop
-  endfacet
-  facet normal -0.941613 -0.336698 0
-    outer loop
-      vertex -13.8038 15.3629 -1
-      vertex -13.8451 15.4784 6
-      vertex -13.8451 15.4784 -1
-    endloop
-  endfacet
-  facet normal -0.941613 -0.336698 0
-    outer loop
-      vertex -13.8451 15.4784 6
-      vertex -13.8038 15.3629 -1
-      vertex -13.8038 15.3629 6
-    endloop
-  endfacet
-  facet normal -0.671617 -0.740898 0
-    outer loop
-      vertex -14.207 15.9663 -1
-      vertex -14.1161 15.8839 6
-      vertex -14.207 15.9663 6
-    endloop
-  endfacet
-  facet normal -0.671617 -0.740898 -0
-    outer loop
-      vertex -14.1161 15.8839 6
-      vertex -14.207 15.9663 -1
-      vertex -14.1161 15.8839 -1
-    endloop
-  endfacet
-  facet normal -0.242919 -0.970047 0
-    outer loop
-      vertex -14.7561 16.226 -1
-      vertex -14.6371 16.1962 6
-      vertex -14.7561 16.226 6
-    endloop
-  endfacet
-  facet normal -0.242919 -0.970047 -0
-    outer loop
-      vertex -14.6371 16.1962 6
-      vertex -14.7561 16.226 -1
-      vertex -14.6371 16.1962 -1
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 -0
-    outer loop
-      vertex -15.1225 13.756 -1
-      vertex -15.2439 13.774 6
-      vertex -15.1225 13.756 6
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 0
-    outer loop
-      vertex -15.2439 13.774 6
-      vertex -15.1225 13.756 -1
-      vertex -15.2439 13.774 -1
-    endloop
-  endfacet
-  facet normal 0.242919 0.970047 -0
-    outer loop
-      vertex -15.2439 13.774 -1
-      vertex -15.3629 13.8038 6
-      vertex -15.2439 13.774 6
-    endloop
-  endfacet
-  facet normal 0.242919 0.970047 0
-    outer loop
-      vertex -15.3629 13.8038 6
-      vertex -15.2439 13.774 -1
-      vertex -15.3629 13.8038 -1
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 -0
-    outer loop
-      vertex -15.3629 13.8038 -1
-      vertex -15.4784 13.8451 6
-      vertex -15.3629 13.8038 6
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 0
-    outer loop
-      vertex -15.4784 13.8451 6
-      vertex -15.3629 13.8038 -1
-      vertex -15.4784 13.8451 -1
-    endloop
-  endfacet
-  facet normal -0.0489209 0.998803 0
-    outer loop
-      vertex -14.8775 13.756 -1
-      vertex -15 13.75 6
-      vertex -14.8775 13.756 6
-    endloop
-  endfacet
-  facet normal -0.0489209 0.998803 0
-    outer loop
-      vertex -15 13.75 6
-      vertex -14.8775 13.756 -1
-      vertex -15 13.75 -1
-    endloop
-  endfacet
-  facet normal 0.595423 -0.803413 0
-    outer loop
-      vertex -15.793 15.9663 -1
-      vertex -15.6945 16.0393 6
-      vertex -15.793 15.9663 6
-    endloop
-  endfacet
-  facet normal 0.595423 -0.803413 0
-    outer loop
-      vertex -15.6945 16.0393 6
-      vertex -15.793 15.9663 -1
-      vertex -15.6945 16.0393 -1
-    endloop
-  endfacet
-  facet normal 0.428192 -0.903688 0
-    outer loop
-      vertex -15.5892 16.1024 -1
-      vertex -15.4784 16.1549 6
-      vertex -15.5892 16.1024 6
-    endloop
-  endfacet
-  facet normal 0.428192 -0.903688 0
-    outer loop
-      vertex -15.4784 16.1549 6
-      vertex -15.5892 16.1024 -1
-      vertex -15.4784 16.1549 -1
-    endloop
-  endfacet
-  facet normal -0.85778 -0.514016 0
-    outer loop
-      vertex -13.8976 15.5892 -1
-      vertex -13.9607 15.6945 6
-      vertex -13.9607 15.6945 -1
-    endloop
-  endfacet
-  facet normal -0.85778 -0.514016 0
-    outer loop
-      vertex -13.9607 15.6945 6
-      vertex -13.8976 15.5892 -1
-      vertex -13.8976 15.5892 6
-    endloop
-  endfacet
-  facet normal -0.903688 -0.428192 0
-    outer loop
-      vertex -13.8451 15.4784 -1
-      vertex -13.8976 15.5892 6
-      vertex -13.8976 15.5892 -1
-    endloop
-  endfacet
-  facet normal -0.903688 -0.428192 0
-    outer loop
-      vertex -13.8976 15.5892 6
-      vertex -13.8451 15.4784 -1
-      vertex -13.8451 15.4784 6
-    endloop
-  endfacet
-  facet normal -0.740898 -0.671617 0
-    outer loop
-      vertex -14.0337 15.793 -1
-      vertex -14.1161 15.8839 6
-      vertex -14.1161 15.8839 -1
-    endloop
-  endfacet
-  facet normal -0.740898 -0.671617 0
-    outer loop
-      vertex -14.1161 15.8839 6
-      vertex -14.0337 15.793 -1
-      vertex -14.0337 15.793 6
-    endloop
-  endfacet
-  facet normal -0.514016 -0.85778 0
-    outer loop
-      vertex -14.4108 16.1024 -1
-      vertex -14.3055 16.0393 6
-      vertex -14.4108 16.1024 6
-    endloop
-  endfacet
-  facet normal -0.514016 -0.85778 -0
-    outer loop
-      vertex -14.3055 16.0393 6
-      vertex -14.4108 16.1024 -1
-      vertex -14.3055 16.0393 -1
-    endloop
-  endfacet
-  facet normal -0.970047 -0.242919 0
-    outer loop
-      vertex 16.226 -14.7561 -1
-      vertex 16.1962 -14.6371 6
-      vertex 16.1962 -14.6371 -1
-    endloop
-  endfacet
-  facet normal -0.970047 -0.242919 0
-    outer loop
-      vertex 16.1962 -14.6371 6
-      vertex 16.226 -14.7561 -1
-      vertex 16.226 -14.7561 6
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex 16.226 -15.2439 -1
-      vertex 16.244 -15.1225 6
-      vertex 16.244 -15.1225 -1
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex 16.244 -15.1225 6
-      vertex 16.226 -15.2439 -1
-      vertex 16.226 -15.2439 6
-    endloop
-  endfacet
-  facet normal -0.85778 -0.514016 0
-    outer loop
-      vertex 16.1024 -14.4108 -1
-      vertex 16.0393 -14.3055 6
-      vertex 16.0393 -14.3055 -1
-    endloop
-  endfacet
-  facet normal -0.85778 -0.514016 0
-    outer loop
-      vertex 16.0393 -14.3055 6
-      vertex 16.1024 -14.4108 -1
-      vertex 16.1024 -14.4108 6
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex 15.5892 -16.1024 -1
-      vertex 15.4784 -16.1549 6
-      vertex 15.5892 -16.1024 6
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex 15.4784 -16.1549 6
-      vertex 15.5892 -16.1024 -1
-      vertex 15.4784 -16.1549 -1
-    endloop
-  endfacet
-  facet normal 0.941613 -0.336698 0
-    outer loop
-      vertex 13.8038 -14.6371 6
-      vertex 13.8451 -14.5216 -1
-      vertex 13.8451 -14.5216 6
-    endloop
-  endfacet
-  facet normal 0.941613 -0.336698 0
-    outer loop
-      vertex 13.8451 -14.5216 -1
-      vertex 13.8038 -14.6371 6
-      vertex 13.8038 -14.6371 -1
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 -0
-    outer loop
-      vertex 14.6371 -16.1962 -1
-      vertex 14.5216 -16.1549 6
-      vertex 14.6371 -16.1962 6
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 0
-    outer loop
-      vertex 14.5216 -16.1549 6
-      vertex 14.6371 -16.1962 -1
-      vertex 14.5216 -16.1549 -1
-    endloop
-  endfacet
-  facet normal 0.428192 -0.903688 0
-    outer loop
-      vertex 14.4108 -13.8976 -1
-      vertex 14.5216 -13.8451 6
-      vertex 14.4108 -13.8976 6
-    endloop
-  endfacet
-  facet normal 0.428192 -0.903688 0
-    outer loop
-      vertex 14.5216 -13.8451 6
-      vertex 14.4108 -13.8976 -1
-      vertex 14.5216 -13.8451 -1
-    endloop
-  endfacet
-  facet normal -0.595423 -0.803413 0
-    outer loop
-      vertex 15.6945 -13.9607 -1
-      vertex 15.793 -14.0337 6
-      vertex 15.6945 -13.9607 6
-    endloop
-  endfacet
-  facet normal -0.595423 -0.803413 -0
-    outer loop
-      vertex 15.793 -14.0337 6
-      vertex 15.6945 -13.9607 -1
-      vertex 15.793 -14.0337 -1
-    endloop
-  endfacet
-  facet normal -0.336698 -0.941613 0
-    outer loop
-      vertex 15.3629 -13.8038 -1
-      vertex 15.4784 -13.8451 6
-      vertex 15.3629 -13.8038 6
-    endloop
-  endfacet
-  facet normal -0.336698 -0.941613 -0
-    outer loop
-      vertex 15.4784 -13.8451 6
-      vertex 15.3629 -13.8038 -1
-      vertex 15.4784 -13.8451 -1
-    endloop
-  endfacet
-  facet normal -0.998803 -0.0489209 0
-    outer loop
-      vertex 16.25 -15 -1
-      vertex 16.244 -14.8775 6
-      vertex 16.244 -14.8775 -1
-    endloop
-  endfacet
-  facet normal -0.998803 -0.0489209 0
-    outer loop
-      vertex 16.244 -14.8775 6
-      vertex 16.25 -15 -1
-      vertex 16.25 -15 6
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489209 0
-    outer loop
-      vertex 16.244 -15.1225 -1
-      vertex 16.25 -15 6
-      vertex 16.25 -15 -1
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489209 0
-    outer loop
-      vertex 16.25 -15 6
-      vertex 16.244 -15.1225 -1
-      vertex 16.244 -15.1225 6
-    endloop
-  endfacet
-  facet normal -0.941613 0.336698 0
-    outer loop
-      vertex 16.1549 -15.4784 -1
-      vertex 16.1962 -15.3629 6
-      vertex 16.1962 -15.3629 -1
-    endloop
-  endfacet
-  facet normal -0.941613 0.336698 0
-    outer loop
-      vertex 16.1962 -15.3629 6
-      vertex 16.1549 -15.4784 -1
-      vertex 16.1549 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0.0489209 0.998803 -0
-    outer loop
-      vertex 15 -16.25 -1
-      vertex 14.8775 -16.244 6
-      vertex 15 -16.25 6
-    endloop
-  endfacet
-  facet normal 0.0489209 0.998803 0
-    outer loop
-      vertex 14.8775 -16.244 6
-      vertex 15 -16.25 -1
-      vertex 14.8775 -16.244 -1
-    endloop
-  endfacet
-  facet normal -0.336698 0.941613 0
-    outer loop
-      vertex 15.4784 -16.1549 -1
-      vertex 15.3629 -16.1962 6
-      vertex 15.4784 -16.1549 6
-    endloop
-  endfacet
-  facet normal -0.336698 0.941613 0
-    outer loop
-      vertex 15.3629 -16.1962 6
-      vertex 15.4784 -16.1549 -1
-      vertex 15.3629 -16.1962 -1
-    endloop
-  endfacet
-  facet normal 0.595423 0.803413 -0
-    outer loop
-      vertex 14.3055 -16.0393 -1
-      vertex 14.207 -15.9663 6
-      vertex 14.3055 -16.0393 6
-    endloop
-  endfacet
-  facet normal 0.595423 0.803413 0
-    outer loop
-      vertex 14.207 -15.9663 6
-      vertex 14.3055 -16.0393 -1
-      vertex 14.207 -15.9663 -1
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex 13.8038 -15.3629 6
-      vertex 13.774 -15.2439 -1
-      vertex 13.774 -15.2439 6
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex 13.774 -15.2439 -1
-      vertex 13.8038 -15.3629 6
-      vertex 13.8038 -15.3629 -1
-    endloop
-  endfacet
-  facet normal -0.428192 -0.903688 0
-    outer loop
-      vertex 15.4784 -13.8451 -1
-      vertex 15.5892 -13.8976 6
-      vertex 15.4784 -13.8451 6
-    endloop
-  endfacet
-  facet normal -0.428192 -0.903688 -0
-    outer loop
-      vertex 15.5892 -13.8976 6
-      vertex 15.4784 -13.8451 -1
-      vertex 15.5892 -13.8976 -1
-    endloop
-  endfacet
-  facet normal -0.671617 -0.740898 0
-    outer loop
-      vertex 15.793 -14.0337 -1
-      vertex 15.8839 -14.1161 6
-      vertex 15.793 -14.0337 6
-    endloop
-  endfacet
-  facet normal -0.671617 -0.740898 -0
-    outer loop
-      vertex 15.8839 -14.1161 6
-      vertex 15.793 -14.0337 -1
-      vertex 15.8839 -14.1161 -1
-    endloop
-  endfacet
-  facet normal -0.941613 -0.336698 0
-    outer loop
-      vertex 16.1962 -14.6371 -1
-      vertex 16.1549 -14.5216 6
-      vertex 16.1549 -14.5216 -1
-    endloop
-  endfacet
-  facet normal -0.941613 -0.336698 0
-    outer loop
-      vertex 16.1549 -14.5216 6
-      vertex 16.1962 -14.6371 -1
-      vertex 16.1962 -14.6371 6
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex 16.244 -14.8775 -1
-      vertex 16.226 -14.7561 6
-      vertex 16.226 -14.7561 -1
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex 16.226 -14.7561 6
-      vertex 16.244 -14.8775 -1
-      vertex 16.244 -14.8775 6
-    endloop
-  endfacet
-  facet normal -0.970047 0.242919 0
-    outer loop
-      vertex 16.1962 -15.3629 -1
-      vertex 16.226 -15.2439 6
-      vertex 16.226 -15.2439 -1
-    endloop
-  endfacet
-  facet normal -0.970047 0.242919 0
-    outer loop
-      vertex 16.226 -15.2439 6
-      vertex 16.1962 -15.3629 -1
-      vertex 16.1962 -15.3629 6
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex 15.8839 -15.8839 -1
-      vertex 15.9663 -15.793 6
-      vertex 15.9663 -15.793 -1
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex 15.9663 -15.793 6
-      vertex 15.8839 -15.8839 -1
-      vertex 15.8839 -15.8839 6
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex 16.0393 -15.6945 -1
-      vertex 16.1024 -15.5892 6
-      vertex 16.1024 -15.5892 -1
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex 16.1024 -15.5892 6
-      vertex 16.0393 -15.6945 -1
-      vertex 16.0393 -15.6945 6
-    endloop
-  endfacet
-  facet normal -0.803413 0.595423 0
-    outer loop
-      vertex 15.9663 -15.793 -1
-      vertex 16.0393 -15.6945 6
-      vertex 16.0393 -15.6945 -1
-    endloop
-  endfacet
-  facet normal -0.803413 0.595423 0
-    outer loop
-      vertex 16.0393 -15.6945 6
-      vertex 15.9663 -15.793 -1
-      vertex 15.9663 -15.793 6
-    endloop
-  endfacet
-  facet normal -0.0489209 0.998803 0
-    outer loop
-      vertex 15.1225 -16.244 -1
-      vertex 15 -16.25 6
-      vertex 15.1225 -16.244 6
-    endloop
-  endfacet
-  facet normal -0.0489209 0.998803 0
-    outer loop
-      vertex 15 -16.25 6
-      vertex 15.1225 -16.244 -1
-      vertex 15 -16.25 -1
-    endloop
-  endfacet
-  facet normal 0.740898 -0.671617 0
-    outer loop
-      vertex 14.0337 -14.207 6
-      vertex 14.1161 -14.1161 -1
-      vertex 14.1161 -14.1161 6
-    endloop
-  endfacet
-  facet normal 0.740898 -0.671617 0
-    outer loop
-      vertex 14.1161 -14.1161 -1
-      vertex 14.0337 -14.207 6
-      vertex 14.0337 -14.207 -1
-    endloop
-  endfacet
-  facet normal 0.803413 -0.595423 0
-    outer loop
-      vertex 13.9607 -14.3055 6
-      vertex 14.0337 -14.207 -1
-      vertex 14.0337 -14.207 6
-    endloop
-  endfacet
-  facet normal 0.803413 -0.595423 0
-    outer loop
-      vertex 14.0337 -14.207 -1
-      vertex 13.9607 -14.3055 6
-      vertex 13.9607 -14.3055 -1
-    endloop
-  endfacet
-  facet normal 0.671617 -0.740898 0
-    outer loop
-      vertex 14.1161 -14.1161 -1
-      vertex 14.207 -14.0337 6
-      vertex 14.1161 -14.1161 6
-    endloop
-  endfacet
-  facet normal 0.671617 -0.740898 0
-    outer loop
-      vertex 14.207 -14.0337 6
-      vertex 14.1161 -14.1161 -1
-      vertex 14.207 -14.0337 -1
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
-    outer loop
-      vertex 14.0337 -15.793 6
-      vertex 13.9607 -15.6945 -1
-      vertex 13.9607 -15.6945 6
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
-    outer loop
-      vertex 13.9607 -15.6945 -1
-      vertex 14.0337 -15.793 6
-      vertex 14.0337 -15.793 -1
-    endloop
-  endfacet
-  facet normal 0.671617 0.740898 -0
-    outer loop
-      vertex 14.207 -15.9663 -1
-      vertex 14.1161 -15.8839 6
-      vertex 14.207 -15.9663 6
-    endloop
-  endfacet
-  facet normal 0.671617 0.740898 0
-    outer loop
-      vertex 14.1161 -15.8839 6
-      vertex 14.207 -15.9663 -1
-      vertex 14.1161 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489209 0
-    outer loop
-      vertex 13.756 -15.1225 6
-      vertex 13.75 -15 -1
-      vertex 13.75 -15 6
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489209 0
-    outer loop
-      vertex 13.75 -15 -1
-      vertex 13.756 -15.1225 6
-      vertex 13.756 -15.1225 -1
-    endloop
-  endfacet
-  facet normal 0.989186 0.146667 0
-    outer loop
-      vertex 13.774 -15.2439 6
-      vertex 13.756 -15.1225 -1
-      vertex 13.756 -15.1225 6
-    endloop
-  endfacet
-  facet normal 0.989186 0.146667 0
-    outer loop
-      vertex 13.756 -15.1225 -1
-      vertex 13.774 -15.2439 6
-      vertex 13.774 -15.2439 -1
-    endloop
-  endfacet
-  facet normal 0.0489209 -0.998803 0
-    outer loop
-      vertex 14.8775 -13.756 -1
-      vertex 15 -13.75 6
-      vertex 14.8775 -13.756 6
-    endloop
-  endfacet
-  facet normal 0.0489209 -0.998803 0
-    outer loop
-      vertex 15 -13.75 6
-      vertex 14.8775 -13.756 -1
-      vertex 15 -13.75 -1
-    endloop
-  endfacet
-  facet normal -0.146667 -0.989186 0
-    outer loop
-      vertex 15.1225 -13.756 -1
-      vertex 15.2439 -13.774 6
-      vertex 15.1225 -13.756 6
-    endloop
-  endfacet
-  facet normal -0.146667 -0.989186 -0
-    outer loop
-      vertex 15.2439 -13.774 6
-      vertex 15.1225 -13.756 -1
-      vertex 15.2439 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0.336698 -0.941613 0
-    outer loop
-      vertex 14.5216 -13.8451 -1
-      vertex 14.6371 -13.8038 6
-      vertex 14.5216 -13.8451 6
-    endloop
-  endfacet
-  facet normal 0.336698 -0.941613 0
-    outer loop
-      vertex 14.6371 -13.8038 6
-      vertex 14.5216 -13.8451 -1
-      vertex 14.6371 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0.595423 -0.803413 0
-    outer loop
-      vertex 14.207 -14.0337 -1
-      vertex 14.3055 -13.9607 6
-      vertex 14.207 -14.0337 6
-    endloop
-  endfacet
-  facet normal 0.595423 -0.803413 0
-    outer loop
-      vertex 14.3055 -13.9607 6
-      vertex 14.207 -14.0337 -1
-      vertex 14.3055 -13.9607 -1
-    endloop
-  endfacet
-  facet normal -0.514016 -0.85778 0
-    outer loop
-      vertex 15.5892 -13.8976 -1
-      vertex 15.6945 -13.9607 6
-      vertex 15.5892 -13.8976 6
-    endloop
-  endfacet
-  facet normal -0.514016 -0.85778 -0
-    outer loop
-      vertex 15.6945 -13.9607 6
-      vertex 15.5892 -13.8976 -1
-      vertex 15.6945 -13.9607 -1
-    endloop
-  endfacet
-  facet normal -0.740898 -0.671617 0
-    outer loop
-      vertex 15.9663 -14.207 -1
-      vertex 15.8839 -14.1161 6
-      vertex 15.8839 -14.1161 -1
-    endloop
-  endfacet
-  facet normal -0.740898 -0.671617 0
-    outer loop
-      vertex 15.8839 -14.1161 6
-      vertex 15.9663 -14.207 -1
-      vertex 15.9663 -14.207 6
-    endloop
-  endfacet
-  facet normal -0.803413 -0.595423 0
-    outer loop
-      vertex 16.0393 -14.3055 -1
-      vertex 15.9663 -14.207 6
-      vertex 15.9663 -14.207 -1
-    endloop
-  endfacet
-  facet normal -0.803413 -0.595423 0
-    outer loop
-      vertex 15.9663 -14.207 6
-      vertex 16.0393 -14.3055 -1
-      vertex 16.0393 -14.3055 6
-    endloop
-  endfacet
-  facet normal -0.903688 -0.428192 0
-    outer loop
-      vertex 16.1549 -14.5216 -1
-      vertex 16.1024 -14.4108 6
-      vertex 16.1024 -14.4108 -1
-    endloop
-  endfacet
-  facet normal -0.903688 -0.428192 0
-    outer loop
-      vertex 16.1024 -14.4108 6
-      vertex 16.1549 -14.5216 -1
-      vertex 16.1549 -14.5216 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex 15.793 -15.9663 -1
-      vertex 15.6945 -16.0393 6
-      vertex 15.793 -15.9663 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex 15.6945 -16.0393 6
-      vertex 15.793 -15.9663 -1
-      vertex 15.6945 -16.0393 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex 16.1024 -15.5892 -1
-      vertex 16.1549 -15.4784 6
-      vertex 16.1549 -15.4784 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex 16.1549 -15.4784 6
-      vertex 16.1024 -15.5892 -1
-      vertex 16.1024 -15.5892 6
-    endloop
-  endfacet
-  facet normal -0.242919 0.970047 0
-    outer loop
-      vertex 15.3629 -16.1962 -1
-      vertex 15.2439 -16.226 6
-      vertex 15.3629 -16.1962 6
-    endloop
-  endfacet
-  facet normal -0.242919 0.970047 0
-    outer loop
-      vertex 15.2439 -16.226 6
-      vertex 15.3629 -16.1962 -1
-      vertex 15.2439 -16.226 -1
-    endloop
-  endfacet
-  facet normal -0.146667 0.989186 0
-    outer loop
-      vertex 15.2439 -16.226 -1
-      vertex 15.1225 -16.244 6
-      vertex 15.2439 -16.226 6
-    endloop
-  endfacet
-  facet normal -0.146667 0.989186 0
-    outer loop
-      vertex 15.1225 -16.244 6
-      vertex 15.2439 -16.226 -1
-      vertex 15.1225 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0.989186 -0.146667 0
-    outer loop
-      vertex 13.756 -14.8775 6
-      vertex 13.774 -14.7561 -1
-      vertex 13.774 -14.7561 6
-    endloop
-  endfacet
-  facet normal 0.989186 -0.146667 0
-    outer loop
-      vertex 13.774 -14.7561 -1
-      vertex 13.756 -14.8775 6
-      vertex 13.756 -14.8775 -1
-    endloop
-  endfacet
-  facet normal 0.970047 -0.242919 0
-    outer loop
-      vertex 13.774 -14.7561 6
-      vertex 13.8038 -14.6371 -1
-      vertex 13.8038 -14.6371 6
-    endloop
-  endfacet
-  facet normal 0.970047 -0.242919 0
-    outer loop
-      vertex 13.8038 -14.6371 -1
-      vertex 13.774 -14.7561 6
-      vertex 13.774 -14.7561 -1
-    endloop
-  endfacet
-  facet normal 0.903688 -0.428192 0
-    outer loop
-      vertex 13.8451 -14.5216 6
-      vertex 13.8976 -14.4108 -1
-      vertex 13.8976 -14.4108 6
-    endloop
-  endfacet
-  facet normal 0.903688 -0.428192 0
-    outer loop
-      vertex 13.8976 -14.4108 -1
-      vertex 13.8451 -14.5216 6
-      vertex 13.8451 -14.5216 -1
-    endloop
-  endfacet
-  facet normal 0.85778 -0.514016 0
-    outer loop
-      vertex 13.8976 -14.4108 6
-      vertex 13.9607 -14.3055 -1
-      vertex 13.9607 -14.3055 6
-    endloop
-  endfacet
-  facet normal 0.85778 -0.514016 0
-    outer loop
-      vertex 13.9607 -14.3055 -1
-      vertex 13.8976 -14.4108 6
-      vertex 13.8976 -14.4108 -1
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 -0
-    outer loop
-      vertex 14.4108 -16.1024 -1
-      vertex 14.3055 -16.0393 6
-      vertex 14.4108 -16.1024 6
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 0
-    outer loop
-      vertex 14.3055 -16.0393 6
-      vertex 14.4108 -16.1024 -1
-      vertex 14.3055 -16.0393 -1
-    endloop
-  endfacet
-  facet normal 0.242919 0.970047 -0
-    outer loop
-      vertex 14.7561 -16.226 -1
-      vertex 14.6371 -16.1962 6
-      vertex 14.7561 -16.226 6
-    endloop
-  endfacet
-  facet normal 0.242919 0.970047 0
-    outer loop
-      vertex 14.6371 -16.1962 6
-      vertex 14.7561 -16.226 -1
-      vertex 14.6371 -16.1962 -1
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex 13.75 -15 6
-      vertex 13.756 -14.8775 -1
-      vertex 13.756 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex 13.756 -14.8775 -1
-      vertex 13.75 -15 6
-      vertex 13.75 -15 -1
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex 13.8976 -15.5892 6
-      vertex 13.8451 -15.4784 -1
-      vertex 13.8451 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex 13.8451 -15.4784 -1
-      vertex 13.8976 -15.5892 6
-      vertex 13.8976 -15.5892 -1
-    endloop
-  endfacet
-  facet normal 0.941613 0.336698 0
-    outer loop
-      vertex 13.8451 -15.4784 6
-      vertex 13.8038 -15.3629 -1
-      vertex 13.8038 -15.3629 6
-    endloop
-  endfacet
-  facet normal 0.941613 0.336698 0
-    outer loop
-      vertex 13.8038 -15.3629 -1
-      vertex 13.8451 -15.4784 6
-      vertex 13.8451 -15.4784 -1
-    endloop
-  endfacet
-  facet normal 0.85778 0.514016 0
-    outer loop
-      vertex 13.9607 -15.6945 6
-      vertex 13.8976 -15.5892 -1
-      vertex 13.8976 -15.5892 6
-    endloop
-  endfacet
-  facet normal 0.85778 0.514016 0
-    outer loop
-      vertex 13.8976 -15.5892 -1
-      vertex 13.9607 -15.6945 6
-      vertex 13.9607 -15.6945 -1
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 0
-    outer loop
-      vertex 15 -13.75 -1
-      vertex 15.1225 -13.756 6
-      vertex 15 -13.75 6
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 -0
-    outer loop
-      vertex 15.1225 -13.756 6
-      vertex 15 -13.75 -1
-      vertex 15.1225 -13.756 -1
-    endloop
-  endfacet
-  facet normal -0.242919 -0.970047 0
-    outer loop
-      vertex 15.2439 -13.774 -1
-      vertex 15.3629 -13.8038 6
-      vertex 15.2439 -13.774 6
-    endloop
-  endfacet
-  facet normal -0.242919 -0.970047 -0
-    outer loop
-      vertex 15.3629 -13.8038 6
-      vertex 15.2439 -13.774 -1
-      vertex 15.3629 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0.242919 -0.970047 0
-    outer loop
-      vertex 14.6371 -13.8038 -1
-      vertex 14.7561 -13.774 6
-      vertex 14.6371 -13.8038 6
-    endloop
-  endfacet
-  facet normal 0.242919 -0.970047 0
-    outer loop
-      vertex 14.7561 -13.774 6
-      vertex 14.6371 -13.8038 -1
-      vertex 14.7561 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0.146667 -0.989186 0
-    outer loop
-      vertex 14.7561 -13.774 -1
-      vertex 14.8775 -13.756 6
-      vertex 14.7561 -13.774 6
-    endloop
-  endfacet
-  facet normal 0.146667 -0.989186 0
-    outer loop
-      vertex 14.8775 -13.756 6
-      vertex 14.7561 -13.774 -1
-      vertex 14.8775 -13.756 -1
-    endloop
-  endfacet
-  facet normal 0.514016 -0.85778 0
-    outer loop
-      vertex 14.3055 -13.9607 -1
-      vertex 14.4108 -13.8976 6
-      vertex 14.3055 -13.9607 6
-    endloop
-  endfacet
-  facet normal 0.514016 -0.85778 0
-    outer loop
-      vertex 14.4108 -13.8976 6
-      vertex 14.3055 -13.9607 -1
-      vertex 14.4108 -13.8976 -1
-    endloop
-  endfacet
-  facet normal -0.671617 0.740898 0
-    outer loop
-      vertex 15.8839 -15.8839 -1
-      vertex 15.793 -15.9663 6
-      vertex 15.8839 -15.8839 6
-    endloop
-  endfacet
-  facet normal -0.671617 0.740898 0
-    outer loop
-      vertex 15.793 -15.9663 6
-      vertex 15.8839 -15.8839 -1
-      vertex 15.793 -15.9663 -1
-    endloop
-  endfacet
-  facet normal -0.514016 0.85778 0
-    outer loop
-      vertex 15.6945 -16.0393 -1
-      vertex 15.5892 -16.1024 6
-      vertex 15.6945 -16.0393 6
-    endloop
-  endfacet
-  facet normal -0.514016 0.85778 0
-    outer loop
-      vertex 15.5892 -16.1024 6
-      vertex 15.6945 -16.0393 -1
-      vertex 15.5892 -16.1024 -1
-    endloop
-  endfacet
-  facet normal 0.428192 0.903688 -0
-    outer loop
-      vertex 14.5216 -16.1549 -1
-      vertex 14.4108 -16.1024 6
-      vertex 14.5216 -16.1549 6
-    endloop
-  endfacet
-  facet normal 0.428192 0.903688 0
-    outer loop
-      vertex 14.4108 -16.1024 6
-      vertex 14.5216 -16.1549 -1
-      vertex 14.4108 -16.1024 -1
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 -0
-    outer loop
-      vertex 14.8775 -16.244 -1
-      vertex 14.7561 -16.226 6
-      vertex 14.8775 -16.244 6
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 0
-    outer loop
-      vertex 14.7561 -16.226 6
-      vertex 14.8775 -16.244 -1
-      vertex 14.7561 -16.226 -1
-    endloop
-  endfacet
-  facet normal 0.740898 0.671617 0
-    outer loop
-      vertex 14.1161 -15.8839 6
-      vertex 14.0337 -15.793 -1
-      vertex 14.0337 -15.793 6
-    endloop
-  endfacet
-  facet normal 0.740898 0.671617 0
-    outer loop
-      vertex 14.0337 -15.793 -1
-      vertex 14.1161 -15.8839 6
-      vertex 14.1161 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489209 0
-    outer loop
-      vertex -16.244 -15.1225 6
-      vertex -16.25 -15 -1
-      vertex -16.25 -15 6
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489209 0
-    outer loop
-      vertex -16.25 -15 -1
-      vertex -16.244 -15.1225 6
-      vertex -16.244 -15.1225 -1
-    endloop
-  endfacet
-  facet normal -0.998803 -0.0489209 0
-    outer loop
-      vertex -13.75 -15 -1
-      vertex -13.756 -14.8775 6
-      vertex -13.756 -14.8775 -1
-    endloop
-  endfacet
-  facet normal -0.998803 -0.0489209 0
+  facet normal 0 0 1
     outer loop
       vertex -13.756 -14.8775 6
-      vertex -13.75 -15 -1
+      vertex -11.5169 -14.6569 6
+      vertex -11.5673 -14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5 -15 6
+      vertex -13.75 -15 6
+      vertex -11.5169 -15.3431 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.774 -14.7561 6
+      vertex -11.5673 -14.3172 6
+      vertex -11.6507 -13.984 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.756 -15.1225 6
+      vertex -11.5169 -15.3431 6
       vertex -13.75 -15 6
     endloop
   endfacet
-  facet normal 0.0489209 -0.998803 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.1225 -13.756 -1
-      vertex -15 -13.75 6
-      vertex -15.1225 -13.756 6
+      vertex -13.8038 -14.6371 6
+      vertex -11.6507 -13.984 6
+      vertex -11.7664 -13.6606 6
     endloop
   endfacet
-  facet normal 0.0489209 -0.998803 0
+  facet normal 0 0 1
     outer loop
-      vertex -15 -13.75 6
-      vertex -15.1225 -13.756 -1
-      vertex -15 -13.75 -1
+      vertex -11.5169 -15.3431 6
+      vertex -13.756 -15.1225 6
+      vertex -11.5673 -15.6828 6
     endloop
   endfacet
-  facet normal -0.671617 -0.740898 0
+  facet normal 0 0 1
     outer loop
-      vertex -14.207 -14.0337 -1
+      vertex -13.8451 -14.5216 6
+      vertex -11.7664 -13.6606 6
+      vertex -11.9133 -13.3501 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.774 -15.2439 6
+      vertex -11.5673 -15.6828 6
+      vertex -13.756 -15.1225 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.8976 -14.4108 6
+      vertex -11.9133 -13.3501 6
+      vertex -12.0899 -13.0555 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5673 -15.6828 6
+      vertex -13.774 -15.2439 6
+      vertex -11.6507 -16.016 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.9607 -14.3055 6
+      vertex -12.0899 -13.0555 6
+      vertex -12.2945 -12.7796 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8038 -15.3629 6
+      vertex -11.6507 -16.016 6
+      vertex -13.774 -15.2439 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0337 -14.207 6
+      vertex -12.2945 -12.7796 6
+      vertex -12.5251 -12.5251 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6507 -16.016 6
+      vertex -13.8038 -15.3629 6
+      vertex -11.7664 -16.3394 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex -14.1161 -14.1161 6
+      vertex -12.5251 -12.5251 6
+      vertex -12.7796 -12.2945 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8451 -15.4784 6
+      vertex -11.7664 -16.3394 6
+      vertex -13.8038 -15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.207 -14.0337 6
+      vertex -12.7796 -12.2945 6
+      vertex -13.0555 -12.0899 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7664 -16.3394 6
+      vertex -13.8451 -15.4784 6
+      vertex -11.9133 -16.6499 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3055 -13.9607 6
+      vertex -13.0555 -12.0899 6
+      vertex -13.3501 -11.9133 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.8976 -15.5892 6
+      vertex -11.9133 -16.6499 6
+      vertex -13.8451 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4108 -13.8976 6
+      vertex -13.3501 -11.9133 6
+      vertex -13.6606 -11.7664 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9133 -16.6499 6
+      vertex -13.8976 -15.5892 6
+      vertex -12.0899 -16.9445 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -13.9607 -15.6945 6
+      vertex -12.0899 -16.9445 6
+      vertex -13.8976 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5169 -14.6569 6
+      vertex -13.756 -14.8775 6
+      vertex -13.75 -15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.5673 -14.3172 6
+      vertex -13.774 -14.7561 6
+      vertex -13.756 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.6507 -13.984 6
+      vertex -13.8038 -14.6371 6
+      vertex -13.774 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.7664 -13.6606 6
+      vertex -13.8451 -14.5216 6
+      vertex -13.8038 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -11.9133 -13.3501 6
+      vertex -13.8976 -14.4108 6
+      vertex -13.8451 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.0899 -13.0555 6
+      vertex -13.9607 -14.3055 6
+      vertex -13.8976 -14.4108 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5216 -13.8451 6
+      vertex -13.6606 -11.7664 6
+      vertex -13.984 -11.6507 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.2945 -12.7796 6
+      vertex -14.0337 -14.207 6
+      vertex -13.9607 -14.3055 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.5251 -12.5251 6
+      vertex -14.1161 -14.1161 6
+      vertex -14.0337 -14.207 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.7796 -12.2945 6
+      vertex -14.207 -14.0337 6
+      vertex -14.1161 -14.1161 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.0555 -12.0899 6
+      vertex -14.3055 -13.9607 6
       vertex -14.207 -14.0337 6
     endloop
   endfacet
-  facet normal -0.671617 -0.740898 -0
+  facet normal 0 0 1
     outer loop
-      vertex -14.1161 -14.1161 6
-      vertex -14.207 -14.0337 -1
-      vertex -14.1161 -14.1161 -1
+      vertex -14.6371 -13.8038 6
+      vertex -13.984 -11.6507 6
+      vertex -14.3172 -11.5673 6
     endloop
   endfacet
-  facet normal 0.740898 -0.671617 0
+  facet normal 0 0 1
     outer loop
-      vertex -15.9663 -14.207 6
-      vertex -15.8839 -14.1161 -1
+      vertex -13.3501 -11.9133 6
+      vertex -14.4108 -13.8976 6
+      vertex -14.3055 -13.9607 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6606 -11.7664 6
+      vertex -14.5216 -13.8451 6
+      vertex -14.4108 -13.8976 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.984 -11.6507 6
+      vertex -14.6371 -13.8038 6
+      vertex -14.5216 -13.8451 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.7561 -13.774 6
+      vertex -14.3172 -11.5673 6
+      vertex -14.6569 -11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3172 -11.5673 6
+      vertex -14.7561 -13.774 6
+      vertex -14.6371 -13.8038 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.6569 -11.5169 6
+      vertex -14.8775 -13.756 6
+      vertex -14.7561 -13.774 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 -11.5 6
+      vertex -14.8775 -13.756 6
+      vertex -14.6569 -11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 -11.5 6
+      vertex -15 -13.75 6
+      vertex -14.8775 -13.756 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 -11.5 6
+      vertex -15.1225 -13.756 6
+      vertex -15 -13.75 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.3431 -11.5169 6
+      vertex -15.1225 -13.756 6
+      vertex -15 -11.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1225 -13.756 6
+      vertex -15.3431 -11.5169 6
+      vertex -15.2439 -13.774 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15.6828 -11.5673 6
+      vertex -15.2439 -13.774 6
+      vertex -15.3431 -11.5169 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.2439 -13.774 6
+      vertex -15.6828 -11.5673 6
+      vertex -15.3629 -13.8038 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.016 -11.6507 6
+      vertex -15.3629 -13.8038 6
+      vertex -15.6828 -11.5673 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3629 -13.8038 6
+      vertex -16.016 -11.6507 6
+      vertex -15.4784 -13.8451 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.3394 -11.7664 6
+      vertex -15.4784 -13.8451 6
+      vertex -16.016 -11.6507 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.4784 -13.8451 6
+      vertex -16.3394 -11.7664 6
+      vertex -15.5892 -13.8976 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.6499 -11.9133 6
+      vertex -15.5892 -13.8976 6
+      vertex -16.3394 -11.7664 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.5892 -13.8976 6
+      vertex -16.6499 -11.9133 6
+      vertex -15.6945 -13.9607 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -16.9445 -12.0899 6
+      vertex -15.6945 -13.9607 6
+      vertex -16.6499 -11.9133 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6945 -13.9607 6
+      vertex -16.9445 -12.0899 6
+      vertex -15.793 -14.0337 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -17.2204 -12.2945 6
+      vertex -15.793 -14.0337 6
+      vertex -16.9445 -12.0899 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.793 -14.0337 6
+      vertex -17.2204 -12.2945 6
       vertex -15.8839 -14.1161 6
     endloop
   endfacet
-  facet normal 0.740898 -0.671617 0
+  facet normal -0 0 1
     outer loop
-      vertex -15.8839 -14.1161 -1
+      vertex -17.4749 -12.5251 6
+      vertex -15.8839 -14.1161 6
+      vertex -17.2204 -12.2945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.8839 -14.1161 6
+      vertex -17.4749 -12.5251 6
       vertex -15.9663 -14.207 6
-      vertex -15.9663 -14.207 -1
     endloop
   endfacet
-  facet normal -0.941613 -0.336698 0
+  facet normal -0 0 1
     outer loop
-      vertex -13.8038 -14.6371 -1
-      vertex -13.8451 -14.5216 6
-      vertex -13.8451 -14.5216 -1
+      vertex -17.7055 -12.7796 6
+      vertex -15.9663 -14.207 6
+      vertex -17.4749 -12.5251 6
     endloop
   endfacet
-  facet normal -0.941613 -0.336698 0
+  facet normal -0 0 1
     outer loop
-      vertex -13.8451 -14.5216 6
-      vertex -13.8038 -14.6371 -1
-      vertex -13.8038 -14.6371 6
+      vertex -17.9101 -13.0555 6
+      vertex -16.0393 -14.3055 6
+      vertex -17.7055 -12.7796 6
     endloop
   endfacet
-  facet normal 0.671617 0.740898 -0
+  facet normal 0 0 1
     outer loop
-      vertex -15.793 -15.9663 -1
-      vertex -15.8839 -15.8839 6
-      vertex -15.793 -15.9663 6
-    endloop
-  endfacet
-  facet normal 0.671617 0.740898 0
-    outer loop
-      vertex -15.8839 -15.8839 6
-      vertex -15.793 -15.9663 -1
-      vertex -15.8839 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 -0
-    outer loop
-      vertex -15.3629 -16.1962 -1
-      vertex -15.4784 -16.1549 6
-      vertex -15.3629 -16.1962 6
-    endloop
-  endfacet
-  facet normal 0.336698 0.941613 0
-    outer loop
-      vertex -15.4784 -16.1549 6
-      vertex -15.3629 -16.1962 -1
-      vertex -15.4784 -16.1549 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex -13.8976 -15.5892 -1
-      vertex -13.8451 -15.4784 6
-      vertex -13.8451 -15.4784 -1
-    endloop
-  endfacet
-  facet normal -0.903688 0.428192 0
-    outer loop
-      vertex -13.8451 -15.4784 6
-      vertex -13.8976 -15.5892 -1
-      vertex -13.8976 -15.5892 6
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex -14.1161 -15.8839 -1
-      vertex -14.0337 -15.793 6
-      vertex -14.0337 -15.793 -1
-    endloop
-  endfacet
-  facet normal -0.740898 0.671617 0
-    outer loop
-      vertex -14.0337 -15.793 6
-      vertex -14.1161 -15.8839 -1
-      vertex -14.1161 -15.8839 6
-    endloop
-  endfacet
-  facet normal 0.903688 -0.428192 0
-    outer loop
-      vertex -16.1549 -14.5216 6
-      vertex -16.1024 -14.4108 -1
-      vertex -16.1024 -14.4108 6
-    endloop
-  endfacet
-  facet normal 0.903688 -0.428192 0
-    outer loop
-      vertex -16.1024 -14.4108 -1
-      vertex -16.1549 -14.5216 6
-      vertex -16.1549 -14.5216 -1
-    endloop
-  endfacet
-  facet normal 0.336698 -0.941613 0
-    outer loop
-      vertex -15.4784 -13.8451 -1
-      vertex -15.3629 -13.8038 6
-      vertex -15.4784 -13.8451 6
-    endloop
-  endfacet
-  facet normal 0.336698 -0.941613 0
-    outer loop
-      vertex -15.3629 -13.8038 6
-      vertex -15.4784 -13.8451 -1
-      vertex -15.3629 -13.8038 -1
-    endloop
-  endfacet
-  facet normal 0.85778 -0.514016 0
-    outer loop
-      vertex -16.1024 -14.4108 6
-      vertex -16.0393 -14.3055 -1
+      vertex -15.9663 -14.207 6
+      vertex -17.7055 -12.7796 6
       vertex -16.0393 -14.3055 6
     endloop
   endfacet
-  facet normal 0.85778 -0.514016 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.0393 -14.3055 -1
-      vertex -16.1024 -14.4108 6
-      vertex -16.1024 -14.4108 -1
+      vertex -12.0899 -16.9445 6
+      vertex -13.9607 -15.6945 6
+      vertex -12.2945 -17.2204 6
     endloop
   endfacet
-  facet normal -0.336698 -0.941613 0
+  facet normal -0 0 1
     outer loop
-      vertex -14.6371 -13.8038 -1
-      vertex -14.5216 -13.8451 6
-      vertex -14.6371 -13.8038 6
+      vertex -14.0337 -15.793 6
+      vertex -12.2945 -17.2204 6
+      vertex -13.9607 -15.6945 6
     endloop
   endfacet
-  facet normal -0.336698 -0.941613 -0
+  facet normal 0 0 1
     outer loop
-      vertex -14.5216 -13.8451 6
-      vertex -14.6371 -13.8038 -1
-      vertex -14.5216 -13.8451 -1
+      vertex -12.2945 -17.2204 6
+      vertex -14.0337 -15.793 6
+      vertex -12.5251 -17.4749 6
     endloop
   endfacet
-  facet normal -0.242919 -0.970047 0
+  facet normal -0 0 1
     outer loop
-      vertex -14.7561 -13.774 -1
-      vertex -14.6371 -13.8038 6
-      vertex -14.7561 -13.774 6
+      vertex -14.1161 -15.8839 6
+      vertex -12.5251 -17.4749 6
+      vertex -14.0337 -15.793 6
     endloop
   endfacet
-  facet normal -0.242919 -0.970047 -0
+  facet normal 0 0 1
     outer loop
-      vertex -14.6371 -13.8038 6
-      vertex -14.7561 -13.774 -1
-      vertex -14.6371 -13.8038 -1
+      vertex -12.5251 -17.4749 6
+      vertex -14.1161 -15.8839 6
+      vertex -12.7796 -17.7055 6
     endloop
   endfacet
-  facet normal -0.740898 -0.671617 0
+  facet normal -0 0 1
     outer loop
-      vertex -14.0337 -14.207 -1
-      vertex -14.1161 -14.1161 6
-      vertex -14.1161 -14.1161 -1
+      vertex -14.207 -15.9663 6
+      vertex -12.7796 -17.7055 6
+      vertex -14.1161 -15.8839 6
     endloop
   endfacet
-  facet normal -0.740898 -0.671617 0
+  facet normal 0 0 1
     outer loop
-      vertex -14.1161 -14.1161 6
-      vertex -14.0337 -14.207 -1
-      vertex -14.0337 -14.207 6
+      vertex -12.7796 -17.7055 6
+      vertex -14.207 -15.9663 6
+      vertex -13.0555 -17.9101 6
     endloop
   endfacet
-  facet normal -0.970047 -0.242919 0
+  facet normal -0 0 1
     outer loop
-      vertex -13.774 -14.7561 -1
-      vertex -13.8038 -14.6371 6
-      vertex -13.8038 -14.6371 -1
+      vertex -14.3055 -16.0393 6
+      vertex -13.0555 -17.9101 6
+      vertex -14.207 -15.9663 6
     endloop
   endfacet
-  facet normal -0.970047 -0.242919 0
+  facet normal 0 0 1
     outer loop
-      vertex -13.8038 -14.6371 6
-      vertex -13.774 -14.7561 -1
-      vertex -13.774 -14.7561 6
+      vertex -13.0555 -17.9101 6
+      vertex -14.3055 -16.0393 6
+      vertex -13.3501 -18.0867 6
     endloop
   endfacet
-  facet normal 0.989186 0.146667 0
+  facet normal -0 0 1
     outer loop
+      vertex -14.4108 -16.1024 6
+      vertex -13.3501 -18.0867 6
+      vertex -14.3055 -16.0393 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.3501 -18.0867 6
+      vertex -14.4108 -16.1024 6
+      vertex -13.6606 -18.2336 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.5216 -16.1549 6
+      vertex -13.6606 -18.2336 6
+      vertex -14.4108 -16.1024 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.6606 -18.2336 6
+      vertex -14.5216 -16.1549 6
+      vertex -13.984 -18.3493 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.6371 -16.1962 6
+      vertex -13.984 -18.3493 6
+      vertex -14.5216 -16.1549 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.984 -18.3493 6
+      vertex -14.6371 -16.1962 6
+      vertex -14.3172 -18.4327 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.7561 -16.226 6
+      vertex -14.3172 -18.4327 6
+      vertex -14.6371 -16.1962 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3172 -18.4327 6
+      vertex -14.7561 -16.226 6
+      vertex -14.6569 -18.4831 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -14.8775 -16.244 6
+      vertex -14.6569 -18.4831 6
+      vertex -14.7561 -16.226 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -15 -16.25 6
+      vertex -14.6569 -18.4831 6
+      vertex -14.8775 -16.244 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15 -16.25 6
+      vertex -15 -18.5 6
+      vertex -14.6569 -18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1225 -16.244 6
+      vertex -15 -18.5 6
+      vertex -15 -16.25 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3431 -18.4831 6
+      vertex -15.1225 -16.244 6
+      vertex -15.2439 -16.226 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.1225 -16.244 6
+      vertex -15.3431 -18.4831 6
+      vertex -15 -18.5 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.6828 -18.4327 6
+      vertex -15.2439 -16.226 6
+      vertex -15.3629 -16.1962 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.016 -18.3493 6
+      vertex -15.3629 -16.1962 6
+      vertex -15.4784 -16.1549 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.3394 -18.2336 6
+      vertex -15.4784 -16.1549 6
+      vertex -15.5892 -16.1024 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.2439 -16.226 6
+      vertex -15.6828 -18.4327 6
+      vertex -15.3431 -18.4831 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.6499 -18.0867 6
+      vertex -15.5892 -16.1024 6
+      vertex -15.6945 -16.0393 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.9445 -17.9101 6
+      vertex -15.6945 -16.0393 6
+      vertex -15.793 -15.9663 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.2204 -17.7055 6
+      vertex -15.793 -15.9663 6
+      vertex -15.8839 -15.8839 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.4749 -17.4749 6
+      vertex -15.8839 -15.8839 6
+      vertex -15.9663 -15.793 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.3629 -16.1962 6
+      vertex -16.016 -18.3493 6
+      vertex -15.6828 -18.4327 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.7055 -17.2204 6
+      vertex -15.9663 -15.793 6
+      vertex -16.0393 -15.6945 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -17.9101 -16.9445 6
+      vertex -16.0393 -15.6945 6
+      vertex -16.1024 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.0867 -16.6499 6
+      vertex -16.1024 -15.5892 6
+      vertex -16.1549 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.2336 -16.3394 6
+      vertex -16.1549 -15.4784 6
+      vertex -16.1962 -15.3629 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.3493 -16.016 6
+      vertex -16.1962 -15.3629 6
       vertex -16.226 -15.2439 6
-      vertex -16.244 -15.1225 -1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4327 -15.6828 6
+      vertex -16.226 -15.2439 6
       vertex -16.244 -15.1225 6
     endloop
   endfacet
-  facet normal 0.989186 0.146667 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.244 -15.1225 -1
-      vertex -16.226 -15.2439 6
-      vertex -16.226 -15.2439 -1
-    endloop
-  endfacet
-  facet normal 0.941613 0.336698 0
-    outer loop
-      vertex -16.1549 -15.4784 6
-      vertex -16.1962 -15.3629 -1
-      vertex -16.1962 -15.3629 6
-    endloop
-  endfacet
-  facet normal 0.941613 0.336698 0
-    outer loop
-      vertex -16.1962 -15.3629 -1
-      vertex -16.1549 -15.4784 6
-      vertex -16.1549 -15.4784 -1
-    endloop
-  endfacet
-  facet normal 0.740898 0.671617 0
-    outer loop
-      vertex -15.8839 -15.8839 6
-      vertex -15.9663 -15.793 -1
-      vertex -15.9663 -15.793 6
-    endloop
-  endfacet
-  facet normal 0.740898 0.671617 0
-    outer loop
-      vertex -15.9663 -15.793 -1
-      vertex -15.8839 -15.8839 6
-      vertex -15.8839 -15.8839 -1
-    endloop
-  endfacet
-  facet normal 0.85778 0.514016 0
-    outer loop
-      vertex -16.0393 -15.6945 6
-      vertex -16.1024 -15.5892 -1
-      vertex -16.1024 -15.5892 6
-    endloop
-  endfacet
-  facet normal 0.85778 0.514016 0
-    outer loop
-      vertex -16.1024 -15.5892 -1
-      vertex -16.0393 -15.6945 6
-      vertex -16.0393 -15.6945 -1
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 -0
-    outer loop
-      vertex -15.1225 -16.244 -1
-      vertex -15.2439 -16.226 6
-      vertex -15.1225 -16.244 6
-    endloop
-  endfacet
-  facet normal 0.146667 0.989186 0
-    outer loop
-      vertex -15.2439 -16.226 6
-      vertex -15.1225 -16.244 -1
-      vertex -15.2439 -16.226 -1
-    endloop
-  endfacet
-  facet normal 0.242919 0.970047 -0
-    outer loop
-      vertex -15.2439 -16.226 -1
-      vertex -15.3629 -16.1962 6
-      vertex -15.2439 -16.226 6
-    endloop
-  endfacet
-  facet normal 0.242919 0.970047 0
-    outer loop
-      vertex -15.3629 -16.1962 6
-      vertex -15.2439 -16.226 -1
-      vertex -15.3629 -16.1962 -1
-    endloop
-  endfacet
-  facet normal 0.0489209 0.998803 -0
-    outer loop
-      vertex -15 -16.25 -1
-      vertex -15.1225 -16.244 6
-      vertex -15 -16.25 6
-    endloop
-  endfacet
-  facet normal 0.0489209 0.998803 0
-    outer loop
-      vertex -15.1225 -16.244 6
-      vertex -15 -16.25 -1
-      vertex -15.1225 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0.428192 0.903688 -0
-    outer loop
-      vertex -15.4784 -16.1549 -1
-      vertex -15.5892 -16.1024 6
       vertex -15.4784 -16.1549 6
+      vertex -16.3394 -18.2336 6
+      vertex -16.016 -18.3493 6
     endloop
   endfacet
-  facet normal 0.428192 0.903688 0
+  facet normal 0 0 1
+    outer loop
+      vertex -18.4831 -15.3431 6
+      vertex -16.244 -15.1225 6
+      vertex -16.25 -15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0393 -14.3055 6
+      vertex -17.9101 -13.0555 6
+      vertex -16.1024 -14.4108 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.0867 -13.3501 6
+      vertex -16.1024 -14.4108 6
+      vertex -17.9101 -13.0555 6
+    endloop
+  endfacet
+  facet normal 0 0 1
     outer loop
       vertex -15.5892 -16.1024 6
-      vertex -15.4784 -16.1549 -1
-      vertex -15.5892 -16.1024 -1
+      vertex -16.6499 -18.0867 6
+      vertex -16.3394 -18.2336 6
     endloop
   endfacet
-  facet normal 0.595423 0.803413 -0
+  facet normal 0 0 1
     outer loop
-      vertex -15.6945 -16.0393 -1
-      vertex -15.793 -15.9663 6
-      vertex -15.6945 -16.0393 6
-    endloop
-  endfacet
-  facet normal 0.595423 0.803413 0
-    outer loop
-      vertex -15.793 -15.9663 6
-      vertex -15.6945 -16.0393 -1
-      vertex -15.793 -15.9663 -1
-    endloop
-  endfacet
-  facet normal -0.803413 0.595423 0
-    outer loop
-      vertex -14.0337 -15.793 -1
-      vertex -13.9607 -15.6945 6
-      vertex -13.9607 -15.6945 -1
-    endloop
-  endfacet
-  facet normal -0.803413 0.595423 0
-    outer loop
-      vertex -13.9607 -15.6945 6
-      vertex -14.0337 -15.793 -1
-      vertex -14.0337 -15.793 6
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex -13.9607 -15.6945 -1
-      vertex -13.8976 -15.5892 6
-      vertex -13.8976 -15.5892 -1
-    endloop
-  endfacet
-  facet normal -0.85778 0.514016 0
-    outer loop
-      vertex -13.8976 -15.5892 6
-      vertex -13.9607 -15.6945 -1
-      vertex -13.9607 -15.6945 6
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex -13.774 -15.2439 -1
-      vertex -13.756 -15.1225 6
-      vertex -13.756 -15.1225 -1
-    endloop
-  endfacet
-  facet normal -0.989186 0.146667 0
-    outer loop
-      vertex -13.756 -15.1225 6
-      vertex -13.774 -15.2439 -1
-      vertex -13.774 -15.2439 6
-    endloop
-  endfacet
-  facet normal -0.970047 0.242919 0
-    outer loop
-      vertex -13.8038 -15.3629 -1
-      vertex -13.774 -15.2439 6
-      vertex -13.774 -15.2439 -1
-    endloop
-  endfacet
-  facet normal -0.970047 0.242919 0
-    outer loop
-      vertex -13.774 -15.2439 6
-      vertex -13.8038 -15.3629 -1
-      vertex -13.8038 -15.3629 6
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489209 0
-    outer loop
-      vertex -13.756 -15.1225 -1
-      vertex -13.75 -15 6
-      vertex -13.75 -15 -1
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489209 0
-    outer loop
-      vertex -13.75 -15 6
-      vertex -13.756 -15.1225 -1
-      vertex -13.756 -15.1225 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex -14.207 -15.9663 -1
-      vertex -14.3055 -16.0393 6
-      vertex -14.207 -15.9663 6
-    endloop
-  endfacet
-  facet normal -0.595423 0.803413 0
-    outer loop
-      vertex -14.3055 -16.0393 6
-      vertex -14.207 -15.9663 -1
-      vertex -14.3055 -16.0393 -1
-    endloop
-  endfacet
-  facet normal -0.514016 0.85778 0
-    outer loop
-      vertex -14.3055 -16.0393 -1
-      vertex -14.4108 -16.1024 6
-      vertex -14.3055 -16.0393 6
-    endloop
-  endfacet
-  facet normal -0.514016 0.85778 0
-    outer loop
-      vertex -14.4108 -16.1024 6
-      vertex -14.3055 -16.0393 -1
-      vertex -14.4108 -16.1024 -1
-    endloop
-  endfacet
-  facet normal -0.671617 0.740898 0
-    outer loop
-      vertex -14.1161 -15.8839 -1
-      vertex -14.207 -15.9663 6
-      vertex -14.1161 -15.8839 6
-    endloop
-  endfacet
-  facet normal -0.671617 0.740898 0
-    outer loop
-      vertex -14.207 -15.9663 6
-      vertex -14.1161 -15.8839 -1
-      vertex -14.207 -15.9663 -1
-    endloop
-  endfacet
-  facet normal -0.336698 0.941613 0
-    outer loop
-      vertex -14.5216 -16.1549 -1
-      vertex -14.6371 -16.1962 6
-      vertex -14.5216 -16.1549 6
-    endloop
-  endfacet
-  facet normal -0.336698 0.941613 0
-    outer loop
-      vertex -14.6371 -16.1962 6
-      vertex -14.5216 -16.1549 -1
-      vertex -14.6371 -16.1962 -1
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex -14.4108 -16.1024 -1
-      vertex -14.5216 -16.1549 6
-      vertex -14.4108 -16.1024 6
-    endloop
-  endfacet
-  facet normal -0.428192 0.903688 0
-    outer loop
-      vertex -14.5216 -16.1549 6
-      vertex -14.4108 -16.1024 -1
-      vertex -14.5216 -16.1549 -1
-    endloop
-  endfacet
-  facet normal -0.146667 0.989186 0
-    outer loop
-      vertex -14.7561 -16.226 -1
-      vertex -14.8775 -16.244 6
-      vertex -14.7561 -16.226 6
-    endloop
-  endfacet
-  facet normal -0.146667 0.989186 0
-    outer loop
-      vertex -14.8775 -16.244 6
-      vertex -14.7561 -16.226 -1
-      vertex -14.8775 -16.244 -1
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex -16.25 -15 6
-      vertex -16.244 -14.8775 -1
-      vertex -16.244 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0.998803 -0.0489209 0
-    outer loop
-      vertex -16.244 -14.8775 -1
-      vertex -16.25 -15 6
-      vertex -16.25 -15 -1
-    endloop
-  endfacet
-  facet normal 0.242919 -0.970047 0
-    outer loop
-      vertex -15.3629 -13.8038 -1
-      vertex -15.2439 -13.774 6
-      vertex -15.3629 -13.8038 6
-    endloop
-  endfacet
-  facet normal 0.242919 -0.970047 0
-    outer loop
-      vertex -15.2439 -13.774 6
-      vertex -15.3629 -13.8038 -1
-      vertex -15.2439 -13.774 -1
-    endloop
-  endfacet
-  facet normal 0.146667 -0.989186 0
-    outer loop
-      vertex -15.2439 -13.774 -1
-      vertex -15.1225 -13.756 6
-      vertex -15.2439 -13.774 6
-    endloop
-  endfacet
-  facet normal 0.146667 -0.989186 0
-    outer loop
-      vertex -15.1225 -13.756 6
-      vertex -15.2439 -13.774 -1
-      vertex -15.1225 -13.756 -1
-    endloop
-  endfacet
-  facet normal 0.428192 -0.903688 0
-    outer loop
-      vertex -15.5892 -13.8976 -1
-      vertex -15.4784 -13.8451 6
-      vertex -15.5892 -13.8976 6
-    endloop
-  endfacet
-  facet normal 0.428192 -0.903688 0
-    outer loop
-      vertex -15.4784 -13.8451 6
-      vertex -15.5892 -13.8976 -1
-      vertex -15.4784 -13.8451 -1
-    endloop
-  endfacet
-  facet normal 0.514016 -0.85778 0
-    outer loop
-      vertex -15.6945 -13.9607 -1
-      vertex -15.5892 -13.8976 6
-      vertex -15.6945 -13.9607 6
-    endloop
-  endfacet
-  facet normal 0.514016 -0.85778 0
-    outer loop
-      vertex -15.5892 -13.8976 6
-      vertex -15.6945 -13.9607 -1
-      vertex -15.5892 -13.8976 -1
-    endloop
-  endfacet
-  facet normal 0.671617 -0.740898 0
-    outer loop
-      vertex -15.8839 -14.1161 -1
-      vertex -15.793 -14.0337 6
-      vertex -15.8839 -14.1161 6
-    endloop
-  endfacet
-  facet normal 0.671617 -0.740898 0
-    outer loop
-      vertex -15.793 -14.0337 6
-      vertex -15.8839 -14.1161 -1
-      vertex -15.793 -14.0337 -1
-    endloop
-  endfacet
-  facet normal 0.595423 -0.803413 0
-    outer loop
-      vertex -15.793 -14.0337 -1
-      vertex -15.6945 -13.9607 6
-      vertex -15.793 -14.0337 6
-    endloop
-  endfacet
-  facet normal 0.595423 -0.803413 0
-    outer loop
-      vertex -15.6945 -13.9607 6
-      vertex -15.793 -14.0337 -1
-      vertex -15.6945 -13.9607 -1
-    endloop
-  endfacet
-  facet normal 0.803413 -0.595423 0
-    outer loop
-      vertex -16.0393 -14.3055 6
-      vertex -15.9663 -14.207 -1
-      vertex -15.9663 -14.207 6
-    endloop
-  endfacet
-  facet normal 0.803413 -0.595423 0
-    outer loop
-      vertex -15.9663 -14.207 -1
-      vertex -16.0393 -14.3055 6
-      vertex -16.0393 -14.3055 -1
-    endloop
-  endfacet
-  facet normal 0.941613 -0.336698 0
-    outer loop
-      vertex -16.1962 -14.6371 6
-      vertex -16.1549 -14.5216 -1
+      vertex -16.1024 -14.4108 6
+      vertex -18.0867 -13.3501 6
       vertex -16.1549 -14.5216 6
     endloop
   endfacet
-  facet normal 0.941613 -0.336698 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.1549 -14.5216 -1
+      vertex -15.6945 -16.0393 6
+      vertex -16.9445 -17.9101 6
+      vertex -16.6499 -18.0867 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.2336 -13.6606 6
+      vertex -16.1549 -14.5216 6
+      vertex -18.0867 -13.3501 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -15.793 -15.9663 6
+      vertex -17.2204 -17.7055 6
+      vertex -16.9445 -17.9101 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1549 -14.5216 6
+      vertex -18.2336 -13.6606 6
       vertex -16.1962 -14.6371 6
-      vertex -16.1962 -14.6371 -1
     endloop
   endfacet
-  facet normal 0.970047 -0.242919 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.226 -14.7561 6
-      vertex -16.1962 -14.6371 -1
+      vertex -15.8839 -15.8839 6
+      vertex -17.4749 -17.4749 6
+      vertex -17.2204 -17.7055 6
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -18.3493 -13.984 6
       vertex -16.1962 -14.6371 6
+      vertex -18.2336 -13.6606 6
     endloop
   endfacet
-  facet normal 0.970047 -0.242919 0
-    outer loop
-      vertex -16.1962 -14.6371 -1
-      vertex -16.226 -14.7561 6
-      vertex -16.226 -14.7561 -1
-    endloop
-  endfacet
-  facet normal -0.146667 -0.989186 0
-    outer loop
-      vertex -14.8775 -13.756 -1
-      vertex -14.7561 -13.774 6
-      vertex -14.8775 -13.756 6
-    endloop
-  endfacet
-  facet normal -0.146667 -0.989186 -0
-    outer loop
-      vertex -14.7561 -13.774 6
-      vertex -14.8775 -13.756 -1
-      vertex -14.7561 -13.774 -1
-    endloop
-  endfacet
-  facet normal -0.514016 -0.85778 0
-    outer loop
-      vertex -14.4108 -13.8976 -1
-      vertex -14.3055 -13.9607 6
-      vertex -14.4108 -13.8976 6
-    endloop
-  endfacet
-  facet normal -0.514016 -0.85778 -0
-    outer loop
-      vertex -14.3055 -13.9607 6
-      vertex -14.4108 -13.8976 -1
-      vertex -14.3055 -13.9607 -1
-    endloop
-  endfacet
-  facet normal -0.428192 -0.903688 0
-    outer loop
-      vertex -14.5216 -13.8451 -1
-      vertex -14.4108 -13.8976 6
-      vertex -14.5216 -13.8451 6
-    endloop
-  endfacet
-  facet normal -0.428192 -0.903688 -0
-    outer loop
-      vertex -14.4108 -13.8976 6
-      vertex -14.5216 -13.8451 -1
-      vertex -14.4108 -13.8976 -1
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 0
-    outer loop
-      vertex -15 -13.75 -1
-      vertex -14.8775 -13.756 6
-      vertex -15 -13.75 6
-    endloop
-  endfacet
-  facet normal -0.0489209 -0.998803 -0
-    outer loop
-      vertex -14.8775 -13.756 6
-      vertex -15 -13.75 -1
-      vertex -14.8775 -13.756 -1
-    endloop
-  endfacet
-  facet normal -0.85778 -0.514016 0
-    outer loop
-      vertex -13.8976 -14.4108 -1
-      vertex -13.9607 -14.3055 6
-      vertex -13.9607 -14.3055 -1
-    endloop
-  endfacet
-  facet normal -0.85778 -0.514016 0
-    outer loop
-      vertex -13.9607 -14.3055 6
-      vertex -13.8976 -14.4108 -1
-      vertex -13.8976 -14.4108 6
-    endloop
-  endfacet
-  facet normal -0.803413 -0.595423 0
-    outer loop
-      vertex -13.9607 -14.3055 -1
-      vertex -14.0337 -14.207 6
-      vertex -14.0337 -14.207 -1
-    endloop
-  endfacet
-  facet normal -0.803413 -0.595423 0
-    outer loop
-      vertex -14.0337 -14.207 6
-      vertex -13.9607 -14.3055 -1
-      vertex -13.9607 -14.3055 6
-    endloop
-  endfacet
-  facet normal -0.903688 -0.428192 0
-    outer loop
-      vertex -13.8451 -14.5216 -1
-      vertex -13.8976 -14.4108 6
-      vertex -13.8976 -14.4108 -1
-    endloop
-  endfacet
-  facet normal -0.903688 -0.428192 0
-    outer loop
-      vertex -13.8976 -14.4108 6
-      vertex -13.8451 -14.5216 -1
-      vertex -13.8451 -14.5216 6
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex -13.756 -14.8775 -1
-      vertex -13.774 -14.7561 6
-      vertex -13.774 -14.7561 -1
-    endloop
-  endfacet
-  facet normal -0.989186 -0.146667 0
-    outer loop
-      vertex -13.774 -14.7561 6
-      vertex -13.756 -14.8775 -1
-      vertex -13.756 -14.8775 6
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex -16.1962 -15.3629 6
-      vertex -16.226 -15.2439 -1
-      vertex -16.226 -15.2439 6
-    endloop
-  endfacet
-  facet normal 0.970047 0.242919 0
-    outer loop
-      vertex -16.226 -15.2439 -1
-      vertex -16.1962 -15.3629 6
-      vertex -16.1962 -15.3629 -1
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex -16.1024 -15.5892 6
-      vertex -16.1549 -15.4784 -1
-      vertex -16.1549 -15.4784 6
-    endloop
-  endfacet
-  facet normal 0.903688 0.428192 0
-    outer loop
-      vertex -16.1549 -15.4784 -1
-      vertex -16.1024 -15.5892 6
-      vertex -16.1024 -15.5892 -1
-    endloop
-  endfacet
-  facet normal 0.803413 0.595423 0
+  facet normal 0 0 1
     outer loop
       vertex -15.9663 -15.793 6
-      vertex -16.0393 -15.6945 -1
+      vertex -17.7055 -17.2204 6
+      vertex -17.4749 -17.4749 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1962 -14.6371 6
+      vertex -18.3493 -13.984 6
+      vertex -16.226 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
       vertex -16.0393 -15.6945 6
+      vertex -17.9101 -16.9445 6
+      vertex -17.7055 -17.2204 6
     endloop
   endfacet
-  facet normal 0.803413 0.595423 0
+  facet normal -0 0 1
     outer loop
-      vertex -16.0393 -15.6945 -1
-      vertex -15.9663 -15.793 6
-      vertex -15.9663 -15.793 -1
-    endloop
-  endfacet
-  facet normal -0.0489209 0.998803 0
-    outer loop
-      vertex -14.8775 -16.244 -1
-      vertex -15 -16.25 6
-      vertex -14.8775 -16.244 6
-    endloop
-  endfacet
-  facet normal -0.0489209 0.998803 0
-    outer loop
-      vertex -15 -16.25 6
-      vertex -14.8775 -16.244 -1
-      vertex -15 -16.25 -1
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 -0
-    outer loop
-      vertex -15.5892 -16.1024 -1
-      vertex -15.6945 -16.0393 6
-      vertex -15.5892 -16.1024 6
-    endloop
-  endfacet
-  facet normal 0.514016 0.85778 0
-    outer loop
-      vertex -15.6945 -16.0393 6
-      vertex -15.5892 -16.1024 -1
-      vertex -15.6945 -16.0393 -1
-    endloop
-  endfacet
-  facet normal -0.941613 0.336698 0
-    outer loop
-      vertex -13.8451 -15.4784 -1
-      vertex -13.8038 -15.3629 6
-      vertex -13.8038 -15.3629 -1
-    endloop
-  endfacet
-  facet normal -0.941613 0.336698 0
-    outer loop
-      vertex -13.8038 -15.3629 6
-      vertex -13.8451 -15.4784 -1
-      vertex -13.8451 -15.4784 6
-    endloop
-  endfacet
-  facet normal -0.242919 0.970047 0
-    outer loop
-      vertex -14.6371 -16.1962 -1
-      vertex -14.7561 -16.226 6
-      vertex -14.6371 -16.1962 6
-    endloop
-  endfacet
-  facet normal -0.242919 0.970047 0
-    outer loop
-      vertex -14.7561 -16.226 6
-      vertex -14.6371 -16.1962 -1
-      vertex -14.7561 -16.226 -1
-    endloop
-  endfacet
-  facet normal 0.989186 -0.146667 0
-    outer loop
-      vertex -16.244 -14.8775 6
-      vertex -16.226 -14.7561 -1
+      vertex -18.4327 -14.3172 6
       vertex -16.226 -14.7561 6
+      vertex -18.3493 -13.984 6
     endloop
   endfacet
-  facet normal 0.989186 -0.146667 0
+  facet normal 0 0 1
     outer loop
-      vertex -16.226 -14.7561 -1
+      vertex -16.1024 -15.5892 6
+      vertex -18.0867 -16.6499 6
+      vertex -17.9101 -16.9445 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.226 -14.7561 6
+      vertex -18.4327 -14.3172 6
       vertex -16.244 -14.8775 6
-      vertex -16.244 -14.8775 -1
     endloop
   endfacet
-  facet normal -0.595423 -0.803413 0
+  facet normal 0 0 1
     outer loop
-      vertex -14.3055 -13.9607 -1
-      vertex -14.207 -14.0337 6
-      vertex -14.3055 -13.9607 6
+      vertex -16.1549 -15.4784 6
+      vertex -18.2336 -16.3394 6
+      vertex -18.0867 -16.6499 6
     endloop
   endfacet
-  facet normal -0.595423 -0.803413 -0
+  facet normal -0 0 1
     outer loop
-      vertex -14.207 -14.0337 6
-      vertex -14.3055 -13.9607 -1
-      vertex -14.207 -14.0337 -1
+      vertex -18.4831 -14.6569 6
+      vertex -16.244 -14.8775 6
+      vertex -18.4327 -14.3172 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.1962 -15.3629 6
+      vertex -18.3493 -16.016 6
+      vertex -18.2336 -16.3394 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.244 -14.8775 6
+      vertex -18.4831 -14.6569 6
+      vertex -16.25 -15 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.226 -15.2439 6
+      vertex -18.4327 -15.6828 6
+      vertex -18.3493 -16.016 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18.5 -15 6
+      vertex -16.25 -15 6
+      vertex -18.4831 -14.6569 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.244 -15.1225 6
+      vertex -18.4831 -15.3431 6
+      vertex -18.4327 -15.6828 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.25 -15 6
+      vertex -18.5 -15 6
+      vertex -18.4831 -15.3431 6
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146737 0
+    outer loop
+      vertex 10.494 0.122521 0
+      vertex 10.476 0.243862 1
+      vertex 10.476 0.243862 0
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146737 0
+    outer loop
+      vertex 10.476 0.243862 1
+      vertex 10.494 0.122521 0
+      vertex 10.494 0.122521 1
     endloop
   endfacet
   facet normal -0.998803 -0.0489126 0
     outer loop
-      vertex 10.5 0 -1
+      vertex 10.5 0 0
       vertex 10.494 0.122521 1
-      vertex 10.494 0.122521 -1
+      vertex 10.494 0.122521 0
     endloop
   endfacet
   facet normal -0.998803 -0.0489126 0
     outer loop
       vertex 10.494 0.122521 1
-      vertex 10.5 0 -1
+      vertex 10.5 0 0
       vertex 10.5 0 1
     endloop
   endfacet
-  facet normal 0.0490756 -0.998795 0
+  facet normal -0.970043 -0.242933 0
     outer loop
-      vertex 9.12748 1.24398 -1
-      vertex 9.25 1.25 1
-      vertex 9.12748 1.24398 1
+      vertex 10.476 0.243862 0
+      vertex 10.4462 0.362855 1
+      vertex 10.4462 0.362855 0
     endloop
   endfacet
-  facet normal 0.0490756 -0.998795 0
+  facet normal -0.970043 -0.242933 0
     outer loop
-      vertex 9.25 1.25 1
-      vertex 9.12748 1.24398 -1
-      vertex 9.25 1.25 -1
+      vertex 10.4462 0.362855 1
+      vertex 10.476 0.243862 0
+      vertex 10.476 0.243862 1
+    endloop
+  endfacet
+  facet normal -0.336842 0.941561 0
+    outer loop
+      vertex 9.72835 -1.15485 0
+      vertex 9.61285 -1.19617 1
+      vertex 9.72835 -1.15485 1
+    endloop
+  endfacet
+  facet normal -0.336842 0.941561 0
+    outer loop
+      vertex 9.61285 -1.19617 1
+      vertex 9.72835 -1.15485 0
+      vertex 9.61285 -1.19617 0
     endloop
   endfacet
   facet normal -0.671528 -0.740979 0
     outer loop
-      vertex 10.043 0.966263 -1
+      vertex 10.043 0.966263 0
       vertex 10.1339 0.883883 1
       vertex 10.043 0.966263 1
     endloop
@@ -16417,825 +12049,27 @@ solid OpenSCAD_Model
   facet normal -0.671528 -0.740979 -0
     outer loop
       vertex 10.1339 0.883883 1
-      vertex 10.043 0.966263 -1
-      vertex 10.1339 0.883883 -1
-    endloop
-  endfacet
-  facet normal 0.74095 -0.67156 0
-    outer loop
-      vertex 8.28374 0.792991 1
-      vertex 8.36612 0.883883 -1
-      vertex 8.36612 0.883883 1
-    endloop
-  endfacet
-  facet normal 0.74095 -0.67156 0
-    outer loop
-      vertex 8.36612 0.883883 -1
-      vertex 8.28374 0.792991 1
-      vertex 8.28374 0.792991 -1
-    endloop
-  endfacet
-  facet normal 0.427543 -0.903995 0
-    outer loop
-      vertex 8.66075 1.1024 -1
-      vertex 8.77165 1.15485 1
-      vertex 8.66075 1.1024 1
-    endloop
-  endfacet
-  facet normal 0.427543 -0.903995 0
-    outer loop
-      vertex 8.77165 1.15485 1
-      vertex 8.66075 1.1024 -1
-      vertex 8.77165 1.15485 -1
-    endloop
-  endfacet
-  facet normal -0.904141 -0.427235 0
-    outer loop
-      vertex 10.4048 0.478354 -1
-      vertex 10.3524 0.589246 1
-      vertex 10.3524 0.589246 -1
-    endloop
-  endfacet
-  facet normal -0.904141 -0.427235 0
-    outer loop
-      vertex 10.3524 0.589246 1
-      vertex 10.4048 0.478354 -1
-      vertex 10.4048 0.478354 1
-    endloop
-  endfacet
-  facet normal -0.336842 -0.941561 0
-    outer loop
-      vertex 9.61285 1.19617 -1
-      vertex 9.72835 1.15485 1
-      vertex 9.61285 1.19617 1
-    endloop
-  endfacet
-  facet normal -0.336842 -0.941561 -0
-    outer loop
-      vertex 9.72835 1.15485 1
-      vertex 9.61285 1.19617 -1
-      vertex 9.72835 1.15485 -1
-    endloop
-  endfacet
-  facet normal 0.903983 -0.427568 0
-    outer loop
-      vertex 8.09515 0.478354 1
-      vertex 8.1476 0.589246 -1
-      vertex 8.1476 0.589246 1
-    endloop
-  endfacet
-  facet normal 0.903983 -0.427568 0
-    outer loop
-      vertex 8.1476 0.589246 -1
-      vertex 8.09515 0.478354 1
-      vertex 8.09515 0.478354 -1
+      vertex 10.043 0.966263 0
+      vertex 10.1339 0.883883 0
     endloop
   endfacet
   facet normal 0.857745 -0.514075 0
     outer loop
       vertex 8.1476 0.589246 1
-      vertex 8.21066 0.694463 -1
+      vertex 8.21066 0.694463 0
       vertex 8.21066 0.694463 1
     endloop
   endfacet
   facet normal 0.857745 -0.514075 0
     outer loop
-      vertex 8.21066 0.694463 -1
+      vertex 8.21066 0.694463 0
       vertex 8.1476 0.589246 1
-      vertex 8.1476 0.589246 -1
-    endloop
-  endfacet
-  facet normal 0.998795 0.0490752 0
-    outer loop
-      vertex 8.00602 -0.122521 1
-      vertex 8 0 -1
-      vertex 8 0 1
-    endloop
-  endfacet
-  facet normal 0.998795 0.0490752 0
-    outer loop
-      vertex 8 0 -1
-      vertex 8.00602 -0.122521 1
-      vertex 8.00602 -0.122521 -1
-    endloop
-  endfacet
-  facet normal 0.903983 0.427568 0
-    outer loop
-      vertex 8.1476 -0.589246 1
-      vertex 8.09515 -0.478354 -1
-      vertex 8.09515 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0.903983 0.427568 0
-    outer loop
-      vertex 8.09515 -0.478354 -1
-      vertex 8.1476 -0.589246 1
-      vertex 8.1476 -0.589246 -1
-    endloop
-  endfacet
-  facet normal -0.146738 0.989175 0
-    outer loop
-      vertex 9.49386 -1.22598 -1
-      vertex 9.37252 -1.24398 1
-      vertex 9.49386 -1.22598 1
-    endloop
-  endfacet
-  facet normal -0.146738 0.989175 0
-    outer loop
-      vertex 9.37252 -1.24398 1
-      vertex 9.49386 -1.22598 -1
-      vertex 9.37252 -1.24398 -1
-    endloop
-  endfacet
-  facet normal -0.970043 -0.242933 0
-    outer loop
-      vertex 10.476 0.243862 -1
-      vertex 10.4462 0.362855 1
-      vertex 10.4462 0.362855 -1
-    endloop
-  endfacet
-  facet normal -0.970043 -0.242933 0
-    outer loop
-      vertex 10.4462 0.362855 1
-      vertex 10.476 0.243862 -1
-      vertex 10.476 0.243862 1
-    endloop
-  endfacet
-  facet normal -0.989176 -0.146737 0
-    outer loop
-      vertex 10.494 0.122521 -1
-      vertex 10.476 0.243862 1
-      vertex 10.476 0.243862 -1
-    endloop
-  endfacet
-  facet normal -0.989176 -0.146737 0
-    outer loop
-      vertex 10.476 0.243862 1
-      vertex 10.494 0.122521 -1
-      vertex 10.494 0.122521 1
-    endloop
-  endfacet
-  facet normal -0.941353 -0.337423 0
-    outer loop
-      vertex 10.4462 0.362855 -1
-      vertex 10.4048 0.478354 1
-      vertex 10.4048 0.478354 -1
-    endloop
-  endfacet
-  facet normal -0.941353 -0.337423 0
-    outer loop
-      vertex 10.4048 0.478354 1
-      vertex 10.4462 0.362855 -1
-      vertex 10.4462 0.362855 1
-    endloop
-  endfacet
-  facet normal -0.803494 -0.595313 0
-    outer loop
-      vertex 10.2893 0.694463 -1
-      vertex 10.2163 0.792991 1
-      vertex 10.2163 0.792991 -1
-    endloop
-  endfacet
-  facet normal -0.803494 -0.595313 0
-    outer loop
-      vertex 10.2163 0.792991 1
-      vertex 10.2893 0.694463 -1
-      vertex 10.2893 0.694463 1
-    endloop
-  endfacet
-  facet normal -0.740869 -0.67165 0
-    outer loop
-      vertex 10.2163 0.792991 -1
-      vertex 10.1339 0.883883 1
-      vertex 10.1339 0.883883 -1
-    endloop
-  endfacet
-  facet normal -0.740869 -0.67165 0
-    outer loop
-      vertex 10.1339 0.883883 1
-      vertex 10.2163 0.792991 -1
-      vertex 10.2163 0.792991 1
-    endloop
-  endfacet
-  facet normal -0.857602 -0.514315 0
-    outer loop
-      vertex 10.3524 0.589246 -1
-      vertex 10.2893 0.694463 1
-      vertex 10.2893 0.694463 -1
-    endloop
-  endfacet
-  facet normal -0.857602 -0.514315 0
-    outer loop
-      vertex 10.2893 0.694463 1
-      vertex 10.3524 0.589246 -1
-      vertex 10.3524 0.589246 1
-    endloop
-  endfacet
-  facet normal -0.146738 -0.989175 0
-    outer loop
-      vertex 9.37252 1.24398 -1
-      vertex 9.49386 1.22598 1
-      vertex 9.37252 1.24398 1
-    endloop
-  endfacet
-  facet normal -0.146738 -0.989175 -0
-    outer loop
-      vertex 9.49386 1.22598 1
-      vertex 9.37252 1.24398 -1
-      vertex 9.49386 1.22598 -1
-    endloop
-  endfacet
-  facet normal -0.0490756 -0.998795 0
-    outer loop
-      vertex 9.25 1.25 -1
-      vertex 9.37252 1.24398 1
-      vertex 9.25 1.25 1
-    endloop
-  endfacet
-  facet normal -0.0490756 -0.998795 -0
-    outer loop
-      vertex 9.37252 1.24398 1
-      vertex 9.25 1.25 -1
-      vertex 9.37252 1.24398 -1
-    endloop
-  endfacet
-  facet normal -0.595672 -0.803228 0
-    outer loop
-      vertex 9.94446 1.03934 -1
-      vertex 10.043 0.966263 1
-      vertex 9.94446 1.03934 1
-    endloop
-  endfacet
-  facet normal -0.595672 -0.803228 -0
-    outer loop
-      vertex 10.043 0.966263 1
-      vertex 9.94446 1.03934 -1
-      vertex 10.043 0.966263 -1
-    endloop
-  endfacet
-  facet normal -0.427543 -0.903995 0
-    outer loop
-      vertex 9.72835 1.15485 -1
-      vertex 9.83925 1.1024 1
-      vertex 9.72835 1.15485 1
-    endloop
-  endfacet
-  facet normal -0.427543 -0.903995 -0
-    outer loop
-      vertex 9.83925 1.1024 1
-      vertex 9.72835 1.15485 -1
-      vertex 9.83925 1.1024 -1
-    endloop
-  endfacet
-  facet normal -0.5141 -0.85773 0
-    outer loop
-      vertex 9.83925 1.1024 -1
-      vertex 9.94446 1.03934 1
-      vertex 9.83925 1.1024 1
-    endloop
-  endfacet
-  facet normal -0.5141 -0.85773 -0
-    outer loop
-      vertex 9.94446 1.03934 1
-      vertex 9.83925 1.1024 -1
-      vertex 9.94446 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0.941534 -0.336917 0
-    outer loop
-      vertex 8.05382 0.362855 1
-      vertex 8.09515 0.478354 -1
-      vertex 8.09515 0.478354 1
-    endloop
-  endfacet
-  facet normal 0.941534 -0.336917 0
-    outer loop
-      vertex 8.09515 0.478354 -1
-      vertex 8.05382 0.362855 1
-      vertex 8.05382 0.362855 -1
-    endloop
-  endfacet
-  facet normal 0.989176 -0.146737 0
-    outer loop
-      vertex 8.00602 0.122521 1
-      vertex 8.02402 0.243862 -1
-      vertex 8.02402 0.243862 1
-    endloop
-  endfacet
-  facet normal 0.989176 -0.146737 0
-    outer loop
-      vertex 8.02402 0.243862 -1
-      vertex 8.00602 0.122521 1
-      vertex 8.00602 0.122521 -1
-    endloop
-  endfacet
-  facet normal 0.998795 -0.0490752 0
-    outer loop
-      vertex 8 0 1
-      vertex 8.00602 0.122521 -1
-      vertex 8.00602 0.122521 1
-    endloop
-  endfacet
-  facet normal 0.998795 -0.0490752 0
-    outer loop
-      vertex 8.00602 0.122521 -1
-      vertex 8 0 1
-      vertex 8 0 -1
-    endloop
-  endfacet
-  facet normal 0.595711 -0.803199 0
-    outer loop
-      vertex 8.45701 0.966263 -1
-      vertex 8.55554 1.03934 1
-      vertex 8.45701 0.966263 1
-    endloop
-  endfacet
-  facet normal 0.595711 -0.803199 0
-    outer loop
-      vertex 8.55554 1.03934 1
-      vertex 8.45701 0.966263 -1
-      vertex 8.55554 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0.671568 -0.740943 0
-    outer loop
-      vertex 8.36612 0.883883 -1
-      vertex 8.45701 0.966263 1
-      vertex 8.36612 0.883883 1
-    endloop
-  endfacet
-  facet normal 0.671568 -0.740943 0
-    outer loop
-      vertex 8.45701 0.966263 1
-      vertex 8.36612 0.883883 -1
-      vertex 8.45701 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0.146738 -0.989175 0
-    outer loop
-      vertex 9.00614 1.22598 -1
-      vertex 9.12748 1.24398 1
-      vertex 9.00614 1.22598 1
-    endloop
-  endfacet
-  facet normal 0.146738 -0.989175 0
-    outer loop
-      vertex 9.12748 1.24398 1
-      vertex 9.00614 1.22598 -1
-      vertex 9.12748 1.24398 -1
-    endloop
-  endfacet
-  facet normal 0.336868 -0.941552 0
-    outer loop
-      vertex 8.77165 1.15485 -1
-      vertex 8.88714 1.19617 1
-      vertex 8.77165 1.15485 1
-    endloop
-  endfacet
-  facet normal 0.336868 -0.941552 0
-    outer loop
-      vertex 8.88714 1.19617 1
-      vertex 8.77165 1.15485 -1
-      vertex 8.88714 1.19617 -1
-    endloop
-  endfacet
-  facet normal 0.242996 -0.970027 0
-    outer loop
-      vertex 8.88714 1.19617 -1
-      vertex 9.00614 1.22598 1
-      vertex 8.88714 1.19617 1
-    endloop
-  endfacet
-  facet normal 0.242996 -0.970027 0
-    outer loop
-      vertex 9.00614 1.22598 1
-      vertex 8.88714 1.19617 -1
-      vertex 9.00614 1.22598 -1
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489126 0
-    outer loop
-      vertex 10.494 -0.122521 -1
-      vertex 10.5 0 1
-      vertex 10.5 0 -1
-    endloop
-  endfacet
-  facet normal -0.998803 0.0489126 0
-    outer loop
-      vertex 10.5 0 1
-      vertex 10.494 -0.122521 -1
-      vertex 10.494 -0.122521 1
-    endloop
-  endfacet
-  facet normal -0.857602 0.514315 0
-    outer loop
-      vertex 10.2893 -0.694463 -1
-      vertex 10.3524 -0.589246 1
-      vertex 10.3524 -0.589246 -1
-    endloop
-  endfacet
-  facet normal -0.857602 0.514315 0
-    outer loop
-      vertex 10.3524 -0.589246 1
-      vertex 10.2893 -0.694463 -1
-      vertex 10.2893 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0.941534 0.336917 0
-    outer loop
-      vertex 8.09515 -0.478354 1
-      vertex 8.05382 -0.362855 -1
-      vertex 8.05382 -0.362855 1
-    endloop
-  endfacet
-  facet normal 0.941534 0.336917 0
-    outer loop
-      vertex 8.05382 -0.362855 -1
-      vertex 8.09515 -0.478354 1
-      vertex 8.09515 -0.478354 -1
-    endloop
-  endfacet
-  facet normal -0.427543 0.903995 0
-    outer loop
-      vertex 9.83925 -1.1024 -1
-      vertex 9.72835 -1.15485 1
-      vertex 9.83925 -1.1024 1
-    endloop
-  endfacet
-  facet normal -0.427543 0.903995 0
-    outer loop
-      vertex 9.72835 -1.15485 1
-      vertex 9.83925 -1.1024 -1
-      vertex 9.72835 -1.15485 -1
-    endloop
-  endfacet
-  facet normal -0.336842 0.941561 0
-    outer loop
-      vertex 9.72835 -1.15485 -1
-      vertex 9.61285 -1.19617 1
-      vertex 9.72835 -1.15485 1
-    endloop
-  endfacet
-  facet normal -0.336842 0.941561 0
-    outer loop
-      vertex 9.61285 -1.19617 1
-      vertex 9.72835 -1.15485 -1
-      vertex 9.61285 -1.19617 -1
-    endloop
-  endfacet
-  facet normal -0.243015 -0.970022 0
-    outer loop
-      vertex 9.49386 1.22598 -1
-      vertex 9.61285 1.19617 1
-      vertex 9.49386 1.22598 1
-    endloop
-  endfacet
-  facet normal -0.243015 -0.970022 -0
-    outer loop
-      vertex 9.61285 1.19617 1
-      vertex 9.49386 1.22598 -1
-      vertex 9.61285 1.19617 -1
-    endloop
-  endfacet
-  facet normal 0.803182 -0.595734 0
-    outer loop
-      vertex 8.21066 0.694463 1
-      vertex 8.28374 0.792991 -1
-      vertex 8.28374 0.792991 1
-    endloop
-  endfacet
-  facet normal 0.803182 -0.595734 0
-    outer loop
-      vertex 8.28374 0.792991 -1
-      vertex 8.21066 0.694463 1
-      vertex 8.21066 0.694463 -1
-    endloop
-  endfacet
-  facet normal 0.970043 -0.242933 0
-    outer loop
-      vertex 8.02402 0.243862 1
-      vertex 8.05382 0.362855 -1
-      vertex 8.05382 0.362855 1
-    endloop
-  endfacet
-  facet normal 0.970043 -0.242933 0
-    outer loop
-      vertex 8.05382 0.362855 -1
-      vertex 8.02402 0.243862 1
-      vertex 8.02402 0.243862 -1
-    endloop
-  endfacet
-  facet normal 0.5141 -0.85773 0
-    outer loop
-      vertex 8.55554 1.03934 -1
-      vertex 8.66075 1.1024 1
-      vertex 8.55554 1.03934 1
-    endloop
-  endfacet
-  facet normal 0.5141 -0.85773 0
-    outer loop
-      vertex 8.66075 1.1024 1
-      vertex 8.55554 1.03934 -1
-      vertex 8.66075 1.1024 -1
-    endloop
-  endfacet
-  facet normal -0.970043 0.242933 0
-    outer loop
-      vertex 10.4462 -0.362855 -1
-      vertex 10.476 -0.243862 1
-      vertex 10.476 -0.243862 -1
-    endloop
-  endfacet
-  facet normal -0.970043 0.242933 0
-    outer loop
-      vertex 10.476 -0.243862 1
-      vertex 10.4462 -0.362855 -1
-      vertex 10.4462 -0.362855 1
-    endloop
-  endfacet
-  facet normal -0.989176 0.146737 0
-    outer loop
-      vertex 10.476 -0.243862 -1
-      vertex 10.494 -0.122521 1
-      vertex 10.494 -0.122521 -1
-    endloop
-  endfacet
-  facet normal -0.989176 0.146737 0
-    outer loop
-      vertex 10.494 -0.122521 1
-      vertex 10.476 -0.243862 -1
-      vertex 10.476 -0.243862 1
-    endloop
-  endfacet
-  facet normal -0.5141 0.85773 0
-    outer loop
-      vertex 9.94446 -1.03934 -1
-      vertex 9.83925 -1.1024 1
-      vertex 9.94446 -1.03934 1
-    endloop
-  endfacet
-  facet normal -0.5141 0.85773 0
-    outer loop
-      vertex 9.83925 -1.1024 1
-      vertex 9.94446 -1.03934 -1
-      vertex 9.83925 -1.1024 -1
-    endloop
-  endfacet
-  facet normal -0.740869 0.67165 0
-    outer loop
-      vertex 10.1339 -0.883883 -1
-      vertex 10.2163 -0.792991 1
-      vertex 10.2163 -0.792991 -1
-    endloop
-  endfacet
-  facet normal -0.740869 0.67165 0
-    outer loop
-      vertex 10.2163 -0.792991 1
-      vertex 10.1339 -0.883883 -1
-      vertex 10.1339 -0.883883 1
-    endloop
-  endfacet
-  facet normal -0.904141 0.427235 0
-    outer loop
-      vertex 10.3524 -0.589246 -1
-      vertex 10.4048 -0.478354 1
-      vertex 10.4048 -0.478354 -1
-    endloop
-  endfacet
-  facet normal -0.904141 0.427235 0
-    outer loop
-      vertex 10.4048 -0.478354 1
-      vertex 10.3524 -0.589246 -1
-      vertex 10.3524 -0.589246 1
-    endloop
-  endfacet
-  facet normal -0.0490756 0.998795 0
-    outer loop
-      vertex 9.37252 -1.24398 -1
-      vertex 9.25 -1.25 1
-      vertex 9.37252 -1.24398 1
-    endloop
-  endfacet
-  facet normal -0.0490756 0.998795 0
-    outer loop
-      vertex 9.25 -1.25 1
-      vertex 9.37252 -1.24398 -1
-      vertex 9.25 -1.25 -1
-    endloop
-  endfacet
-  facet normal 0.336868 0.941552 -0
-    outer loop
-      vertex 8.88714 -1.19617 -1
-      vertex 8.77165 -1.15485 1
-      vertex 8.88714 -1.19617 1
-    endloop
-  endfacet
-  facet normal 0.336868 0.941552 0
-    outer loop
-      vertex 8.77165 -1.15485 1
-      vertex 8.88714 -1.19617 -1
-      vertex 8.77165 -1.15485 -1
-    endloop
-  endfacet
-  facet normal 0.857745 0.514075 0
-    outer loop
-      vertex 8.21066 -0.694463 1
-      vertex 8.1476 -0.589246 -1
-      vertex 8.1476 -0.589246 1
-    endloop
-  endfacet
-  facet normal 0.857745 0.514075 0
-    outer loop
-      vertex 8.1476 -0.589246 -1
-      vertex 8.21066 -0.694463 1
-      vertex 8.21066 -0.694463 -1
-    endloop
-  endfacet
-  facet normal 0.989176 0.146737 0
-    outer loop
-      vertex 8.02402 -0.243862 1
-      vertex 8.00602 -0.122521 -1
-      vertex 8.00602 -0.122521 1
-    endloop
-  endfacet
-  facet normal 0.989176 0.146737 0
-    outer loop
-      vertex 8.00602 -0.122521 -1
-      vertex 8.02402 -0.243862 1
-      vertex 8.02402 -0.243862 -1
-    endloop
-  endfacet
-  facet normal -0.803494 0.595313 0
-    outer loop
-      vertex 10.2163 -0.792991 -1
-      vertex 10.2893 -0.694463 1
-      vertex 10.2893 -0.694463 -1
-    endloop
-  endfacet
-  facet normal -0.803494 0.595313 0
-    outer loop
-      vertex 10.2893 -0.694463 1
-      vertex 10.2163 -0.792991 -1
-      vertex 10.2163 -0.792991 1
-    endloop
-  endfacet
-  facet normal -0.671528 0.740979 0
-    outer loop
-      vertex 10.1339 -0.883883 -1
-      vertex 10.043 -0.966263 1
-      vertex 10.1339 -0.883883 1
-    endloop
-  endfacet
-  facet normal -0.671528 0.740979 0
-    outer loop
-      vertex 10.043 -0.966263 1
-      vertex 10.1339 -0.883883 -1
-      vertex 10.043 -0.966263 -1
-    endloop
-  endfacet
-  facet normal -0.595672 0.803228 0
-    outer loop
-      vertex 10.043 -0.966263 -1
-      vertex 9.94446 -1.03934 1
-      vertex 10.043 -0.966263 1
-    endloop
-  endfacet
-  facet normal -0.595672 0.803228 0
-    outer loop
-      vertex 9.94446 -1.03934 1
-      vertex 10.043 -0.966263 -1
-      vertex 9.94446 -1.03934 -1
-    endloop
-  endfacet
-  facet normal -0.941353 0.337423 0
-    outer loop
-      vertex 10.4048 -0.478354 -1
-      vertex 10.4462 -0.362855 1
-      vertex 10.4462 -0.362855 -1
-    endloop
-  endfacet
-  facet normal -0.941353 0.337423 0
-    outer loop
-      vertex 10.4462 -0.362855 1
-      vertex 10.4048 -0.478354 -1
-      vertex 10.4048 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0.0490756 0.998795 -0
-    outer loop
-      vertex 9.25 -1.25 -1
-      vertex 9.12748 -1.24398 1
-      vertex 9.25 -1.25 1
-    endloop
-  endfacet
-  facet normal 0.0490756 0.998795 0
-    outer loop
-      vertex 9.12748 -1.24398 1
-      vertex 9.25 -1.25 -1
-      vertex 9.12748 -1.24398 -1
-    endloop
-  endfacet
-  facet normal 0.242996 0.970027 -0
-    outer loop
-      vertex 9.00614 -1.22598 -1
-      vertex 8.88714 -1.19617 1
-      vertex 9.00614 -1.22598 1
-    endloop
-  endfacet
-  facet normal 0.242996 0.970027 0
-    outer loop
-      vertex 8.88714 -1.19617 1
-      vertex 9.00614 -1.22598 -1
-      vertex 8.88714 -1.19617 -1
-    endloop
-  endfacet
-  facet normal 0.427543 0.903995 -0
-    outer loop
-      vertex 8.77165 -1.15485 -1
-      vertex 8.66075 -1.1024 1
-      vertex 8.77165 -1.15485 1
-    endloop
-  endfacet
-  facet normal 0.427543 0.903995 0
-    outer loop
-      vertex 8.66075 -1.1024 1
-      vertex 8.77165 -1.15485 -1
-      vertex 8.66075 -1.1024 -1
-    endloop
-  endfacet
-  facet normal 0.671568 0.740943 -0
-    outer loop
-      vertex 8.45701 -0.966263 -1
-      vertex 8.36612 -0.883883 1
-      vertex 8.45701 -0.966263 1
-    endloop
-  endfacet
-  facet normal 0.671568 0.740943 0
-    outer loop
-      vertex 8.36612 -0.883883 1
-      vertex 8.45701 -0.966263 -1
-      vertex 8.36612 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0.803182 0.595734 0
-    outer loop
-      vertex 8.28374 -0.792991 1
-      vertex 8.21066 -0.694463 -1
-      vertex 8.21066 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0.803182 0.595734 0
-    outer loop
-      vertex 8.21066 -0.694463 -1
-      vertex 8.28374 -0.792991 1
-      vertex 8.28374 -0.792991 -1
-    endloop
-  endfacet
-  facet normal 0.74095 0.67156 0
-    outer loop
-      vertex 8.36612 -0.883883 1
-      vertex 8.28374 -0.792991 -1
-      vertex 8.28374 -0.792991 1
-    endloop
-  endfacet
-  facet normal 0.74095 0.67156 0
-    outer loop
-      vertex 8.28374 -0.792991 -1
-      vertex 8.36612 -0.883883 1
-      vertex 8.36612 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0.970043 0.242933 0
-    outer loop
-      vertex 8.05382 -0.362855 1
-      vertex 8.02402 -0.243862 -1
-      vertex 8.02402 -0.243862 1
-    endloop
-  endfacet
-  facet normal 0.970043 0.242933 0
-    outer loop
-      vertex 8.02402 -0.243862 -1
-      vertex 8.05382 -0.362855 1
-      vertex 8.05382 -0.362855 -1
-    endloop
-  endfacet
-  facet normal -0.243015 0.970022 0
-    outer loop
-      vertex 9.61285 -1.19617 -1
-      vertex 9.49386 -1.22598 1
-      vertex 9.61285 -1.19617 1
-    endloop
-  endfacet
-  facet normal -0.243015 0.970022 0
-    outer loop
-      vertex 9.49386 -1.22598 1
-      vertex 9.61285 -1.19617 -1
-      vertex 9.49386 -1.22598 -1
+      vertex 8.1476 0.589246 0
     endloop
   endfacet
   facet normal 0.146738 0.989175 -0
     outer loop
-      vertex 9.12748 -1.24398 -1
+      vertex 9.12748 -1.24398 0
       vertex 9.00614 -1.22598 1
       vertex 9.12748 -1.24398 1
     endloop
@@ -17243,13 +12077,69 @@ solid OpenSCAD_Model
   facet normal 0.146738 0.989175 0
     outer loop
       vertex 9.00614 -1.22598 1
-      vertex 9.12748 -1.24398 -1
-      vertex 9.00614 -1.22598 -1
+      vertex 9.12748 -1.24398 0
+      vertex 9.00614 -1.22598 0
+    endloop
+  endfacet
+  facet normal -0.941353 -0.337423 0
+    outer loop
+      vertex 10.4462 0.362855 0
+      vertex 10.4048 0.478354 1
+      vertex 10.4048 0.478354 0
+    endloop
+  endfacet
+  facet normal -0.941353 -0.337423 0
+    outer loop
+      vertex 10.4048 0.478354 1
+      vertex 10.4462 0.362855 0
+      vertex 10.4462 0.362855 1
+    endloop
+  endfacet
+  facet normal 0.0490756 -0.998795 0
+    outer loop
+      vertex 9.12748 1.24398 0
+      vertex 9.25 1.25 1
+      vertex 9.12748 1.24398 1
+    endloop
+  endfacet
+  facet normal 0.0490756 -0.998795 0
+    outer loop
+      vertex 9.25 1.25 1
+      vertex 9.12748 1.24398 0
+      vertex 9.25 1.25 0
+    endloop
+  endfacet
+  facet normal -0.0490756 0.998795 0
+    outer loop
+      vertex 9.37252 -1.24398 0
+      vertex 9.25 -1.25 1
+      vertex 9.37252 -1.24398 1
+    endloop
+  endfacet
+  facet normal -0.0490756 0.998795 0
+    outer loop
+      vertex 9.25 -1.25 1
+      vertex 9.37252 -1.24398 0
+      vertex 9.25 -1.25 0
+    endloop
+  endfacet
+  facet normal 0.903983 0.427568 0
+    outer loop
+      vertex 8.1476 -0.589246 1
+      vertex 8.09515 -0.478354 0
+      vertex 8.09515 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0.903983 0.427568 0
+    outer loop
+      vertex 8.09515 -0.478354 0
+      vertex 8.1476 -0.589246 1
+      vertex 8.1476 -0.589246 0
     endloop
   endfacet
   facet normal 0.595711 0.803199 -0
     outer loop
-      vertex 8.55554 -1.03934 -1
+      vertex 8.55554 -1.03934 0
       vertex 8.45701 -0.966263 1
       vertex 8.55554 -1.03934 1
     endloop
@@ -17257,13 +12147,573 @@ solid OpenSCAD_Model
   facet normal 0.595711 0.803199 0
     outer loop
       vertex 8.45701 -0.966263 1
-      vertex 8.55554 -1.03934 -1
-      vertex 8.45701 -0.966263 -1
+      vertex 8.55554 -1.03934 0
+      vertex 8.45701 -0.966263 0
+    endloop
+  endfacet
+  facet normal 0.803182 -0.595734 0
+    outer loop
+      vertex 8.21066 0.694463 1
+      vertex 8.28374 0.792991 0
+      vertex 8.28374 0.792991 1
+    endloop
+  endfacet
+  facet normal 0.803182 -0.595734 0
+    outer loop
+      vertex 8.28374 0.792991 0
+      vertex 8.21066 0.694463 1
+      vertex 8.21066 0.694463 0
+    endloop
+  endfacet
+  facet normal -0.970043 0.242933 0
+    outer loop
+      vertex 10.4462 -0.362855 0
+      vertex 10.476 -0.243862 1
+      vertex 10.476 -0.243862 0
+    endloop
+  endfacet
+  facet normal -0.970043 0.242933 0
+    outer loop
+      vertex 10.476 -0.243862 1
+      vertex 10.4462 -0.362855 0
+      vertex 10.4462 -0.362855 1
+    endloop
+  endfacet
+  facet normal -0.5141 0.85773 0
+    outer loop
+      vertex 9.94446 -1.03934 0
+      vertex 9.83925 -1.1024 1
+      vertex 9.94446 -1.03934 1
+    endloop
+  endfacet
+  facet normal -0.5141 0.85773 0
+    outer loop
+      vertex 9.83925 -1.1024 1
+      vertex 9.94446 -1.03934 0
+      vertex 9.83925 -1.1024 0
+    endloop
+  endfacet
+  facet normal -0.857602 -0.514315 0
+    outer loop
+      vertex 10.3524 0.589246 0
+      vertex 10.2893 0.694463 1
+      vertex 10.2893 0.694463 0
+    endloop
+  endfacet
+  facet normal -0.857602 -0.514315 0
+    outer loop
+      vertex 10.2893 0.694463 1
+      vertex 10.3524 0.589246 0
+      vertex 10.3524 0.589246 1
+    endloop
+  endfacet
+  facet normal 0.998795 0.0490752 0
+    outer loop
+      vertex 8.00602 -0.122521 1
+      vertex 8 0 0
+      vertex 8 0 1
+    endloop
+  endfacet
+  facet normal 0.998795 0.0490752 0
+    outer loop
+      vertex 8 0 0
+      vertex 8.00602 -0.122521 1
+      vertex 8.00602 -0.122521 0
+    endloop
+  endfacet
+  facet normal -0.904141 -0.427235 0
+    outer loop
+      vertex 10.4048 0.478354 0
+      vertex 10.3524 0.589246 1
+      vertex 10.3524 0.589246 0
+    endloop
+  endfacet
+  facet normal -0.904141 -0.427235 0
+    outer loop
+      vertex 10.3524 0.589246 1
+      vertex 10.4048 0.478354 0
+      vertex 10.4048 0.478354 1
+    endloop
+  endfacet
+  facet normal -0.941353 0.337423 0
+    outer loop
+      vertex 10.4048 -0.478354 0
+      vertex 10.4462 -0.362855 1
+      vertex 10.4462 -0.362855 0
+    endloop
+  endfacet
+  facet normal -0.941353 0.337423 0
+    outer loop
+      vertex 10.4462 -0.362855 1
+      vertex 10.4048 -0.478354 0
+      vertex 10.4048 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0.427543 0.903995 -0
+    outer loop
+      vertex 8.77165 -1.15485 0
+      vertex 8.66075 -1.1024 1
+      vertex 8.77165 -1.15485 1
+    endloop
+  endfacet
+  facet normal 0.427543 0.903995 0
+    outer loop
+      vertex 8.66075 -1.1024 1
+      vertex 8.77165 -1.15485 0
+      vertex 8.66075 -1.1024 0
+    endloop
+  endfacet
+  facet normal 0.970024 0.243009 0
+    outer loop
+      vertex 8.05383 -0.362855 1
+      vertex 8.02402 -0.243862 0
+      vertex 8.02402 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0.970024 0.243009 0
+    outer loop
+      vertex 8.02402 -0.243862 0
+      vertex 8.05383 -0.362855 1
+      vertex 8.05383 -0.362855 0
+    endloop
+  endfacet
+  facet normal 0.74095 -0.67156 0
+    outer loop
+      vertex 8.28374 0.792991 1
+      vertex 8.36612 0.883883 0
+      vertex 8.36612 0.883883 1
+    endloop
+  endfacet
+  facet normal 0.74095 -0.67156 0
+    outer loop
+      vertex 8.36612 0.883883 0
+      vertex 8.28374 0.792991 1
+      vertex 8.28374 0.792991 0
+    endloop
+  endfacet
+  facet normal 0.243015 0.970022 -0
+    outer loop
+      vertex 9.00614 -1.22598 0
+      vertex 8.88715 -1.19617 1
+      vertex 9.00614 -1.22598 1
+    endloop
+  endfacet
+  facet normal 0.243015 0.970022 0
+    outer loop
+      vertex 8.88715 -1.19617 1
+      vertex 9.00614 -1.22598 0
+      vertex 8.88715 -1.19617 0
+    endloop
+  endfacet
+  facet normal 0.5141 -0.85773 0
+    outer loop
+      vertex 8.55554 1.03934 0
+      vertex 8.66075 1.1024 1
+      vertex 8.55554 1.03934 1
+    endloop
+  endfacet
+  facet normal 0.5141 -0.85773 0
+    outer loop
+      vertex 8.66075 1.1024 1
+      vertex 8.55554 1.03934 0
+      vertex 8.66075 1.1024 0
+    endloop
+  endfacet
+  facet normal -0.803494 -0.595313 0
+    outer loop
+      vertex 10.2893 0.694463 0
+      vertex 10.2163 0.792991 1
+      vertex 10.2163 0.792991 0
+    endloop
+  endfacet
+  facet normal -0.803494 -0.595313 0
+    outer loop
+      vertex 10.2163 0.792991 1
+      vertex 10.2893 0.694463 0
+      vertex 10.2893 0.694463 1
+    endloop
+  endfacet
+  facet normal 0.146738 -0.989175 0
+    outer loop
+      vertex 9.00614 1.22598 0
+      vertex 9.12748 1.24398 1
+      vertex 9.00614 1.22598 1
+    endloop
+  endfacet
+  facet normal 0.146738 -0.989175 0
+    outer loop
+      vertex 9.12748 1.24398 1
+      vertex 9.00614 1.22598 0
+      vertex 9.12748 1.24398 0
+    endloop
+  endfacet
+  facet normal -0.427543 0.903995 0
+    outer loop
+      vertex 9.83925 -1.1024 0
+      vertex 9.72835 -1.15485 1
+      vertex 9.83925 -1.1024 1
+    endloop
+  endfacet
+  facet normal -0.427543 0.903995 0
+    outer loop
+      vertex 9.72835 -1.15485 1
+      vertex 9.83925 -1.1024 0
+      vertex 9.72835 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0.671568 -0.740943 0
+    outer loop
+      vertex 8.36612 0.883883 0
+      vertex 8.45701 0.966263 1
+      vertex 8.36612 0.883883 1
+    endloop
+  endfacet
+  facet normal 0.671568 -0.740943 0
+    outer loop
+      vertex 8.45701 0.966263 1
+      vertex 8.36612 0.883883 0
+      vertex 8.45701 0.966263 0
+    endloop
+  endfacet
+  facet normal -0.857602 0.514315 0
+    outer loop
+      vertex 10.2893 -0.694463 0
+      vertex 10.3524 -0.589246 1
+      vertex 10.3524 -0.589246 0
+    endloop
+  endfacet
+  facet normal -0.857602 0.514315 0
+    outer loop
+      vertex 10.3524 -0.589246 1
+      vertex 10.2893 -0.694463 0
+      vertex 10.2893 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0.595711 -0.803199 0
+    outer loop
+      vertex 8.45701 0.966263 0
+      vertex 8.55554 1.03934 1
+      vertex 8.45701 0.966263 1
+    endloop
+  endfacet
+  facet normal 0.595711 -0.803199 0
+    outer loop
+      vertex 8.55554 1.03934 1
+      vertex 8.45701 0.966263 0
+      vertex 8.55554 1.03934 0
+    endloop
+  endfacet
+  facet normal -0.336842 -0.941561 0
+    outer loop
+      vertex 9.61285 1.19617 0
+      vertex 9.72835 1.15485 1
+      vertex 9.61285 1.19617 1
+    endloop
+  endfacet
+  facet normal -0.336842 -0.941561 -0
+    outer loop
+      vertex 9.72835 1.15485 1
+      vertex 9.61285 1.19617 0
+      vertex 9.72835 1.15485 0
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489126 0
+    outer loop
+      vertex 10.494 -0.122521 0
+      vertex 10.5 0 1
+      vertex 10.5 0 0
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489126 0
+    outer loop
+      vertex 10.5 0 1
+      vertex 10.494 -0.122521 0
+      vertex 10.494 -0.122521 1
+    endloop
+  endfacet
+  facet normal 0.94156 0.336845 0
+    outer loop
+      vertex 8.09515 -0.478354 1
+      vertex 8.05383 -0.362855 0
+      vertex 8.05383 -0.362855 1
+    endloop
+  endfacet
+  facet normal 0.94156 0.336845 0
+    outer loop
+      vertex 8.05383 -0.362855 0
+      vertex 8.09515 -0.478354 1
+      vertex 8.09515 -0.478354 0
+    endloop
+  endfacet
+  facet normal -0.5141 -0.85773 0
+    outer loop
+      vertex 9.83925 1.1024 0
+      vertex 9.94446 1.03934 1
+      vertex 9.83925 1.1024 1
+    endloop
+  endfacet
+  facet normal -0.5141 -0.85773 -0
+    outer loop
+      vertex 9.94446 1.03934 1
+      vertex 9.83925 1.1024 0
+      vertex 9.94446 1.03934 0
+    endloop
+  endfacet
+  facet normal -0.595672 -0.803228 0
+    outer loop
+      vertex 9.94446 1.03934 0
+      vertex 10.043 0.966263 1
+      vertex 9.94446 1.03934 1
+    endloop
+  endfacet
+  facet normal -0.595672 -0.803228 -0
+    outer loop
+      vertex 10.043 0.966263 1
+      vertex 9.94446 1.03934 0
+      vertex 10.043 0.966263 0
+    endloop
+  endfacet
+  facet normal -0.146738 0.989175 0
+    outer loop
+      vertex 9.49386 -1.22598 0
+      vertex 9.37252 -1.24398 1
+      vertex 9.49386 -1.22598 1
+    endloop
+  endfacet
+  facet normal -0.146738 0.989175 0
+    outer loop
+      vertex 9.37252 -1.24398 1
+      vertex 9.49386 -1.22598 0
+      vertex 9.37252 -1.24398 0
+    endloop
+  endfacet
+  facet normal -0.740869 0.67165 0
+    outer loop
+      vertex 10.1339 -0.883883 0
+      vertex 10.2163 -0.792991 1
+      vertex 10.2163 -0.792991 0
+    endloop
+  endfacet
+  facet normal -0.740869 0.67165 0
+    outer loop
+      vertex 10.2163 -0.792991 1
+      vertex 10.1339 -0.883883 0
+      vertex 10.1339 -0.883883 1
+    endloop
+  endfacet
+  facet normal -0.803494 0.595313 0
+    outer loop
+      vertex 10.2163 -0.792991 0
+      vertex 10.2893 -0.694463 1
+      vertex 10.2893 -0.694463 0
+    endloop
+  endfacet
+  facet normal -0.803494 0.595313 0
+    outer loop
+      vertex 10.2893 -0.694463 1
+      vertex 10.2163 -0.792991 0
+      vertex 10.2163 -0.792991 1
+    endloop
+  endfacet
+  facet normal -0.243015 0.970022 0
+    outer loop
+      vertex 9.61285 -1.19617 0
+      vertex 9.49386 -1.22598 1
+      vertex 9.61285 -1.19617 1
+    endloop
+  endfacet
+  facet normal -0.243015 0.970022 0
+    outer loop
+      vertex 9.49386 -1.22598 1
+      vertex 9.61285 -1.19617 0
+      vertex 9.49386 -1.22598 0
+    endloop
+  endfacet
+  facet normal -0.904141 0.427235 0
+    outer loop
+      vertex 10.3524 -0.589246 0
+      vertex 10.4048 -0.478354 1
+      vertex 10.4048 -0.478354 0
+    endloop
+  endfacet
+  facet normal -0.904141 0.427235 0
+    outer loop
+      vertex 10.4048 -0.478354 1
+      vertex 10.3524 -0.589246 0
+      vertex 10.3524 -0.589246 1
+    endloop
+  endfacet
+  facet normal 0.243015 -0.970022 0
+    outer loop
+      vertex 8.88715 1.19617 0
+      vertex 9.00614 1.22598 1
+      vertex 8.88715 1.19617 1
+    endloop
+  endfacet
+  facet normal 0.243015 -0.970022 0
+    outer loop
+      vertex 9.00614 1.22598 1
+      vertex 8.88715 1.19617 0
+      vertex 9.00614 1.22598 0
+    endloop
+  endfacet
+  facet normal 0.94156 -0.336845 0
+    outer loop
+      vertex 8.05383 0.362855 1
+      vertex 8.09515 0.478354 0
+      vertex 8.09515 0.478354 1
+    endloop
+  endfacet
+  facet normal 0.94156 -0.336845 0
+    outer loop
+      vertex 8.09515 0.478354 0
+      vertex 8.05383 0.362855 1
+      vertex 8.05383 0.362855 0
+    endloop
+  endfacet
+  facet normal 0.427543 -0.903995 0
+    outer loop
+      vertex 8.66075 1.1024 0
+      vertex 8.77165 1.15485 1
+      vertex 8.66075 1.1024 1
+    endloop
+  endfacet
+  facet normal 0.427543 -0.903995 0
+    outer loop
+      vertex 8.77165 1.15485 1
+      vertex 8.66075 1.1024 0
+      vertex 8.77165 1.15485 0
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146737 0
+    outer loop
+      vertex 8.00602 0.122521 1
+      vertex 8.02402 0.243862 0
+      vertex 8.02402 0.243862 1
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146737 0
+    outer loop
+      vertex 8.02402 0.243862 0
+      vertex 8.00602 0.122521 1
+      vertex 8.00602 0.122521 0
+    endloop
+  endfacet
+  facet normal 0.970024 -0.243009 0
+    outer loop
+      vertex 8.02402 0.243862 1
+      vertex 8.05383 0.362855 0
+      vertex 8.05383 0.362855 1
+    endloop
+  endfacet
+  facet normal 0.970024 -0.243009 0
+    outer loop
+      vertex 8.05383 0.362855 0
+      vertex 8.02402 0.243862 1
+      vertex 8.02402 0.243862 0
+    endloop
+  endfacet
+  facet normal -0.427543 -0.903995 0
+    outer loop
+      vertex 9.72835 1.15485 0
+      vertex 9.83925 1.1024 1
+      vertex 9.72835 1.15485 1
+    endloop
+  endfacet
+  facet normal -0.427543 -0.903995 -0
+    outer loop
+      vertex 9.83925 1.1024 1
+      vertex 9.72835 1.15485 0
+      vertex 9.83925 1.1024 0
+    endloop
+  endfacet
+  facet normal -0.989176 0.146737 0
+    outer loop
+      vertex 10.476 -0.243862 0
+      vertex 10.494 -0.122521 1
+      vertex 10.494 -0.122521 0
+    endloop
+  endfacet
+  facet normal -0.989176 0.146737 0
+    outer loop
+      vertex 10.494 -0.122521 1
+      vertex 10.476 -0.243862 0
+      vertex 10.476 -0.243862 1
+    endloop
+  endfacet
+  facet normal -0.146738 -0.989175 0
+    outer loop
+      vertex 9.37252 1.24398 0
+      vertex 9.49386 1.22598 1
+      vertex 9.37252 1.24398 1
+    endloop
+  endfacet
+  facet normal -0.146738 -0.989175 -0
+    outer loop
+      vertex 9.49386 1.22598 1
+      vertex 9.37252 1.24398 0
+      vertex 9.49386 1.22598 0
+    endloop
+  endfacet
+  facet normal -0.0490756 -0.998795 0
+    outer loop
+      vertex 9.25 1.25 0
+      vertex 9.37252 1.24398 1
+      vertex 9.25 1.25 1
+    endloop
+  endfacet
+  facet normal -0.0490756 -0.998795 -0
+    outer loop
+      vertex 9.37252 1.24398 1
+      vertex 9.25 1.25 0
+      vertex 9.37252 1.24398 0
+    endloop
+  endfacet
+  facet normal 0.74095 0.67156 0
+    outer loop
+      vertex 8.36612 -0.883883 1
+      vertex 8.28374 -0.792991 0
+      vertex 8.28374 -0.792991 1
+    endloop
+  endfacet
+  facet normal 0.74095 0.67156 0
+    outer loop
+      vertex 8.28374 -0.792991 0
+      vertex 8.36612 -0.883883 1
+      vertex 8.36612 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0.857745 0.514075 0
+    outer loop
+      vertex 8.21066 -0.694463 1
+      vertex 8.1476 -0.589246 0
+      vertex 8.1476 -0.589246 1
+    endloop
+  endfacet
+  facet normal 0.857745 0.514075 0
+    outer loop
+      vertex 8.1476 -0.589246 0
+      vertex 8.21066 -0.694463 1
+      vertex 8.21066 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0.336842 -0.941561 0
+    outer loop
+      vertex 8.77165 1.15485 0
+      vertex 8.88715 1.19617 1
+      vertex 8.77165 1.15485 1
+    endloop
+  endfacet
+  facet normal 0.336842 -0.941561 0
+    outer loop
+      vertex 8.88715 1.19617 1
+      vertex 8.77165 1.15485 0
+      vertex 8.88715 1.19617 0
     endloop
   endfacet
   facet normal 0.5141 0.85773 -0
     outer loop
-      vertex 8.66075 -1.1024 -1
+      vertex 8.66075 -1.1024 0
       vertex 8.55554 -1.03934 1
       vertex 8.66075 -1.1024 1
     endloop
@@ -17271,461 +12721,783 @@ solid OpenSCAD_Model
   facet normal 0.5141 0.85773 0
     outer loop
       vertex 8.55554 -1.03934 1
-      vertex 8.66075 -1.1024 -1
-      vertex 8.55554 -1.03934 -1
+      vertex 8.66075 -1.1024 0
+      vertex 8.55554 -1.03934 0
     endloop
   endfacet
-  facet normal 0.998803 -0.0489126 0
+  facet normal -0.595672 0.803228 0
     outer loop
-      vertex -10.5 0 1
-      vertex -10.494 0.122521 -1
-      vertex -10.494 0.122521 1
+      vertex 10.043 -0.966263 0
+      vertex 9.94446 -1.03934 1
+      vertex 10.043 -0.966263 1
     endloop
   endfacet
-  facet normal 0.998803 -0.0489126 0
+  facet normal -0.595672 0.803228 0
     outer loop
-      vertex -10.494 0.122521 -1
-      vertex -10.5 0 1
-      vertex -10.5 0 -1
-    endloop
-  endfacet
-  facet normal 0.803494 -0.595313 0
-    outer loop
-      vertex -10.2893 0.694463 1
-      vertex -10.2163 0.792991 -1
-      vertex -10.2163 0.792991 1
-    endloop
-  endfacet
-  facet normal 0.803494 -0.595313 0
-    outer loop
-      vertex -10.2163 0.792991 -1
-      vertex -10.2893 0.694463 1
-      vertex -10.2893 0.694463 -1
-    endloop
-  endfacet
-  facet normal 0.5141 0.85773 -0
-    outer loop
-      vertex -9.83925 -1.1024 -1
-      vertex -9.94446 -1.03934 1
-      vertex -9.83925 -1.1024 1
-    endloop
-  endfacet
-  facet normal 0.5141 0.85773 0
-    outer loop
-      vertex -9.94446 -1.03934 1
-      vertex -9.83925 -1.1024 -1
-      vertex -9.94446 -1.03934 -1
-    endloop
-  endfacet
-  facet normal 0.970043 -0.242933 0
-    outer loop
-      vertex -10.476 0.243862 1
-      vertex -10.4462 0.362855 -1
-      vertex -10.4462 0.362855 1
-    endloop
-  endfacet
-  facet normal 0.970043 -0.242933 0
-    outer loop
-      vertex -10.4462 0.362855 -1
-      vertex -10.476 0.243862 1
-      vertex -10.476 0.243862 -1
-    endloop
-  endfacet
-  facet normal -0.146738 -0.989175 0
-    outer loop
-      vertex -9.12748 1.24398 -1
-      vertex -9.00614 1.22598 1
-      vertex -9.12748 1.24398 1
-    endloop
-  endfacet
-  facet normal -0.146738 -0.989175 -0
-    outer loop
-      vertex -9.00614 1.22598 1
-      vertex -9.12748 1.24398 -1
-      vertex -9.00614 1.22598 -1
-    endloop
-  endfacet
-  facet normal -0.803182 -0.595734 0
-    outer loop
-      vertex -8.21066 0.694463 -1
-      vertex -8.28374 0.792991 1
-      vertex -8.28374 0.792991 -1
-    endloop
-  endfacet
-  facet normal -0.803182 -0.595734 0
-    outer loop
-      vertex -8.28374 0.792991 1
-      vertex -8.21066 0.694463 -1
-      vertex -8.21066 0.694463 1
-    endloop
-  endfacet
-  facet normal -0.671568 0.740943 0
-    outer loop
-      vertex -8.36612 -0.883883 -1
-      vertex -8.45701 -0.966263 1
-      vertex -8.36612 -0.883883 1
-    endloop
-  endfacet
-  facet normal -0.671568 0.740943 0
-    outer loop
-      vertex -8.45701 -0.966263 1
-      vertex -8.36612 -0.883883 -1
-      vertex -8.45701 -0.966263 -1
-    endloop
-  endfacet
-  facet normal -0.0490756 0.998795 0
-    outer loop
-      vertex -9.12748 -1.24398 -1
-      vertex -9.25 -1.25 1
-      vertex -9.12748 -1.24398 1
-    endloop
-  endfacet
-  facet normal -0.0490756 0.998795 0
-    outer loop
-      vertex -9.25 -1.25 1
-      vertex -9.12748 -1.24398 -1
-      vertex -9.25 -1.25 -1
-    endloop
-  endfacet
-  facet normal 0.740869 0.67165 0
-    outer loop
-      vertex -10.1339 -0.883883 1
-      vertex -10.2163 -0.792991 -1
-      vertex -10.2163 -0.792991 1
-    endloop
-  endfacet
-  facet normal 0.740869 0.67165 0
-    outer loop
-      vertex -10.2163 -0.792991 -1
-      vertex -10.1339 -0.883883 1
-      vertex -10.1339 -0.883883 -1
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489126 0
-    outer loop
-      vertex -10.494 -0.122521 1
-      vertex -10.5 0 -1
-      vertex -10.5 0 1
-    endloop
-  endfacet
-  facet normal 0.998803 0.0489126 0
-    outer loop
-      vertex -10.5 0 -1
-      vertex -10.494 -0.122521 1
-      vertex -10.494 -0.122521 -1
-    endloop
-  endfacet
-  facet normal 0.989176 -0.146737 0
-    outer loop
-      vertex -10.494 0.122521 1
-      vertex -10.476 0.243862 -1
-      vertex -10.476 0.243862 1
-    endloop
-  endfacet
-  facet normal 0.989176 -0.146737 0
-    outer loop
-      vertex -10.476 0.243862 -1
-      vertex -10.494 0.122521 1
-      vertex -10.494 0.122521 -1
-    endloop
-  endfacet
-  facet normal 0.671528 -0.740979 0
-    outer loop
-      vertex -10.1339 0.883883 -1
-      vertex -10.043 0.966263 1
-      vertex -10.1339 0.883883 1
-    endloop
-  endfacet
-  facet normal 0.671528 -0.740979 0
-    outer loop
-      vertex -10.043 0.966263 1
-      vertex -10.1339 0.883883 -1
-      vertex -10.043 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0.904141 -0.427235 0
-    outer loop
-      vertex -10.4048 0.478354 1
-      vertex -10.3524 0.589246 -1
-      vertex -10.3524 0.589246 1
-    endloop
-  endfacet
-  facet normal 0.904141 -0.427235 0
-    outer loop
-      vertex -10.3524 0.589246 -1
-      vertex -10.4048 0.478354 1
-      vertex -10.4048 0.478354 -1
-    endloop
-  endfacet
-  facet normal 0.336842 -0.941561 0
-    outer loop
-      vertex -9.72835 1.15485 -1
-      vertex -9.61285 1.19617 1
-      vertex -9.72835 1.15485 1
-    endloop
-  endfacet
-  facet normal 0.336842 -0.941561 0
-    outer loop
-      vertex -9.61285 1.19617 1
-      vertex -9.72835 1.15485 -1
-      vertex -9.61285 1.19617 -1
-    endloop
-  endfacet
-  facet normal -0.857745 0.514075 0
-    outer loop
-      vertex -8.21066 -0.694463 -1
-      vertex -8.1476 -0.589246 1
-      vertex -8.1476 -0.589246 -1
-    endloop
-  endfacet
-  facet normal -0.857745 0.514075 0
-    outer loop
-      vertex -8.1476 -0.589246 1
-      vertex -8.21066 -0.694463 -1
-      vertex -8.21066 -0.694463 1
-    endloop
-  endfacet
-  facet normal -0.242996 0.970027 0
-    outer loop
-      vertex -8.88714 -1.19617 -1
-      vertex -9.00614 -1.22598 1
-      vertex -8.88714 -1.19617 1
-    endloop
-  endfacet
-  facet normal -0.242996 0.970027 0
-    outer loop
-      vertex -9.00614 -1.22598 1
-      vertex -8.88714 -1.19617 -1
-      vertex -9.00614 -1.22598 -1
-    endloop
-  endfacet
-  facet normal 0.427543 0.903995 -0
-    outer loop
-      vertex -9.72835 -1.15485 -1
-      vertex -9.83925 -1.1024 1
-      vertex -9.72835 -1.15485 1
-    endloop
-  endfacet
-  facet normal 0.427543 0.903995 0
-    outer loop
-      vertex -9.83925 -1.1024 1
-      vertex -9.72835 -1.15485 -1
-      vertex -9.83925 -1.1024 -1
-    endloop
-  endfacet
-  facet normal 0.803494 0.595313 0
-    outer loop
-      vertex -10.2163 -0.792991 1
-      vertex -10.2893 -0.694463 -1
-      vertex -10.2893 -0.694463 1
-    endloop
-  endfacet
-  facet normal 0.803494 0.595313 0
-    outer loop
-      vertex -10.2893 -0.694463 -1
-      vertex -10.2163 -0.792991 1
-      vertex -10.2163 -0.792991 -1
-    endloop
-  endfacet
-  facet normal 0.941353 -0.337423 0
-    outer loop
-      vertex -10.4462 0.362855 1
-      vertex -10.4048 0.478354 -1
-      vertex -10.4048 0.478354 1
-    endloop
-  endfacet
-  facet normal 0.941353 -0.337423 0
-    outer loop
-      vertex -10.4048 0.478354 -1
-      vertex -10.4462 0.362855 1
-      vertex -10.4462 0.362855 -1
-    endloop
-  endfacet
-  facet normal 0.857602 -0.514315 0
-    outer loop
-      vertex -10.3524 0.589246 1
-      vertex -10.2893 0.694463 -1
-      vertex -10.2893 0.694463 1
-    endloop
-  endfacet
-  facet normal 0.857602 -0.514315 0
-    outer loop
-      vertex -10.2893 0.694463 -1
-      vertex -10.3524 0.589246 1
-      vertex -10.3524 0.589246 -1
-    endloop
-  endfacet
-  facet normal 0.740869 -0.67165 0
-    outer loop
-      vertex -10.2163 0.792991 1
-      vertex -10.1339 0.883883 -1
-      vertex -10.1339 0.883883 1
-    endloop
-  endfacet
-  facet normal 0.740869 -0.67165 0
-    outer loop
-      vertex -10.1339 0.883883 -1
-      vertex -10.2163 0.792991 1
-      vertex -10.2163 0.792991 -1
-    endloop
-  endfacet
-  facet normal -0.970043 -0.242933 0
-    outer loop
-      vertex -8.02402 0.243862 -1
-      vertex -8.05382 0.362855 1
-      vertex -8.05382 0.362855 -1
-    endloop
-  endfacet
-  facet normal -0.970043 -0.242933 0
-    outer loop
-      vertex -8.05382 0.362855 1
-      vertex -8.02402 0.243862 -1
-      vertex -8.02402 0.243862 1
-    endloop
-  endfacet
-  facet normal -0.595711 -0.803199 0
-    outer loop
-      vertex -8.55554 1.03934 -1
-      vertex -8.45701 0.966263 1
-      vertex -8.55554 1.03934 1
-    endloop
-  endfacet
-  facet normal -0.595711 -0.803199 -0
-    outer loop
-      vertex -8.45701 0.966263 1
-      vertex -8.55554 1.03934 -1
-      vertex -8.45701 0.966263 -1
-    endloop
-  endfacet
-  facet normal 0.0490756 -0.998795 0
-    outer loop
-      vertex -9.37252 1.24398 -1
-      vertex -9.25 1.25 1
-      vertex -9.37252 1.24398 1
-    endloop
-  endfacet
-  facet normal 0.0490756 -0.998795 0
-    outer loop
-      vertex -9.25 1.25 1
-      vertex -9.37252 1.24398 -1
-      vertex -9.25 1.25 -1
-    endloop
-  endfacet
-  facet normal -0.0490756 -0.998795 0
-    outer loop
-      vertex -9.25 1.25 -1
-      vertex -9.12748 1.24398 1
-      vertex -9.25 1.25 1
-    endloop
-  endfacet
-  facet normal -0.0490756 -0.998795 -0
-    outer loop
-      vertex -9.12748 1.24398 1
-      vertex -9.25 1.25 -1
-      vertex -9.12748 1.24398 -1
-    endloop
-  endfacet
-  facet normal -0.595711 0.803199 0
-    outer loop
-      vertex -8.45701 -0.966263 -1
-      vertex -8.55554 -1.03934 1
-      vertex -8.45701 -0.966263 1
-    endloop
-  endfacet
-  facet normal -0.595711 0.803199 0
-    outer loop
-      vertex -8.55554 -1.03934 1
-      vertex -8.45701 -0.966263 -1
-      vertex -8.55554 -1.03934 -1
-    endloop
-  endfacet
-  facet normal -0.74095 0.67156 0
-    outer loop
-      vertex -8.36612 -0.883883 -1
-      vertex -8.28374 -0.792991 1
-      vertex -8.28374 -0.792991 -1
-    endloop
-  endfacet
-  facet normal -0.74095 0.67156 0
-    outer loop
-      vertex -8.28374 -0.792991 1
-      vertex -8.36612 -0.883883 -1
-      vertex -8.36612 -0.883883 1
-    endloop
-  endfacet
-  facet normal 0.0490756 0.998795 -0
-    outer loop
-      vertex -9.25 -1.25 -1
-      vertex -9.37252 -1.24398 1
-      vertex -9.25 -1.25 1
-    endloop
-  endfacet
-  facet normal 0.0490756 0.998795 0
-    outer loop
-      vertex -9.37252 -1.24398 1
-      vertex -9.25 -1.25 -1
-      vertex -9.37252 -1.24398 -1
-    endloop
-  endfacet
-  facet normal -0.146738 0.989175 0
-    outer loop
-      vertex -9.00614 -1.22598 -1
-      vertex -9.12748 -1.24398 1
-      vertex -9.00614 -1.22598 1
-    endloop
-  endfacet
-  facet normal -0.146738 0.989175 0
-    outer loop
-      vertex -9.12748 -1.24398 1
-      vertex -9.00614 -1.22598 -1
-      vertex -9.12748 -1.24398 -1
-    endloop
-  endfacet
-  facet normal -0.5141 0.85773 0
-    outer loop
-      vertex -8.55554 -1.03934 -1
-      vertex -8.66075 -1.1024 1
-      vertex -8.55554 -1.03934 1
-    endloop
-  endfacet
-  facet normal -0.5141 0.85773 0
-    outer loop
-      vertex -8.66075 -1.1024 1
-      vertex -8.55554 -1.03934 -1
-      vertex -8.66075 -1.1024 -1
-    endloop
-  endfacet
-  facet normal -0.427543 0.903995 0
-    outer loop
-      vertex -8.66075 -1.1024 -1
-      vertex -8.77165 -1.15485 1
-      vertex -8.66075 -1.1024 1
-    endloop
-  endfacet
-  facet normal -0.427543 0.903995 0
-    outer loop
-      vertex -8.77165 -1.15485 1
-      vertex -8.66075 -1.1024 -1
-      vertex -8.77165 -1.15485 -1
-    endloop
-  endfacet
-  facet normal 0.243015 0.970022 -0
-    outer loop
-      vertex -9.49386 -1.22598 -1
-      vertex -9.61285 -1.19617 1
-      vertex -9.49386 -1.22598 1
-    endloop
-  endfacet
-  facet normal 0.243015 0.970022 0
-    outer loop
-      vertex -9.61285 -1.19617 1
-      vertex -9.49386 -1.22598 -1
-      vertex -9.61285 -1.19617 -1
+      vertex 9.94446 -1.03934 1
+      vertex 10.043 -0.966263 0
+      vertex 9.94446 -1.03934 0
     endloop
   endfacet
   facet normal 0.336842 0.941561 -0
     outer loop
-      vertex -9.61285 -1.19617 -1
+      vertex 8.88715 -1.19617 0
+      vertex 8.77165 -1.15485 1
+      vertex 8.88715 -1.19617 1
+    endloop
+  endfacet
+  facet normal 0.336842 0.941561 0
+    outer loop
+      vertex 8.77165 -1.15485 1
+      vertex 8.88715 -1.19617 0
+      vertex 8.77165 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0.803182 0.595734 0
+    outer loop
+      vertex 8.28374 -0.792991 1
+      vertex 8.21066 -0.694463 0
+      vertex 8.21066 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0.803182 0.595734 0
+    outer loop
+      vertex 8.21066 -0.694463 0
+      vertex 8.28374 -0.792991 1
+      vertex 8.28374 -0.792991 0
+    endloop
+  endfacet
+  facet normal 0.903983 -0.427568 0
+    outer loop
+      vertex 8.09515 0.478354 1
+      vertex 8.1476 0.589246 0
+      vertex 8.1476 0.589246 1
+    endloop
+  endfacet
+  facet normal 0.903983 -0.427568 0
+    outer loop
+      vertex 8.1476 0.589246 0
+      vertex 8.09515 0.478354 1
+      vertex 8.09515 0.478354 0
+    endloop
+  endfacet
+  facet normal 0.989176 0.146737 0
+    outer loop
+      vertex 8.02402 -0.243862 1
+      vertex 8.00602 -0.122521 0
+      vertex 8.00602 -0.122521 1
+    endloop
+  endfacet
+  facet normal 0.989176 0.146737 0
+    outer loop
+      vertex 8.00602 -0.122521 0
+      vertex 8.02402 -0.243862 1
+      vertex 8.02402 -0.243862 0
+    endloop
+  endfacet
+  facet normal -0.740869 -0.67165 0
+    outer loop
+      vertex 10.2163 0.792991 0
+      vertex 10.1339 0.883883 1
+      vertex 10.1339 0.883883 0
+    endloop
+  endfacet
+  facet normal -0.740869 -0.67165 0
+    outer loop
+      vertex 10.1339 0.883883 1
+      vertex 10.2163 0.792991 0
+      vertex 10.2163 0.792991 1
+    endloop
+  endfacet
+  facet normal -0.243015 -0.970022 0
+    outer loop
+      vertex 9.49386 1.22598 0
+      vertex 9.61285 1.19617 1
+      vertex 9.49386 1.22598 1
+    endloop
+  endfacet
+  facet normal -0.243015 -0.970022 -0
+    outer loop
+      vertex 9.61285 1.19617 1
+      vertex 9.49386 1.22598 0
+      vertex 9.61285 1.19617 0
+    endloop
+  endfacet
+  facet normal 0.671568 0.740943 -0
+    outer loop
+      vertex 8.45701 -0.966263 0
+      vertex 8.36612 -0.883883 1
+      vertex 8.45701 -0.966263 1
+    endloop
+  endfacet
+  facet normal 0.671568 0.740943 0
+    outer loop
+      vertex 8.36612 -0.883883 1
+      vertex 8.45701 -0.966263 0
+      vertex 8.36612 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0.0490756 0.998795 -0
+    outer loop
+      vertex 9.25 -1.25 0
+      vertex 9.12748 -1.24398 1
+      vertex 9.25 -1.25 1
+    endloop
+  endfacet
+  facet normal 0.0490756 0.998795 0
+    outer loop
+      vertex 9.12748 -1.24398 1
+      vertex 9.25 -1.25 0
+      vertex 9.12748 -1.24398 0
+    endloop
+  endfacet
+  facet normal 0.998795 -0.0490752 0
+    outer loop
+      vertex 8 0 1
+      vertex 8.00602 0.122521 0
+      vertex 8.00602 0.122521 1
+    endloop
+  endfacet
+  facet normal 0.998795 -0.0490752 0
+    outer loop
+      vertex 8.00602 0.122521 0
+      vertex 8 0 1
+      vertex 8 0 0
+    endloop
+  endfacet
+  facet normal -0.671528 0.740979 0
+    outer loop
+      vertex 10.1339 -0.883883 0
+      vertex 10.043 -0.966263 1
+      vertex 10.1339 -0.883883 1
+    endloop
+  endfacet
+  facet normal -0.671528 0.740979 0
+    outer loop
+      vertex 10.043 -0.966263 1
+      vertex 10.1339 -0.883883 0
+      vertex 10.043 -0.966263 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 8.25 -1.73205 0
+      vertex 10.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 10.25 -1.73205 -1
+      vertex 8.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 10.25 -1.73205 -1
+      vertex 11.25 0 0
+      vertex 11.25 0 -1
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 11.25 0 0
+      vertex 10.25 -1.73205 -1
+      vertex 10.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 8.25 1.73205 -1
+      vertex 10.25 1.73205 0
+      vertex 8.25 1.73205 0
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 10.25 1.73205 0
+      vertex 8.25 1.73205 -1
+      vertex 10.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 11.25 0 -1
+      vertex 10.25 1.73205 0
+      vertex 10.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex 10.25 1.73205 0
+      vertex 11.25 0 -1
+      vertex 11.25 0 0
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 7.25 0 0
+      vertex 8.25 1.73205 -1
+      vertex 8.25 1.73205 0
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 8.25 1.73205 -1
+      vertex 7.25 0 0
+      vertex 7.25 0 -1
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 7.25 0 -1
+      vertex 7.25 0 0
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 7.25 0 -1
+      vertex 8.25 -1.73205 0
+      vertex 8.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.25 0 0
+      vertex 10.494 -0.122521 0
+      vertex 10.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 0
+      vertex 10.476 -0.243862 0
+      vertex 10.494 -0.122521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 0
+      vertex 10.4462 -0.362855 0
+      vertex 10.476 -0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 0
+      vertex 10.4048 -0.478354 0
+      vertex 10.4462 -0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.25 0 0
+      vertex 10.3524 -0.589246 0
+      vertex 10.4048 -0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 10.3524 -0.589246 0
+      vertex 11.25 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.3524 -0.589246 0
+      vertex 10.25 -1.73205 0
+      vertex 10.2893 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 10.2163 -0.792991 0
+      vertex 10.2893 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 10.1339 -0.883883 0
+      vertex 10.2163 -0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 10.043 -0.966263 0
+      vertex 10.1339 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.94446 -1.03934 0
+      vertex 10.043 -0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.83925 -1.1024 0
+      vertex 9.94446 -1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.72835 -1.15485 0
+      vertex 9.83925 -1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.61285 -1.19617 0
+      vertex 9.72835 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.49386 -1.22598 0
+      vertex 9.61285 -1.19617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.37252 -1.24398 0
+      vertex 9.49386 -1.22598 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 -1.73205 0
+      vertex 9.25 -1.25 0
+      vertex 9.37252 -1.24398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 9.25 -1.25 0
+      vertex 10.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.25 -1.25 0
+      vertex 8.25 -1.73205 0
+      vertex 9.12748 -1.24398 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.12748 -1.24398 0
+      vertex 8.25 -1.73205 0
+      vertex 9.00614 -1.22598 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 9.00614 -1.22598 0
+      vertex 8.25 -1.73205 0
+      vertex 8.88715 -1.19617 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.88715 -1.19617 0
+      vertex 8.25 -1.73205 0
+      vertex 8.77165 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.66075 -1.1024 0
+      vertex 8.77165 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.55554 -1.03934 0
+      vertex 8.66075 -1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.45701 -0.966263 0
+      vertex 8.55554 -1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.36612 -0.883883 0
+      vertex 8.45701 -0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.28374 -0.792991 0
+      vertex 8.36612 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.21066 -0.694463 0
+      vertex 8.28374 -0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 -1.73205 0
+      vertex 8.1476 -0.589246 0
+      vertex 8.21066 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25 0 0
+      vertex 8.1476 -0.589246 0
+      vertex 8.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.1476 -0.589246 0
+      vertex 7.25 0 0
+      vertex 8.09515 -0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.09515 -0.478354 0
+      vertex 7.25 0 0
+      vertex 8.05383 -0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.00602 -0.122521 0
+      vertex 7.25 0 0
+      vertex 8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.02402 -0.243862 0
+      vertex 7.25 0 0
+      vertex 8.00602 -0.122521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.05383 -0.362855 0
+      vertex 7.25 0 0
+      vertex 8.02402 -0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.494 0.122521 0
+      vertex 11.25 0 0
+      vertex 10.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.476 0.243862 0
+      vertex 11.25 0 0
+      vertex 10.494 0.122521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.4462 0.362855 0
+      vertex 11.25 0 0
+      vertex 10.476 0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.4048 0.478354 0
+      vertex 11.25 0 0
+      vertex 10.4462 0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.3524 0.589246 0
+      vertex 11.25 0 0
+      vertex 10.4048 0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.25 1.73205 0
+      vertex 10.3524 0.589246 0
+      vertex 10.2893 0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.3524 0.589246 0
+      vertex 10.25 1.73205 0
+      vertex 11.25 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.2163 0.792991 0
+      vertex 10.25 1.73205 0
+      vertex 10.2893 0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.1339 0.883883 0
+      vertex 10.25 1.73205 0
+      vertex 10.2163 0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.043 0.966263 0
+      vertex 10.25 1.73205 0
+      vertex 10.1339 0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.94446 1.03934 0
+      vertex 10.25 1.73205 0
+      vertex 10.043 0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.83925 1.1024 0
+      vertex 10.25 1.73205 0
+      vertex 9.94446 1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.72835 1.15485 0
+      vertex 10.25 1.73205 0
+      vertex 9.83925 1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.61285 1.19617 0
+      vertex 10.25 1.73205 0
+      vertex 9.72835 1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.49386 1.22598 0
+      vertex 10.25 1.73205 0
+      vertex 9.61285 1.19617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.37252 1.24398 0
+      vertex 10.25 1.73205 0
+      vertex 9.49386 1.22598 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.25 1.25 0
+      vertex 10.25 1.73205 0
+      vertex 9.37252 1.24398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 1.73205 0
+      vertex 9.25 1.25 0
+      vertex 9.12748 1.24398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 1.73205 0
+      vertex 9.12748 1.24398 0
+      vertex 9.00614 1.22598 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 1.73205 0
+      vertex 9.00614 1.22598 0
+      vertex 8.88715 1.19617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.25 1.73205 0
+      vertex 8.88715 1.19617 0
+      vertex 8.77165 1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.25 1.25 0
+      vertex 8.25 1.73205 0
+      vertex 10.25 1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.66075 1.1024 0
+      vertex 8.25 1.73205 0
+      vertex 8.77165 1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.55554 1.03934 0
+      vertex 8.25 1.73205 0
+      vertex 8.66075 1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.45701 0.966263 0
+      vertex 8.25 1.73205 0
+      vertex 8.55554 1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.36612 0.883883 0
+      vertex 8.25 1.73205 0
+      vertex 8.45701 0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.28374 0.792991 0
+      vertex 8.25 1.73205 0
+      vertex 8.36612 0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.21066 0.694463 0
+      vertex 8.25 1.73205 0
+      vertex 8.28374 0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.1476 0.589246 0
+      vertex 8.25 1.73205 0
+      vertex 8.21066 0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25 0 0
+      vertex 8.1476 0.589246 0
+      vertex 8.09515 0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25 0 0
+      vertex 8.09515 0.478354 0
+      vertex 8.05383 0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25 0 0
+      vertex 8.05383 0.362855 0
+      vertex 8.02402 0.243862 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.1476 0.589246 0
+      vertex 7.25 0 0
+      vertex 8.25 1.73205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.00602 0.122521 0
+      vertex 7.25 0 0
+      vertex 8.02402 0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7.25 0 0
+      vertex 8.00602 0.122521 0
+      vertex 8 0 0
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146737 0
+    outer loop
+      vertex -10.494 0.122521 1
+      vertex -10.476 0.243862 0
+      vertex -10.476 0.243862 1
+    endloop
+  endfacet
+  facet normal 0.989176 -0.146737 0
+    outer loop
+      vertex -10.476 0.243862 0
+      vertex -10.494 0.122521 1
+      vertex -10.494 0.122521 0
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489126 0
+    outer loop
+      vertex -10.5 0 1
+      vertex -10.494 0.122521 0
+      vertex -10.494 0.122521 1
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489126 0
+    outer loop
+      vertex -10.494 0.122521 0
+      vertex -10.5 0 1
+      vertex -10.5 0 0
+    endloop
+  endfacet
+  facet normal 0.970043 -0.242933 0
+    outer loop
+      vertex -10.476 0.243862 1
+      vertex -10.4462 0.362855 0
+      vertex -10.4462 0.362855 1
+    endloop
+  endfacet
+  facet normal 0.970043 -0.242933 0
+    outer loop
+      vertex -10.4462 0.362855 0
+      vertex -10.476 0.243862 1
+      vertex -10.476 0.243862 0
+    endloop
+  endfacet
+  facet normal 0.336842 0.941561 -0
+    outer loop
+      vertex -9.61285 -1.19617 0
       vertex -9.72835 -1.15485 1
       vertex -9.61285 -1.19617 1
     endloop
@@ -17733,139 +13505,279 @@ solid OpenSCAD_Model
   facet normal 0.336842 0.941561 0
     outer loop
       vertex -9.72835 -1.15485 1
-      vertex -9.61285 -1.19617 -1
-      vertex -9.72835 -1.15485 -1
+      vertex -9.61285 -1.19617 0
+      vertex -9.72835 -1.15485 0
     endloop
   endfacet
-  facet normal 0.595672 0.803228 -0
+  facet normal 0.671528 -0.740979 0
     outer loop
-      vertex -9.94446 -1.03934 -1
-      vertex -10.043 -0.966263 1
-      vertex -9.94446 -1.03934 1
+      vertex -10.1339 0.883883 0
+      vertex -10.043 0.966263 1
+      vertex -10.1339 0.883883 1
     endloop
   endfacet
-  facet normal 0.595672 0.803228 0
+  facet normal 0.671528 -0.740979 0
     outer loop
-      vertex -10.043 -0.966263 1
-      vertex -9.94446 -1.03934 -1
-      vertex -10.043 -0.966263 -1
+      vertex -10.043 0.966263 1
+      vertex -10.1339 0.883883 0
+      vertex -10.043 0.966263 0
     endloop
   endfacet
-  facet normal 0.671528 0.740979 -0
+  facet normal -0.857745 -0.514075 0
     outer loop
-      vertex -10.043 -0.966263 -1
-      vertex -10.1339 -0.883883 1
-      vertex -10.043 -0.966263 1
+      vertex -8.1476 0.589246 0
+      vertex -8.21066 0.694463 1
+      vertex -8.21066 0.694463 0
     endloop
   endfacet
-  facet normal 0.671528 0.740979 0
+  facet normal -0.857745 -0.514075 0
     outer loop
-      vertex -10.1339 -0.883883 1
-      vertex -10.043 -0.966263 -1
-      vertex -10.1339 -0.883883 -1
+      vertex -8.21066 0.694463 1
+      vertex -8.1476 0.589246 0
+      vertex -8.1476 0.589246 1
     endloop
   endfacet
-  facet normal 0.857602 0.514315 0
+  facet normal -0.146738 0.989175 0
     outer loop
-      vertex -10.2893 -0.694463 1
-      vertex -10.3524 -0.589246 -1
-      vertex -10.3524 -0.589246 1
+      vertex -9.00614 -1.22598 0
+      vertex -9.12748 -1.24398 1
+      vertex -9.00614 -1.22598 1
     endloop
   endfacet
-  facet normal 0.857602 0.514315 0
+  facet normal -0.146738 0.989175 0
     outer loop
-      vertex -10.3524 -0.589246 -1
-      vertex -10.2893 -0.694463 1
-      vertex -10.2893 -0.694463 -1
+      vertex -9.12748 -1.24398 1
+      vertex -9.00614 -1.22598 0
+      vertex -9.12748 -1.24398 0
     endloop
   endfacet
-  facet normal -0.970043 0.242933 0
+  facet normal 0.941353 -0.337423 0
     outer loop
-      vertex -8.05382 -0.362855 -1
-      vertex -8.02402 -0.243862 1
-      vertex -8.02402 -0.243862 -1
+      vertex -10.4462 0.362855 1
+      vertex -10.4048 0.478354 0
+      vertex -10.4048 0.478354 1
     endloop
   endfacet
-  facet normal -0.970043 0.242933 0
+  facet normal 0.941353 -0.337423 0
     outer loop
-      vertex -8.02402 -0.243862 1
-      vertex -8.05382 -0.362855 -1
-      vertex -8.05382 -0.362855 1
+      vertex -10.4048 0.478354 0
+      vertex -10.4462 0.362855 1
+      vertex -10.4462 0.362855 0
     endloop
   endfacet
-  facet normal -0.989176 0.146737 0
+  facet normal -0.0490756 -0.998795 0
     outer loop
-      vertex -8.02402 -0.243862 -1
-      vertex -8.00602 -0.122521 1
-      vertex -8.00602 -0.122521 -1
+      vertex -9.25 1.25 0
+      vertex -9.12748 1.24398 1
+      vertex -9.25 1.25 1
     endloop
   endfacet
-  facet normal -0.989176 0.146737 0
+  facet normal -0.0490756 -0.998795 -0
     outer loop
-      vertex -8.00602 -0.122521 1
-      vertex -8.02402 -0.243862 -1
-      vertex -8.02402 -0.243862 1
+      vertex -9.12748 1.24398 1
+      vertex -9.25 1.25 0
+      vertex -9.12748 1.24398 0
+    endloop
+  endfacet
+  facet normal 0.0490756 0.998795 -0
+    outer loop
+      vertex -9.25 -1.25 0
+      vertex -9.37252 -1.24398 1
+      vertex -9.25 -1.25 1
+    endloop
+  endfacet
+  facet normal 0.0490756 0.998795 0
+    outer loop
+      vertex -9.37252 -1.24398 1
+      vertex -9.25 -1.25 0
+      vertex -9.37252 -1.24398 0
     endloop
   endfacet
   facet normal -0.903983 0.427568 0
     outer loop
-      vertex -8.1476 -0.589246 -1
+      vertex -8.1476 -0.589246 0
       vertex -8.09515 -0.478354 1
-      vertex -8.09515 -0.478354 -1
+      vertex -8.09515 -0.478354 0
     endloop
   endfacet
   facet normal -0.903983 0.427568 0
     outer loop
       vertex -8.09515 -0.478354 1
-      vertex -8.1476 -0.589246 -1
+      vertex -8.1476 -0.589246 0
       vertex -8.1476 -0.589246 1
     endloop
   endfacet
+  facet normal -0.595711 0.803199 0
+    outer loop
+      vertex -8.45701 -0.966263 0
+      vertex -8.55554 -1.03934 1
+      vertex -8.45701 -0.966263 1
+    endloop
+  endfacet
+  facet normal -0.595711 0.803199 0
+    outer loop
+      vertex -8.55554 -1.03934 1
+      vertex -8.45701 -0.966263 0
+      vertex -8.55554 -1.03934 0
+    endloop
+  endfacet
+  facet normal -0.803182 -0.595734 0
+    outer loop
+      vertex -8.21066 0.694463 0
+      vertex -8.28374 0.792991 1
+      vertex -8.28374 0.792991 0
+    endloop
+  endfacet
+  facet normal -0.803182 -0.595734 0
+    outer loop
+      vertex -8.28374 0.792991 1
+      vertex -8.21066 0.694463 0
+      vertex -8.21066 0.694463 1
+    endloop
+  endfacet
+  facet normal 0.970043 0.242933 0
+    outer loop
+      vertex -10.4462 -0.362855 1
+      vertex -10.476 -0.243862 0
+      vertex -10.476 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0.970043 0.242933 0
+    outer loop
+      vertex -10.476 -0.243862 0
+      vertex -10.4462 -0.362855 1
+      vertex -10.4462 -0.362855 0
+    endloop
+  endfacet
+  facet normal 0.5141 0.85773 -0
+    outer loop
+      vertex -9.83925 -1.1024 0
+      vertex -9.94446 -1.03934 1
+      vertex -9.83925 -1.1024 1
+    endloop
+  endfacet
+  facet normal 0.5141 0.85773 0
+    outer loop
+      vertex -9.94446 -1.03934 1
+      vertex -9.83925 -1.1024 0
+      vertex -9.94446 -1.03934 0
+    endloop
+  endfacet
+  facet normal 0.857602 -0.514315 0
+    outer loop
+      vertex -10.3524 0.589246 1
+      vertex -10.2893 0.694463 0
+      vertex -10.2893 0.694463 1
+    endloop
+  endfacet
+  facet normal 0.857602 -0.514315 0
+    outer loop
+      vertex -10.2893 0.694463 0
+      vertex -10.3524 0.589246 1
+      vertex -10.3524 0.589246 0
+    endloop
+  endfacet
   facet normal -0.998795 0.0490752 0
     outer loop
-      vertex -8.00602 -0.122521 -1
+      vertex -8.00602 -0.122521 0
       vertex -8 0 1
-      vertex -8 0 -1
+      vertex -8 0 0
     endloop
   endfacet
   facet normal -0.998795 0.0490752 0
     outer loop
       vertex -8 0 1
-      vertex -8.00602 -0.122521 -1
+      vertex -8.00602 -0.122521 0
       vertex -8.00602 -0.122521 1
     endloop
   endfacet
-  facet normal -0.989176 -0.146737 0
+  facet normal 0.904141 -0.427235 0
     outer loop
-      vertex -8.00602 0.122521 -1
-      vertex -8.02402 0.243862 1
-      vertex -8.02402 0.243862 -1
+      vertex -10.4048 0.478354 1
+      vertex -10.3524 0.589246 0
+      vertex -10.3524 0.589246 1
     endloop
   endfacet
-  facet normal -0.989176 -0.146737 0
+  facet normal 0.904141 -0.427235 0
     outer loop
-      vertex -8.02402 0.243862 1
-      vertex -8.00602 0.122521 -1
-      vertex -8.00602 0.122521 1
+      vertex -10.3524 0.589246 0
+      vertex -10.4048 0.478354 1
+      vertex -10.4048 0.478354 0
     endloop
   endfacet
-  facet normal -0.336868 -0.941552 0
+  facet normal 0.941353 0.337423 0
     outer loop
-      vertex -8.88714 1.19617 -1
-      vertex -8.77165 1.15485 1
-      vertex -8.88714 1.19617 1
+      vertex -10.4048 -0.478354 1
+      vertex -10.4462 -0.362855 0
+      vertex -10.4462 -0.362855 1
     endloop
   endfacet
-  facet normal -0.336868 -0.941552 -0
+  facet normal 0.941353 0.337423 0
     outer loop
-      vertex -8.77165 1.15485 1
-      vertex -8.88714 1.19617 -1
-      vertex -8.77165 1.15485 -1
+      vertex -10.4462 -0.362855 0
+      vertex -10.4048 -0.478354 1
+      vertex -10.4048 -0.478354 0
+    endloop
+  endfacet
+  facet normal -0.427543 0.903995 0
+    outer loop
+      vertex -8.66075 -1.1024 0
+      vertex -8.77165 -1.15485 1
+      vertex -8.66075 -1.1024 1
+    endloop
+  endfacet
+  facet normal -0.427543 0.903995 0
+    outer loop
+      vertex -8.77165 -1.15485 1
+      vertex -8.66075 -1.1024 0
+      vertex -8.77165 -1.15485 0
+    endloop
+  endfacet
+  facet normal -0.970024 0.243009 0
+    outer loop
+      vertex -8.05383 -0.362855 0
+      vertex -8.02402 -0.243862 1
+      vertex -8.02402 -0.243862 0
+    endloop
+  endfacet
+  facet normal -0.970024 0.243009 0
+    outer loop
+      vertex -8.02402 -0.243862 1
+      vertex -8.05383 -0.362855 0
+      vertex -8.05383 -0.362855 1
+    endloop
+  endfacet
+  facet normal -0.74095 -0.67156 0
+    outer loop
+      vertex -8.28374 0.792991 0
+      vertex -8.36612 0.883883 1
+      vertex -8.36612 0.883883 0
+    endloop
+  endfacet
+  facet normal -0.74095 -0.67156 0
+    outer loop
+      vertex -8.36612 0.883883 1
+      vertex -8.28374 0.792991 0
+      vertex -8.28374 0.792991 1
+    endloop
+  endfacet
+  facet normal -0.243015 0.970022 0
+    outer loop
+      vertex -8.88715 -1.19617 0
+      vertex -9.00614 -1.22598 1
+      vertex -8.88715 -1.19617 1
+    endloop
+  endfacet
+  facet normal -0.243015 0.970022 0
+    outer loop
+      vertex -9.00614 -1.22598 1
+      vertex -8.88715 -1.19617 0
+      vertex -9.00614 -1.22598 0
     endloop
   endfacet
   facet normal -0.5141 -0.85773 0
     outer loop
-      vertex -8.66075 1.1024 -1
+      vertex -8.66075 1.1024 0
       vertex -8.55554 1.03934 1
       vertex -8.66075 1.1024 1
     endloop
@@ -17873,209 +13785,55 @@ solid OpenSCAD_Model
   facet normal -0.5141 -0.85773 -0
     outer loop
       vertex -8.55554 1.03934 1
-      vertex -8.66075 1.1024 -1
-      vertex -8.55554 1.03934 -1
+      vertex -8.66075 1.1024 0
+      vertex -8.55554 1.03934 0
     endloop
   endfacet
-  facet normal -0.903983 -0.427568 0
+  facet normal 0.803494 -0.595313 0
     outer loop
-      vertex -8.09515 0.478354 -1
-      vertex -8.1476 0.589246 1
-      vertex -8.1476 0.589246 -1
+      vertex -10.2893 0.694463 1
+      vertex -10.2163 0.792991 0
+      vertex -10.2163 0.792991 1
     endloop
   endfacet
-  facet normal -0.903983 -0.427568 0
+  facet normal 0.803494 -0.595313 0
     outer loop
-      vertex -8.1476 0.589246 1
-      vertex -8.09515 0.478354 -1
-      vertex -8.09515 0.478354 1
+      vertex -10.2163 0.792991 0
+      vertex -10.2893 0.694463 1
+      vertex -10.2893 0.694463 0
     endloop
   endfacet
-  facet normal 0.243015 -0.970022 0
+  facet normal -0.146738 -0.989175 0
     outer loop
-      vertex -9.61285 1.19617 -1
-      vertex -9.49386 1.22598 1
-      vertex -9.61285 1.19617 1
-    endloop
-  endfacet
-  facet normal 0.243015 -0.970022 0
-    outer loop
-      vertex -9.49386 1.22598 1
-      vertex -9.61285 1.19617 -1
-      vertex -9.49386 1.22598 -1
-    endloop
-  endfacet
-  facet normal 0.146738 -0.989175 0
-    outer loop
-      vertex -9.49386 1.22598 -1
-      vertex -9.37252 1.24398 1
-      vertex -9.49386 1.22598 1
-    endloop
-  endfacet
-  facet normal 0.146738 -0.989175 0
-    outer loop
-      vertex -9.37252 1.24398 1
-      vertex -9.49386 1.22598 -1
-      vertex -9.37252 1.24398 -1
-    endloop
-  endfacet
-  facet normal -0.336868 0.941552 0
-    outer loop
-      vertex -8.77165 -1.15485 -1
-      vertex -8.88714 -1.19617 1
-      vertex -8.77165 -1.15485 1
-    endloop
-  endfacet
-  facet normal -0.336868 0.941552 0
-    outer loop
-      vertex -8.88714 -1.19617 1
-      vertex -8.77165 -1.15485 -1
-      vertex -8.88714 -1.19617 -1
-    endloop
-  endfacet
-  facet normal 0.146738 0.989175 -0
-    outer loop
-      vertex -9.37252 -1.24398 -1
-      vertex -9.49386 -1.22598 1
-      vertex -9.37252 -1.24398 1
-    endloop
-  endfacet
-  facet normal 0.146738 0.989175 0
-    outer loop
-      vertex -9.49386 -1.22598 1
-      vertex -9.37252 -1.24398 -1
-      vertex -9.49386 -1.22598 -1
-    endloop
-  endfacet
-  facet normal 0.904141 0.427235 0
-    outer loop
-      vertex -10.3524 -0.589246 1
-      vertex -10.4048 -0.478354 -1
-      vertex -10.4048 -0.478354 1
-    endloop
-  endfacet
-  facet normal 0.904141 0.427235 0
-    outer loop
-      vertex -10.4048 -0.478354 -1
-      vertex -10.3524 -0.589246 1
-      vertex -10.3524 -0.589246 -1
-    endloop
-  endfacet
-  facet normal 0.595672 -0.803228 0
-    outer loop
-      vertex -10.043 0.966263 -1
-      vertex -9.94446 1.03934 1
-      vertex -10.043 0.966263 1
-    endloop
-  endfacet
-  facet normal 0.595672 -0.803228 0
-    outer loop
-      vertex -9.94446 1.03934 1
-      vertex -10.043 0.966263 -1
-      vertex -9.94446 1.03934 -1
-    endloop
-  endfacet
-  facet normal 0.5141 -0.85773 0
-    outer loop
-      vertex -9.94446 1.03934 -1
-      vertex -9.83925 1.1024 1
-      vertex -9.94446 1.03934 1
-    endloop
-  endfacet
-  facet normal 0.5141 -0.85773 0
-    outer loop
-      vertex -9.83925 1.1024 1
-      vertex -9.94446 1.03934 -1
-      vertex -9.83925 1.1024 -1
-    endloop
-  endfacet
-  facet normal 0.427543 -0.903995 0
-    outer loop
-      vertex -9.83925 1.1024 -1
-      vertex -9.72835 1.15485 1
-      vertex -9.83925 1.1024 1
-    endloop
-  endfacet
-  facet normal 0.427543 -0.903995 0
-    outer loop
-      vertex -9.72835 1.15485 1
-      vertex -9.83925 1.1024 -1
-      vertex -9.72835 1.15485 -1
-    endloop
-  endfacet
-  facet normal -0.941534 0.336917 0
-    outer loop
-      vertex -8.09515 -0.478354 -1
-      vertex -8.05382 -0.362855 1
-      vertex -8.05382 -0.362855 -1
-    endloop
-  endfacet
-  facet normal -0.941534 0.336917 0
-    outer loop
-      vertex -8.05382 -0.362855 1
-      vertex -8.09515 -0.478354 -1
-      vertex -8.09515 -0.478354 1
-    endloop
-  endfacet
-  facet normal -0.803182 0.595734 0
-    outer loop
-      vertex -8.28374 -0.792991 -1
-      vertex -8.21066 -0.694463 1
-      vertex -8.21066 -0.694463 -1
-    endloop
-  endfacet
-  facet normal -0.803182 0.595734 0
-    outer loop
-      vertex -8.21066 -0.694463 1
-      vertex -8.28374 -0.792991 -1
-      vertex -8.28374 -0.792991 1
-    endloop
-  endfacet
-  facet normal -0.998795 -0.0490752 0
-    outer loop
-      vertex -8 0 -1
-      vertex -8.00602 0.122521 1
-      vertex -8.00602 0.122521 -1
-    endloop
-  endfacet
-  facet normal -0.998795 -0.0490752 0
-    outer loop
-      vertex -8.00602 0.122521 1
-      vertex -8 0 -1
-      vertex -8 0 1
-    endloop
-  endfacet
-  facet normal -0.242996 -0.970027 0
-    outer loop
-      vertex -9.00614 1.22598 -1
-      vertex -8.88714 1.19617 1
+      vertex -9.12748 1.24398 0
       vertex -9.00614 1.22598 1
+      vertex -9.12748 1.24398 1
     endloop
   endfacet
-  facet normal -0.242996 -0.970027 -0
+  facet normal -0.146738 -0.989175 -0
     outer loop
-      vertex -8.88714 1.19617 1
-      vertex -9.00614 1.22598 -1
-      vertex -8.88714 1.19617 -1
+      vertex -9.00614 1.22598 1
+      vertex -9.12748 1.24398 0
+      vertex -9.00614 1.22598 0
     endloop
   endfacet
-  facet normal -0.427543 -0.903995 0
+  facet normal 0.427543 0.903995 -0
     outer loop
-      vertex -8.77165 1.15485 -1
-      vertex -8.66075 1.1024 1
-      vertex -8.77165 1.15485 1
+      vertex -9.72835 -1.15485 0
+      vertex -9.83925 -1.1024 1
+      vertex -9.72835 -1.15485 1
     endloop
   endfacet
-  facet normal -0.427543 -0.903995 -0
+  facet normal 0.427543 0.903995 0
     outer loop
-      vertex -8.66075 1.1024 1
-      vertex -8.77165 1.15485 -1
-      vertex -8.66075 1.1024 -1
+      vertex -9.83925 -1.1024 1
+      vertex -9.72835 -1.15485 0
+      vertex -9.83925 -1.1024 0
     endloop
   endfacet
   facet normal -0.671568 -0.740943 0
     outer loop
-      vertex -8.45701 0.966263 -1
+      vertex -8.45701 0.966263 0
       vertex -8.36612 0.883883 1
       vertex -8.45701 0.966263 1
     endloop
@@ -18083,92 +13841,4670 @@ solid OpenSCAD_Model
   facet normal -0.671568 -0.740943 -0
     outer loop
       vertex -8.36612 0.883883 1
-      vertex -8.45701 0.966263 -1
-      vertex -8.36612 0.883883 -1
+      vertex -8.45701 0.966263 0
+      vertex -8.36612 0.883883 0
     endloop
   endfacet
-  facet normal -0.941534 -0.336917 0
+  facet normal 0.857602 0.514315 0
     outer loop
-      vertex -8.05382 0.362855 -1
-      vertex -8.09515 0.478354 1
-      vertex -8.09515 0.478354 -1
+      vertex -10.2893 -0.694463 1
+      vertex -10.3524 -0.589246 0
+      vertex -10.3524 -0.589246 1
     endloop
   endfacet
-  facet normal -0.941534 -0.336917 0
+  facet normal 0.857602 0.514315 0
     outer loop
-      vertex -8.09515 0.478354 1
-      vertex -8.05382 0.362855 -1
-      vertex -8.05382 0.362855 1
+      vertex -10.3524 -0.589246 0
+      vertex -10.2893 -0.694463 1
+      vertex -10.2893 -0.694463 0
     endloop
   endfacet
-  facet normal 0.941353 0.337423 0
+  facet normal -0.595711 -0.803199 0
     outer loop
+      vertex -8.55554 1.03934 0
+      vertex -8.45701 0.966263 1
+      vertex -8.55554 1.03934 1
+    endloop
+  endfacet
+  facet normal -0.595711 -0.803199 -0
+    outer loop
+      vertex -8.45701 0.966263 1
+      vertex -8.55554 1.03934 0
+      vertex -8.45701 0.966263 0
+    endloop
+  endfacet
+  facet normal 0.336842 -0.941561 0
+    outer loop
+      vertex -9.72835 1.15485 0
+      vertex -9.61285 1.19617 1
+      vertex -9.72835 1.15485 1
+    endloop
+  endfacet
+  facet normal 0.336842 -0.941561 0
+    outer loop
+      vertex -9.61285 1.19617 1
+      vertex -9.72835 1.15485 0
+      vertex -9.61285 1.19617 0
+    endloop
+  endfacet
+  facet normal 0.740869 -0.67165 0
+    outer loop
+      vertex -10.2163 0.792991 1
+      vertex -10.1339 0.883883 0
+      vertex -10.1339 0.883883 1
+    endloop
+  endfacet
+  facet normal 0.740869 -0.67165 0
+    outer loop
+      vertex -10.1339 0.883883 0
+      vertex -10.2163 0.792991 1
+      vertex -10.2163 0.792991 0
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489126 0
+    outer loop
+      vertex -10.494 -0.122521 1
+      vertex -10.5 0 0
+      vertex -10.5 0 1
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489126 0
+    outer loop
+      vertex -10.5 0 0
+      vertex -10.494 -0.122521 1
+      vertex -10.494 -0.122521 0
+    endloop
+  endfacet
+  facet normal -0.94156 0.336845 0
+    outer loop
+      vertex -8.09515 -0.478354 0
+      vertex -8.05383 -0.362855 1
+      vertex -8.05383 -0.362855 0
+    endloop
+  endfacet
+  facet normal -0.94156 0.336845 0
+    outer loop
+      vertex -8.05383 -0.362855 1
+      vertex -8.09515 -0.478354 0
+      vertex -8.09515 -0.478354 1
+    endloop
+  endfacet
+  facet normal 0.5141 -0.85773 0
+    outer loop
+      vertex -9.94446 1.03934 0
+      vertex -9.83925 1.1024 1
+      vertex -9.94446 1.03934 1
+    endloop
+  endfacet
+  facet normal 0.5141 -0.85773 0
+    outer loop
+      vertex -9.83925 1.1024 1
+      vertex -9.94446 1.03934 0
+      vertex -9.83925 1.1024 0
+    endloop
+  endfacet
+  facet normal 0.595672 -0.803228 0
+    outer loop
+      vertex -10.043 0.966263 0
+      vertex -9.94446 1.03934 1
+      vertex -10.043 0.966263 1
+    endloop
+  endfacet
+  facet normal 0.595672 -0.803228 0
+    outer loop
+      vertex -9.94446 1.03934 1
+      vertex -10.043 0.966263 0
+      vertex -9.94446 1.03934 0
+    endloop
+  endfacet
+  facet normal 0.146738 0.989175 -0
+    outer loop
+      vertex -9.37252 -1.24398 0
+      vertex -9.49386 -1.22598 1
+      vertex -9.37252 -1.24398 1
+    endloop
+  endfacet
+  facet normal 0.146738 0.989175 0
+    outer loop
+      vertex -9.49386 -1.22598 1
+      vertex -9.37252 -1.24398 0
+      vertex -9.49386 -1.22598 0
+    endloop
+  endfacet
+  facet normal 0.740869 0.67165 0
+    outer loop
+      vertex -10.1339 -0.883883 1
+      vertex -10.2163 -0.792991 0
+      vertex -10.2163 -0.792991 1
+    endloop
+  endfacet
+  facet normal 0.740869 0.67165 0
+    outer loop
+      vertex -10.2163 -0.792991 0
+      vertex -10.1339 -0.883883 1
+      vertex -10.1339 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0.803494 0.595313 0
+    outer loop
+      vertex -10.2163 -0.792991 1
+      vertex -10.2893 -0.694463 0
+      vertex -10.2893 -0.694463 1
+    endloop
+  endfacet
+  facet normal 0.803494 0.595313 0
+    outer loop
+      vertex -10.2893 -0.694463 0
+      vertex -10.2163 -0.792991 1
+      vertex -10.2163 -0.792991 0
+    endloop
+  endfacet
+  facet normal 0.243015 0.970022 -0
+    outer loop
+      vertex -9.49386 -1.22598 0
+      vertex -9.61285 -1.19617 1
+      vertex -9.49386 -1.22598 1
+    endloop
+  endfacet
+  facet normal 0.243015 0.970022 0
+    outer loop
+      vertex -9.61285 -1.19617 1
+      vertex -9.49386 -1.22598 0
+      vertex -9.61285 -1.19617 0
+    endloop
+  endfacet
+  facet normal 0.904141 0.427235 0
+    outer loop
+      vertex -10.3524 -0.589246 1
+      vertex -10.4048 -0.478354 0
       vertex -10.4048 -0.478354 1
-      vertex -10.4462 -0.362855 -1
-      vertex -10.4462 -0.362855 1
     endloop
   endfacet
-  facet normal 0.941353 0.337423 0
+  facet normal 0.904141 0.427235 0
     outer loop
-      vertex -10.4462 -0.362855 -1
-      vertex -10.4048 -0.478354 1
-      vertex -10.4048 -0.478354 -1
+      vertex -10.4048 -0.478354 0
+      vertex -10.3524 -0.589246 1
+      vertex -10.3524 -0.589246 0
     endloop
   endfacet
-  facet normal -0.74095 -0.67156 0
+  facet normal -0.243015 -0.970022 0
     outer loop
-      vertex -8.28374 0.792991 -1
-      vertex -8.36612 0.883883 1
-      vertex -8.36612 0.883883 -1
+      vertex -9.00614 1.22598 0
+      vertex -8.88715 1.19617 1
+      vertex -9.00614 1.22598 1
     endloop
   endfacet
-  facet normal -0.74095 -0.67156 0
+  facet normal -0.243015 -0.970022 -0
     outer loop
-      vertex -8.36612 0.883883 1
-      vertex -8.28374 0.792991 -1
-      vertex -8.28374 0.792991 1
+      vertex -8.88715 1.19617 1
+      vertex -9.00614 1.22598 0
+      vertex -8.88715 1.19617 0
     endloop
   endfacet
-  facet normal -0.857745 -0.514075 0
+  facet normal -0.94156 -0.336845 0
     outer loop
-      vertex -8.1476 0.589246 -1
-      vertex -8.21066 0.694463 1
-      vertex -8.21066 0.694463 -1
+      vertex -8.05383 0.362855 0
+      vertex -8.09515 0.478354 1
+      vertex -8.09515 0.478354 0
     endloop
   endfacet
-  facet normal -0.857745 -0.514075 0
+  facet normal -0.94156 -0.336845 0
     outer loop
-      vertex -8.21066 0.694463 1
-      vertex -8.1476 0.589246 -1
-      vertex -8.1476 0.589246 1
+      vertex -8.09515 0.478354 1
+      vertex -8.05383 0.362855 0
+      vertex -8.05383 0.362855 1
     endloop
   endfacet
-  facet normal 0.970043 0.242933 0
+  facet normal -0.427543 -0.903995 0
     outer loop
-      vertex -10.4462 -0.362855 1
-      vertex -10.476 -0.243862 -1
-      vertex -10.476 -0.243862 1
+      vertex -8.77165 1.15485 0
+      vertex -8.66075 1.1024 1
+      vertex -8.77165 1.15485 1
     endloop
   endfacet
-  facet normal 0.970043 0.242933 0
+  facet normal -0.427543 -0.903995 -0
     outer loop
-      vertex -10.476 -0.243862 -1
-      vertex -10.4462 -0.362855 1
-      vertex -10.4462 -0.362855 -1
+      vertex -8.66075 1.1024 1
+      vertex -8.77165 1.15485 0
+      vertex -8.66075 1.1024 0
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146737 0
+    outer loop
+      vertex -8.00602 0.122521 0
+      vertex -8.02402 0.243862 1
+      vertex -8.02402 0.243862 0
+    endloop
+  endfacet
+  facet normal -0.989176 -0.146737 0
+    outer loop
+      vertex -8.02402 0.243862 1
+      vertex -8.00602 0.122521 0
+      vertex -8.00602 0.122521 1
+    endloop
+  endfacet
+  facet normal -0.970024 -0.243009 0
+    outer loop
+      vertex -8.02402 0.243862 0
+      vertex -8.05383 0.362855 1
+      vertex -8.05383 0.362855 0
+    endloop
+  endfacet
+  facet normal -0.970024 -0.243009 0
+    outer loop
+      vertex -8.05383 0.362855 1
+      vertex -8.02402 0.243862 0
+      vertex -8.02402 0.243862 1
+    endloop
+  endfacet
+  facet normal 0.427543 -0.903995 0
+    outer loop
+      vertex -9.83925 1.1024 0
+      vertex -9.72835 1.15485 1
+      vertex -9.83925 1.1024 1
+    endloop
+  endfacet
+  facet normal 0.427543 -0.903995 0
+    outer loop
+      vertex -9.72835 1.15485 1
+      vertex -9.83925 1.1024 0
+      vertex -9.72835 1.15485 0
     endloop
   endfacet
   facet normal 0.989176 0.146737 0
     outer loop
       vertex -10.476 -0.243862 1
-      vertex -10.494 -0.122521 -1
+      vertex -10.494 -0.122521 0
       vertex -10.494 -0.122521 1
     endloop
   endfacet
   facet normal 0.989176 0.146737 0
     outer loop
-      vertex -10.494 -0.122521 -1
+      vertex -10.494 -0.122521 0
       vertex -10.476 -0.243862 1
-      vertex -10.476 -0.243862 -1
+      vertex -10.476 -0.243862 0
+    endloop
+  endfacet
+  facet normal 0.146738 -0.989175 0
+    outer loop
+      vertex -9.49386 1.22598 0
+      vertex -9.37252 1.24398 1
+      vertex -9.49386 1.22598 1
+    endloop
+  endfacet
+  facet normal 0.146738 -0.989175 0
+    outer loop
+      vertex -9.37252 1.24398 1
+      vertex -9.49386 1.22598 0
+      vertex -9.37252 1.24398 0
+    endloop
+  endfacet
+  facet normal 0.0490756 -0.998795 0
+    outer loop
+      vertex -9.37252 1.24398 0
+      vertex -9.25 1.25 1
+      vertex -9.37252 1.24398 1
+    endloop
+  endfacet
+  facet normal 0.0490756 -0.998795 0
+    outer loop
+      vertex -9.25 1.25 1
+      vertex -9.37252 1.24398 0
+      vertex -9.25 1.25 0
+    endloop
+  endfacet
+  facet normal -0.74095 0.67156 0
+    outer loop
+      vertex -8.36612 -0.883883 0
+      vertex -8.28374 -0.792991 1
+      vertex -8.28374 -0.792991 0
+    endloop
+  endfacet
+  facet normal -0.74095 0.67156 0
+    outer loop
+      vertex -8.28374 -0.792991 1
+      vertex -8.36612 -0.883883 0
+      vertex -8.36612 -0.883883 1
+    endloop
+  endfacet
+  facet normal -0.857745 0.514075 0
+    outer loop
+      vertex -8.21066 -0.694463 0
+      vertex -8.1476 -0.589246 1
+      vertex -8.1476 -0.589246 0
+    endloop
+  endfacet
+  facet normal -0.857745 0.514075 0
+    outer loop
+      vertex -8.1476 -0.589246 1
+      vertex -8.21066 -0.694463 0
+      vertex -8.21066 -0.694463 1
+    endloop
+  endfacet
+  facet normal -0.336842 -0.941561 0
+    outer loop
+      vertex -8.88715 1.19617 0
+      vertex -8.77165 1.15485 1
+      vertex -8.88715 1.19617 1
+    endloop
+  endfacet
+  facet normal -0.336842 -0.941561 -0
+    outer loop
+      vertex -8.77165 1.15485 1
+      vertex -8.88715 1.19617 0
+      vertex -8.77165 1.15485 0
+    endloop
+  endfacet
+  facet normal -0.5141 0.85773 0
+    outer loop
+      vertex -8.55554 -1.03934 0
+      vertex -8.66075 -1.1024 1
+      vertex -8.55554 -1.03934 1
+    endloop
+  endfacet
+  facet normal -0.5141 0.85773 0
+    outer loop
+      vertex -8.66075 -1.1024 1
+      vertex -8.55554 -1.03934 0
+      vertex -8.66075 -1.1024 0
+    endloop
+  endfacet
+  facet normal 0.595672 0.803228 -0
+    outer loop
+      vertex -9.94446 -1.03934 0
+      vertex -10.043 -0.966263 1
+      vertex -9.94446 -1.03934 1
+    endloop
+  endfacet
+  facet normal 0.595672 0.803228 0
+    outer loop
+      vertex -10.043 -0.966263 1
+      vertex -9.94446 -1.03934 0
+      vertex -10.043 -0.966263 0
+    endloop
+  endfacet
+  facet normal -0.336842 0.941561 0
+    outer loop
+      vertex -8.77165 -1.15485 0
+      vertex -8.88715 -1.19617 1
+      vertex -8.77165 -1.15485 1
+    endloop
+  endfacet
+  facet normal -0.336842 0.941561 0
+    outer loop
+      vertex -8.88715 -1.19617 1
+      vertex -8.77165 -1.15485 0
+      vertex -8.88715 -1.19617 0
+    endloop
+  endfacet
+  facet normal -0.803182 0.595734 0
+    outer loop
+      vertex -8.28374 -0.792991 0
+      vertex -8.21066 -0.694463 1
+      vertex -8.21066 -0.694463 0
+    endloop
+  endfacet
+  facet normal -0.803182 0.595734 0
+    outer loop
+      vertex -8.21066 -0.694463 1
+      vertex -8.28374 -0.792991 0
+      vertex -8.28374 -0.792991 1
+    endloop
+  endfacet
+  facet normal -0.903983 -0.427568 0
+    outer loop
+      vertex -8.09515 0.478354 0
+      vertex -8.1476 0.589246 1
+      vertex -8.1476 0.589246 0
+    endloop
+  endfacet
+  facet normal -0.903983 -0.427568 0
+    outer loop
+      vertex -8.1476 0.589246 1
+      vertex -8.09515 0.478354 0
+      vertex -8.09515 0.478354 1
+    endloop
+  endfacet
+  facet normal -0.989176 0.146737 0
+    outer loop
+      vertex -8.02402 -0.243862 0
+      vertex -8.00602 -0.122521 1
+      vertex -8.00602 -0.122521 0
+    endloop
+  endfacet
+  facet normal -0.989176 0.146737 0
+    outer loop
+      vertex -8.00602 -0.122521 1
+      vertex -8.02402 -0.243862 0
+      vertex -8.02402 -0.243862 1
+    endloop
+  endfacet
+  facet normal 0.243015 -0.970022 0
+    outer loop
+      vertex -9.61285 1.19617 0
+      vertex -9.49386 1.22598 1
+      vertex -9.61285 1.19617 1
+    endloop
+  endfacet
+  facet normal 0.243015 -0.970022 0
+    outer loop
+      vertex -9.49386 1.22598 1
+      vertex -9.61285 1.19617 0
+      vertex -9.49386 1.22598 0
+    endloop
+  endfacet
+  facet normal -0.671568 0.740943 0
+    outer loop
+      vertex -8.36612 -0.883883 0
+      vertex -8.45701 -0.966263 1
+      vertex -8.36612 -0.883883 1
+    endloop
+  endfacet
+  facet normal -0.671568 0.740943 0
+    outer loop
+      vertex -8.45701 -0.966263 1
+      vertex -8.36612 -0.883883 0
+      vertex -8.45701 -0.966263 0
+    endloop
+  endfacet
+  facet normal -0.0490756 0.998795 0
+    outer loop
+      vertex -9.12748 -1.24398 0
+      vertex -9.25 -1.25 1
+      vertex -9.12748 -1.24398 1
+    endloop
+  endfacet
+  facet normal -0.0490756 0.998795 0
+    outer loop
+      vertex -9.25 -1.25 1
+      vertex -9.12748 -1.24398 0
+      vertex -9.25 -1.25 0
+    endloop
+  endfacet
+  facet normal -0.998795 -0.0490752 0
+    outer loop
+      vertex -8 0 0
+      vertex -8.00602 0.122521 1
+      vertex -8.00602 0.122521 0
+    endloop
+  endfacet
+  facet normal -0.998795 -0.0490752 0
+    outer loop
+      vertex -8.00602 0.122521 1
+      vertex -8 0 0
+      vertex -8 0 1
+    endloop
+  endfacet
+  facet normal 0.671528 0.740979 -0
+    outer loop
+      vertex -10.043 -0.966263 0
+      vertex -10.1339 -0.883883 1
+      vertex -10.043 -0.966263 1
+    endloop
+  endfacet
+  facet normal 0.671528 0.740979 0
+    outer loop
+      vertex -10.1339 -0.883883 1
+      vertex -10.043 -0.966263 0
+      vertex -10.1339 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -8.25 -1.73205 -1
+      vertex -10.25 -1.73205 0
+      vertex -8.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -8.25 -1.73205 -1
+      vertex -10.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -11.25 0 -1
+      vertex -11.25 0 0
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex -11.25 0 -1
+      vertex -10.25 -1.73205 0
+      vertex -10.25 -1.73205 -1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -10.25 1.73205 -1
+      vertex -8.25 1.73205 0
+      vertex -10.25 1.73205 0
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -8.25 1.73205 0
+      vertex -10.25 1.73205 -1
+      vertex -8.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -11.25 0 0
+      vertex -10.25 1.73205 -1
+      vertex -10.25 1.73205 0
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -10.25 1.73205 -1
+      vertex -11.25 0 0
+      vertex -11.25 0 -1
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -7.25 0 -1
+      vertex -8.25 1.73205 0
+      vertex -8.25 1.73205 -1
+    endloop
+  endfacet
+  facet normal -0.866025 -0.5 0
+    outer loop
+      vertex -8.25 1.73205 0
+      vertex -7.25 0 -1
+      vertex -7.25 0 0
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -8.25 -1.73205 -1
+      vertex -7.25 0 0
+      vertex -7.25 0 -1
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -7.25 0 0
+      vertex -8.25 -1.73205 -1
+      vertex -8.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -7.25 0 0
+      vertex -8.00602 -0.122521 0
+      vertex -8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.25 0 0
+      vertex -8.02402 -0.243862 0
+      vertex -8.00602 -0.122521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.25 0 0
+      vertex -8.05383 -0.362855 0
+      vertex -8.02402 -0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.25 0 0
+      vertex -8.09515 -0.478354 0
+      vertex -8.05383 -0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.25 0 0
+      vertex -8.1476 -0.589246 0
+      vertex -8.09515 -0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.1476 -0.589246 0
+      vertex -7.25 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.1476 -0.589246 0
+      vertex -8.25 -1.73205 0
+      vertex -8.21066 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.28374 -0.792991 0
+      vertex -8.21066 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.36612 -0.883883 0
+      vertex -8.28374 -0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.45701 -0.966263 0
+      vertex -8.36612 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.55554 -1.03934 0
+      vertex -8.45701 -0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.66075 -1.1024 0
+      vertex -8.55554 -1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.77165 -1.15485 0
+      vertex -8.66075 -1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -8.88715 -1.19617 0
+      vertex -8.77165 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -9.00614 -1.22598 0
+      vertex -8.88715 -1.19617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -9.12748 -1.24398 0
+      vertex -9.00614 -1.22598 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 -1.73205 0
+      vertex -9.25 -1.25 0
+      vertex -9.12748 -1.24398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -9.25 -1.25 0
+      vertex -8.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.25 -1.25 0
+      vertex -10.25 -1.73205 0
+      vertex -9.37252 -1.24398 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.37252 -1.24398 0
+      vertex -10.25 -1.73205 0
+      vertex -9.49386 -1.22598 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.49386 -1.22598 0
+      vertex -10.25 -1.73205 0
+      vertex -9.61285 -1.19617 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -9.61285 -1.19617 0
+      vertex -10.25 -1.73205 0
+      vertex -9.72835 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -9.83925 -1.1024 0
+      vertex -9.72835 -1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -9.94446 -1.03934 0
+      vertex -9.83925 -1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -10.043 -0.966263 0
+      vertex -9.94446 -1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -10.1339 -0.883883 0
+      vertex -10.043 -0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -10.2163 -0.792991 0
+      vertex -10.1339 -0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -10.2893 -0.694463 0
+      vertex -10.2163 -0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 -1.73205 0
+      vertex -10.3524 -0.589246 0
+      vertex -10.2893 -0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 0
+      vertex -10.3524 -0.589246 0
+      vertex -10.25 -1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.3524 -0.589246 0
+      vertex -11.25 0 0
+      vertex -10.4048 -0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.4048 -0.478354 0
+      vertex -11.25 0 0
+      vertex -10.4462 -0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.494 -0.122521 0
+      vertex -11.25 0 0
+      vertex -10.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.476 -0.243862 0
+      vertex -11.25 0 0
+      vertex -10.494 -0.122521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.4462 -0.362855 0
+      vertex -11.25 0 0
+      vertex -10.476 -0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.00602 0.122521 0
+      vertex -7.25 0 0
+      vertex -8 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.02402 0.243862 0
+      vertex -7.25 0 0
+      vertex -8.00602 0.122521 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.05383 0.362855 0
+      vertex -7.25 0 0
+      vertex -8.02402 0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.09515 0.478354 0
+      vertex -7.25 0 0
+      vertex -8.05383 0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.1476 0.589246 0
+      vertex -7.25 0 0
+      vertex -8.09515 0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.25 1.73205 0
+      vertex -8.1476 0.589246 0
+      vertex -8.21066 0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.1476 0.589246 0
+      vertex -8.25 1.73205 0
+      vertex -7.25 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.28374 0.792991 0
+      vertex -8.25 1.73205 0
+      vertex -8.21066 0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.36612 0.883883 0
+      vertex -8.25 1.73205 0
+      vertex -8.28374 0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.45701 0.966263 0
+      vertex -8.25 1.73205 0
+      vertex -8.36612 0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.55554 1.03934 0
+      vertex -8.25 1.73205 0
+      vertex -8.45701 0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.66075 1.1024 0
+      vertex -8.25 1.73205 0
+      vertex -8.55554 1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.77165 1.15485 0
+      vertex -8.25 1.73205 0
+      vertex -8.66075 1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.88715 1.19617 0
+      vertex -8.25 1.73205 0
+      vertex -8.77165 1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.00614 1.22598 0
+      vertex -8.25 1.73205 0
+      vertex -8.88715 1.19617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.12748 1.24398 0
+      vertex -8.25 1.73205 0
+      vertex -9.00614 1.22598 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.25 1.25 0
+      vertex -8.25 1.73205 0
+      vertex -9.12748 1.24398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 1.73205 0
+      vertex -9.25 1.25 0
+      vertex -9.37252 1.24398 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 1.73205 0
+      vertex -9.37252 1.24398 0
+      vertex -9.49386 1.22598 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 1.73205 0
+      vertex -9.49386 1.22598 0
+      vertex -9.61285 1.19617 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 1.73205 0
+      vertex -9.61285 1.19617 0
+      vertex -9.72835 1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.25 1.25 0
+      vertex -10.25 1.73205 0
+      vertex -8.25 1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.83925 1.1024 0
+      vertex -10.25 1.73205 0
+      vertex -9.72835 1.15485 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.94446 1.03934 0
+      vertex -10.25 1.73205 0
+      vertex -9.83925 1.1024 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.043 0.966263 0
+      vertex -10.25 1.73205 0
+      vertex -9.94446 1.03934 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.1339 0.883883 0
+      vertex -10.25 1.73205 0
+      vertex -10.043 0.966263 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.2163 0.792991 0
+      vertex -10.25 1.73205 0
+      vertex -10.1339 0.883883 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.2893 0.694463 0
+      vertex -10.25 1.73205 0
+      vertex -10.2163 0.792991 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.3524 0.589246 0
+      vertex -10.25 1.73205 0
+      vertex -10.2893 0.694463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 0
+      vertex -10.3524 0.589246 0
+      vertex -10.4048 0.478354 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 0
+      vertex -10.4048 0.478354 0
+      vertex -10.4462 0.362855 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 0
+      vertex -10.4462 0.362855 0
+      vertex -10.476 0.243862 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.3524 0.589246 0
+      vertex -11.25 0 0
+      vertex -10.25 1.73205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.494 0.122521 0
+      vertex -11.25 0 0
+      vertex -10.476 0.243862 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.25 0 0
+      vertex -10.494 0.122521 0
+      vertex -10.5 0 0
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 -0
+    outer loop
+      vertex 14.6371 13.8038 -1
+      vertex 14.5216 13.8451 6
+      vertex 14.6371 13.8038 6
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 0
+    outer loop
+      vertex 14.5216 13.8451 6
+      vertex 14.6371 13.8038 -1
+      vertex 14.5216 13.8451 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex 16.244 15.1225 -1
+      vertex 16.226 15.2439 6
+      vertex 16.226 15.2439 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex 16.226 15.2439 6
+      vertex 16.244 15.1225 -1
+      vertex 16.244 15.1225 6
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex 16.25 15 -1
+      vertex 16.244 15.1225 6
+      vertex 16.244 15.1225 -1
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex 16.244 15.1225 6
+      vertex 16.25 15 -1
+      vertex 16.25 15 6
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex 16.226 15.2439 -1
+      vertex 16.1962 15.3629 6
+      vertex 16.1962 15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex 16.1962 15.3629 6
+      vertex 16.226 15.2439 -1
+      vertex 16.226 15.2439 6
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex 13.756 15.1225 6
+      vertex 13.774 15.2439 -1
+      vertex 13.774 15.2439 6
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex 13.774 15.2439 -1
+      vertex 13.756 15.1225 6
+      vertex 13.756 15.1225 -1
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 -0
+    outer loop
+      vertex 14.7561 13.774 -1
+      vertex 14.6371 13.8038 6
+      vertex 14.7561 13.774 6
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 0
+    outer loop
+      vertex 14.6371 13.8038 6
+      vertex 14.7561 13.774 -1
+      vertex 14.6371 13.8038 -1
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 0
+    outer loop
+      vertex 15.3629 16.1962 -1
+      vertex 15.4784 16.1549 6
+      vertex 15.3629 16.1962 6
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 -0
+    outer loop
+      vertex 15.4784 16.1549 6
+      vertex 15.3629 16.1962 -1
+      vertex 15.4784 16.1549 -1
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex 14.3055 16.0393 -1
+      vertex 14.4108 16.1024 6
+      vertex 14.3055 16.0393 6
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex 14.4108 16.1024 6
+      vertex 14.3055 16.0393 -1
+      vertex 14.4108 16.1024 -1
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex 13.8976 14.4108 6
+      vertex 13.8451 14.5216 -1
+      vertex 13.8451 14.5216 6
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex 13.8451 14.5216 -1
+      vertex 13.8976 14.4108 6
+      vertex 13.8976 14.4108 -1
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex 14.6371 16.1962 -1
+      vertex 14.7561 16.226 6
+      vertex 14.6371 16.1962 6
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex 14.7561 16.226 6
+      vertex 14.6371 16.1962 -1
+      vertex 14.7561 16.226 -1
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex 13.9607 14.3055 6
+      vertex 13.8976 14.4108 -1
+      vertex 13.8976 14.4108 6
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex 13.8976 14.4108 -1
+      vertex 13.9607 14.3055 6
+      vertex 13.9607 14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex 15.3629 13.8038 -1
+      vertex 15.2439 13.774 6
+      vertex 15.3629 13.8038 6
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex 15.2439 13.774 6
+      vertex 15.3629 13.8038 -1
+      vertex 15.2439 13.774 -1
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 -0
+    outer loop
+      vertex 14.3055 13.9607 -1
+      vertex 14.207 14.0337 6
+      vertex 14.3055 13.9607 6
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 0
+    outer loop
+      vertex 14.207 14.0337 6
+      vertex 14.3055 13.9607 -1
+      vertex 14.207 14.0337 -1
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex 15.6945 13.9607 -1
+      vertex 15.5892 13.8976 6
+      vertex 15.6945 13.9607 6
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex 15.5892 13.8976 6
+      vertex 15.6945 13.9607 -1
+      vertex 15.5892 13.8976 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex 15.9663 14.207 -1
+      vertex 16.0393 14.3055 6
+      vertex 16.0393 14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex 16.0393 14.3055 6
+      vertex 15.9663 14.207 -1
+      vertex 15.9663 14.207 6
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 0
+    outer loop
+      vertex 15.1225 16.244 -1
+      vertex 15.2439 16.226 6
+      vertex 15.1225 16.244 6
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 -0
+    outer loop
+      vertex 15.2439 16.226 6
+      vertex 15.1225 16.244 -1
+      vertex 15.2439 16.226 -1
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex 14.207 15.9663 -1
+      vertex 14.3055 16.0393 6
+      vertex 14.207 15.9663 6
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex 14.3055 16.0393 6
+      vertex 14.207 15.9663 -1
+      vertex 14.3055 16.0393 -1
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex 15.5892 13.8976 -1
+      vertex 15.4784 13.8451 6
+      vertex 15.5892 13.8976 6
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex 15.4784 13.8451 6
+      vertex 15.5892 13.8976 -1
+      vertex 15.4784 13.8451 -1
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex 13.9607 15.6945 6
+      vertex 14.0337 15.793 -1
+      vertex 14.0337 15.793 6
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex 14.0337 15.793 -1
+      vertex 13.9607 15.6945 6
+      vertex 13.9607 15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex 16.226 14.7561 -1
+      vertex 16.244 14.8775 6
+      vertex 16.244 14.8775 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex 16.244 14.8775 6
+      vertex 16.226 14.7561 -1
+      vertex 16.226 14.7561 6
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex 13.8038 15.3629 6
+      vertex 13.8451 15.4784 -1
+      vertex 13.8451 15.4784 6
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex 13.8451 15.4784 -1
+      vertex 13.8038 15.3629 6
+      vertex 13.8038 15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 0
+    outer loop
+      vertex 15.4784 16.1549 -1
+      vertex 15.5892 16.1024 6
+      vertex 15.4784 16.1549 6
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 -0
+    outer loop
+      vertex 15.5892 16.1024 6
+      vertex 15.4784 16.1549 -1
+      vertex 15.5892 16.1024 -1
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex 13.8451 14.5216 6
+      vertex 13.8038 14.6371 -1
+      vertex 13.8038 14.6371 6
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex 13.8038 14.6371 -1
+      vertex 13.8451 14.5216 6
+      vertex 13.8451 14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex 16.1962 14.6371 -1
+      vertex 16.226 14.7561 6
+      vertex 16.226 14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex 16.226 14.7561 6
+      vertex 16.1962 14.6371 -1
+      vertex 16.1962 14.6371 6
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex 14.8775 16.244 -1
+      vertex 15 16.25 6
+      vertex 14.8775 16.244 6
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex 15 16.25 6
+      vertex 14.8775 16.244 -1
+      vertex 15 16.25 -1
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 0
+    outer loop
+      vertex 15.793 15.9663 -1
+      vertex 15.8839 15.8839 6
+      vertex 15.793 15.9663 6
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 -0
+    outer loop
+      vertex 15.8839 15.8839 6
+      vertex 15.793 15.9663 -1
+      vertex 15.8839 15.8839 -1
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex 14.4108 16.1024 -1
+      vertex 14.5216 16.1549 6
+      vertex 14.4108 16.1024 6
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex 14.5216 16.1549 6
+      vertex 14.4108 16.1024 -1
+      vertex 14.5216 16.1549 -1
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex 14.1161 15.8839 -1
+      vertex 14.207 15.9663 6
+      vertex 14.1161 15.8839 6
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex 14.207 15.9663 6
+      vertex 14.1161 15.8839 -1
+      vertex 14.207 15.9663 -1
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex 15.4784 13.8451 -1
+      vertex 15.3629 13.8038 6
+      vertex 15.4784 13.8451 6
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex 15.3629 13.8038 6
+      vertex 15.4784 13.8451 -1
+      vertex 15.3629 13.8038 -1
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex 14.5216 16.1549 -1
+      vertex 14.6371 16.1962 6
+      vertex 14.5216 16.1549 6
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex 14.6371 16.1962 6
+      vertex 14.5216 16.1549 -1
+      vertex 14.6371 16.1962 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex 16.0393 15.6945 -1
+      vertex 15.9663 15.793 6
+      vertex 15.9663 15.793 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex 15.9663 15.793 6
+      vertex 16.0393 15.6945 -1
+      vertex 16.0393 15.6945 6
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex 13.8976 15.5892 6
+      vertex 13.9607 15.6945 -1
+      vertex 13.9607 15.6945 6
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex 13.9607 15.6945 -1
+      vertex 13.8976 15.5892 6
+      vertex 13.8976 15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex 16.244 14.8775 -1
+      vertex 16.25 15 6
+      vertex 16.25 15 -1
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex 16.25 15 6
+      vertex 16.244 14.8775 -1
+      vertex 16.244 14.8775 6
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex 16.1024 14.4108 -1
+      vertex 16.1549 14.5216 6
+      vertex 16.1549 14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex 16.1549 14.5216 6
+      vertex 16.1024 14.4108 -1
+      vertex 16.1024 14.4108 6
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex 16.1024 15.5892 -1
+      vertex 16.0393 15.6945 6
+      vertex 16.0393 15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex 16.0393 15.6945 6
+      vertex 16.1024 15.5892 -1
+      vertex 16.1024 15.5892 6
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 0
+    outer loop
+      vertex 15.6945 16.0393 -1
+      vertex 15.793 15.9663 6
+      vertex 15.6945 16.0393 6
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 -0
+    outer loop
+      vertex 15.793 15.9663 6
+      vertex 15.6945 16.0393 -1
+      vertex 15.793 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 -0
+    outer loop
+      vertex 14.4108 13.8976 -1
+      vertex 14.3055 13.9607 6
+      vertex 14.4108 13.8976 6
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 0
+    outer loop
+      vertex 14.3055 13.9607 6
+      vertex 14.4108 13.8976 -1
+      vertex 14.3055 13.9607 -1
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 0
+    outer loop
+      vertex 15.5892 16.1024 -1
+      vertex 15.6945 16.0393 6
+      vertex 15.5892 16.1024 6
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 -0
+    outer loop
+      vertex 15.6945 16.0393 6
+      vertex 15.5892 16.1024 -1
+      vertex 15.6945 16.0393 -1
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex 15.2439 13.774 -1
+      vertex 15.1225 13.756 6
+      vertex 15.2439 13.774 6
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex 15.1225 13.756 6
+      vertex 15.2439 13.774 -1
+      vertex 15.1225 13.756 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex 16.1962 15.3629 -1
+      vertex 16.1549 15.4784 6
+      vertex 16.1549 15.4784 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex 16.1549 15.4784 6
+      vertex 16.1962 15.3629 -1
+      vertex 16.1962 15.3629 6
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex 16.0393 14.3055 -1
+      vertex 16.1024 14.4108 6
+      vertex 16.1024 14.4108 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex 16.1024 14.4108 6
+      vertex 16.0393 14.3055 -1
+      vertex 16.0393 14.3055 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex 13.756 14.8775 6
+      vertex 13.75 15 -1
+      vertex 13.75 15 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex 13.75 15 -1
+      vertex 13.756 14.8775 6
+      vertex 13.756 14.8775 -1
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex 16.1549 14.5216 -1
+      vertex 16.1962 14.6371 6
+      vertex 16.1962 14.6371 -1
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex 16.1962 14.6371 6
+      vertex 16.1549 14.5216 -1
+      vertex 16.1549 14.5216 6
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex 14.7561 16.226 -1
+      vertex 14.8775 16.244 6
+      vertex 14.7561 16.226 6
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex 14.8775 16.244 6
+      vertex 14.7561 16.226 -1
+      vertex 14.8775 16.244 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex 15.9663 15.793 -1
+      vertex 15.8839 15.8839 6
+      vertex 15.8839 15.8839 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex 15.8839 15.8839 6
+      vertex 15.9663 15.793 -1
+      vertex 15.9663 15.793 6
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 0
+    outer loop
+      vertex 15 16.25 -1
+      vertex 15.1225 16.244 6
+      vertex 15 16.25 6
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 -0
+    outer loop
+      vertex 15.1225 16.244 6
+      vertex 15 16.25 -1
+      vertex 15.1225 16.244 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex 16.1549 15.4784 -1
+      vertex 16.1024 15.5892 6
+      vertex 16.1024 15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex 16.1024 15.5892 6
+      vertex 16.1549 15.4784 -1
+      vertex 16.1549 15.4784 6
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 -0
+    outer loop
+      vertex 14.8775 13.756 -1
+      vertex 14.7561 13.774 6
+      vertex 14.8775 13.756 6
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 0
+    outer loop
+      vertex 14.7561 13.774 6
+      vertex 14.8775 13.756 -1
+      vertex 14.7561 13.774 -1
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex 15.8839 14.1161 -1
+      vertex 15.793 14.0337 6
+      vertex 15.8839 14.1161 6
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex 15.793 14.0337 6
+      vertex 15.8839 14.1161 -1
+      vertex 15.793 14.0337 -1
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 -0
+    outer loop
+      vertex 15 13.75 -1
+      vertex 14.8775 13.756 6
+      vertex 15 13.75 6
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 0
+    outer loop
+      vertex 14.8775 13.756 6
+      vertex 15 13.75 -1
+      vertex 14.8775 13.756 -1
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex 14.0337 15.793 6
+      vertex 14.1161 15.8839 -1
+      vertex 14.1161 15.8839 6
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex 14.1161 15.8839 -1
+      vertex 14.0337 15.793 6
+      vertex 14.0337 15.793 -1
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex 13.8451 15.4784 6
+      vertex 13.8976 15.5892 -1
+      vertex 13.8976 15.5892 6
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex 13.8976 15.5892 -1
+      vertex 13.8451 15.4784 6
+      vertex 13.8451 15.4784 -1
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 -0
+    outer loop
+      vertex 14.207 14.0337 -1
+      vertex 14.1161 14.1161 6
+      vertex 14.207 14.0337 6
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 0
+    outer loop
+      vertex 14.1161 14.1161 6
+      vertex 14.207 14.0337 -1
+      vertex 14.1161 14.1161 -1
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex 13.774 15.2439 6
+      vertex 13.8038 15.3629 -1
+      vertex 13.8038 15.3629 6
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex 13.8038 15.3629 -1
+      vertex 13.774 15.2439 6
+      vertex 13.774 15.2439 -1
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 0
+    outer loop
+      vertex 15.2439 16.226 -1
+      vertex 15.3629 16.1962 6
+      vertex 15.2439 16.226 6
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 -0
+    outer loop
+      vertex 15.3629 16.1962 6
+      vertex 15.2439 16.226 -1
+      vertex 15.3629 16.1962 -1
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex 13.8038 14.6371 6
+      vertex 13.774 14.7561 -1
+      vertex 13.774 14.7561 6
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex 13.774 14.7561 -1
+      vertex 13.8038 14.6371 6
+      vertex 13.8038 14.6371 -1
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 -0
+    outer loop
+      vertex 14.5216 13.8451 -1
+      vertex 14.4108 13.8976 6
+      vertex 14.5216 13.8451 6
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 0
+    outer loop
+      vertex 14.4108 13.8976 6
+      vertex 14.5216 13.8451 -1
+      vertex 14.4108 13.8976 -1
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex 14.1161 14.1161 6
+      vertex 14.0337 14.207 -1
+      vertex 14.0337 14.207 6
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex 14.0337 14.207 -1
+      vertex 14.1161 14.1161 6
+      vertex 14.1161 14.1161 -1
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex 15.1225 13.756 -1
+      vertex 15 13.75 6
+      vertex 15.1225 13.756 6
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex 15 13.75 6
+      vertex 15.1225 13.756 -1
+      vertex 15 13.75 -1
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex 13.774 14.7561 6
+      vertex 13.756 14.8775 -1
+      vertex 13.756 14.8775 6
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex 13.756 14.8775 -1
+      vertex 13.774 14.7561 6
+      vertex 13.774 14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex 15.793 14.0337 -1
+      vertex 15.6945 13.9607 6
+      vertex 15.793 14.0337 6
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex 15.6945 13.9607 6
+      vertex 15.793 14.0337 -1
+      vertex 15.6945 13.9607 -1
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex 14.0337 14.207 6
+      vertex 13.9607 14.3055 -1
+      vertex 13.9607 14.3055 6
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex 13.9607 14.3055 -1
+      vertex 14.0337 14.207 6
+      vertex 14.0337 14.207 -1
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex 13.75 15 6
+      vertex 13.756 15.1225 -1
+      vertex 13.756 15.1225 6
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex 13.756 15.1225 -1
+      vertex 13.75 15 6
+      vertex 13.75 15 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex 15.8839 14.1161 -1
+      vertex 15.9663 14.207 6
+      vertex 15.9663 14.207 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex 15.9663 14.207 6
+      vertex 15.8839 14.1161 -1
+      vertex 15.8839 14.1161 6
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex -15.9663 14.207 6
+      vertex -16.0393 14.3055 -1
+      vertex -16.0393 14.3055 6
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex -16.0393 14.3055 -1
+      vertex -15.9663 14.207 6
+      vertex -15.9663 14.207 -1
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex -16.25 15 6
+      vertex -16.244 15.1225 -1
+      vertex -16.244 15.1225 6
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex -16.244 15.1225 -1
+      vertex -16.25 15 6
+      vertex -16.25 15 -1
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex -16.0393 15.6945 6
+      vertex -15.9663 15.793 -1
+      vertex -15.9663 15.793 6
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex -15.9663 15.793 -1
+      vertex -16.0393 15.6945 6
+      vertex -16.0393 15.6945 -1
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex -16.1024 14.4108 6
+      vertex -16.1549 14.5216 -1
+      vertex -16.1549 14.5216 6
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex -16.1549 14.5216 -1
+      vertex -16.1024 14.4108 6
+      vertex -16.1024 14.4108 -1
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 0
+    outer loop
+      vertex -14.3055 16.0393 -1
+      vertex -14.207 15.9663 6
+      vertex -14.3055 16.0393 6
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 -0
+    outer loop
+      vertex -14.207 15.9663 6
+      vertex -14.3055 16.0393 -1
+      vertex -14.207 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 -0
+    outer loop
+      vertex -15.2439 13.774 -1
+      vertex -15.3629 13.8038 6
+      vertex -15.2439 13.774 6
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 0
+    outer loop
+      vertex -15.3629 13.8038 6
+      vertex -15.2439 13.774 -1
+      vertex -15.3629 13.8038 -1
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex -14.4108 13.8976 -1
+      vertex -14.5216 13.8451 6
+      vertex -14.4108 13.8976 6
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex -14.5216 13.8451 6
+      vertex -14.4108 13.8976 -1
+      vertex -14.5216 13.8451 -1
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 0
+    outer loop
+      vertex -14.4108 16.1024 -1
+      vertex -14.3055 16.0393 6
+      vertex -14.4108 16.1024 6
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 -0
+    outer loop
+      vertex -14.3055 16.0393 6
+      vertex -14.4108 16.1024 -1
+      vertex -14.3055 16.0393 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex -13.9607 14.3055 -1
+      vertex -13.8976 14.4108 6
+      vertex -13.8976 14.4108 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex -13.8976 14.4108 6
+      vertex -13.9607 14.3055 -1
+      vertex -13.9607 14.3055 6
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 -0
+    outer loop
+      vertex -15 13.75 -1
+      vertex -15.1225 13.756 6
+      vertex -15 13.75 6
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 0
+    outer loop
+      vertex -15.1225 13.756 6
+      vertex -15 13.75 -1
+      vertex -15.1225 13.756 -1
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex -16.1962 14.6371 6
+      vertex -16.226 14.7561 -1
+      vertex -16.226 14.7561 6
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex -16.226 14.7561 -1
+      vertex -16.1962 14.6371 6
+      vertex -16.1962 14.6371 -1
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex -16.244 15.1225 6
+      vertex -16.226 15.2439 -1
+      vertex -16.226 15.2439 6
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex -16.226 15.2439 -1
+      vertex -16.244 15.1225 6
+      vertex -16.244 15.1225 -1
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex -15.1225 16.244 -1
+      vertex -15 16.25 6
+      vertex -15.1225 16.244 6
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex -15 16.25 6
+      vertex -15.1225 16.244 -1
+      vertex -15 16.25 -1
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex -15.8839 14.1161 6
+      vertex -15.9663 14.207 -1
+      vertex -15.9663 14.207 6
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex -15.9663 14.207 -1
+      vertex -15.8839 14.1161 6
+      vertex -15.8839 14.1161 -1
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 -0
+    outer loop
+      vertex -15.793 14.0337 -1
+      vertex -15.8839 14.1161 6
+      vertex -15.793 14.0337 6
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 0
+    outer loop
+      vertex -15.8839 14.1161 6
+      vertex -15.793 14.0337 -1
+      vertex -15.8839 14.1161 -1
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex -14.7561 13.774 -1
+      vertex -14.8775 13.756 6
+      vertex -14.7561 13.774 6
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex -14.8775 13.756 6
+      vertex -14.7561 13.774 -1
+      vertex -14.8775 13.756 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex -13.9607 15.6945 -1
+      vertex -14.0337 15.793 6
+      vertex -14.0337 15.793 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex -14.0337 15.793 6
+      vertex -13.9607 15.6945 -1
+      vertex -13.9607 15.6945 6
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 0
+    outer loop
+      vertex -14.5216 16.1549 -1
+      vertex -14.4108 16.1024 6
+      vertex -14.5216 16.1549 6
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 -0
+    outer loop
+      vertex -14.4108 16.1024 6
+      vertex -14.5216 16.1549 -1
+      vertex -14.4108 16.1024 -1
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex -14.8775 13.756 -1
+      vertex -15 13.75 6
+      vertex -14.8775 13.756 6
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex -15 13.75 6
+      vertex -14.8775 13.756 -1
+      vertex -15 13.75 -1
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex -16.1549 14.5216 6
+      vertex -16.1962 14.6371 -1
+      vertex -16.1962 14.6371 6
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex -16.1962 14.6371 -1
+      vertex -16.1549 14.5216 6
+      vertex -16.1549 14.5216 -1
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex -15.4784 16.1549 -1
+      vertex -15.3629 16.1962 6
+      vertex -15.4784 16.1549 6
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex -15.3629 16.1962 6
+      vertex -15.4784 16.1549 -1
+      vertex -15.3629 16.1962 -1
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 0
+    outer loop
+      vertex -14.207 15.9663 -1
+      vertex -14.1161 15.8839 6
+      vertex -14.207 15.9663 6
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 -0
+    outer loop
+      vertex -14.1161 15.8839 6
+      vertex -14.207 15.9663 -1
+      vertex -14.1161 15.8839 -1
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex -14.1161 14.1161 -1
+      vertex -14.207 14.0337 6
+      vertex -14.1161 14.1161 6
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex -14.207 14.0337 6
+      vertex -14.1161 14.1161 -1
+      vertex -14.207 14.0337 -1
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 0
+    outer loop
+      vertex -14.8775 16.244 -1
+      vertex -14.7561 16.226 6
+      vertex -14.8775 16.244 6
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 -0
+    outer loop
+      vertex -14.7561 16.226 6
+      vertex -14.8775 16.244 -1
+      vertex -14.7561 16.226 -1
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 0
+    outer loop
+      vertex -15 16.25 -1
+      vertex -14.8775 16.244 6
+      vertex -15 16.25 6
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 -0
+    outer loop
+      vertex -14.8775 16.244 6
+      vertex -15 16.25 -1
+      vertex -14.8775 16.244 -1
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 -0
+    outer loop
+      vertex -15.3629 13.8038 -1
+      vertex -15.4784 13.8451 6
+      vertex -15.3629 13.8038 6
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 0
+    outer loop
+      vertex -15.4784 13.8451 6
+      vertex -15.3629 13.8038 -1
+      vertex -15.4784 13.8451 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex -14.0337 15.793 -1
+      vertex -14.1161 15.8839 6
+      vertex -14.1161 15.8839 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex -14.1161 15.8839 6
+      vertex -14.0337 15.793 -1
+      vertex -14.0337 15.793 6
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex -14.0337 14.207 -1
+      vertex -13.9607 14.3055 6
+      vertex -13.9607 14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex -13.9607 14.3055 6
+      vertex -14.0337 14.207 -1
+      vertex -14.0337 14.207 6
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex -13.756 15.1225 -1
+      vertex -13.774 15.2439 6
+      vertex -13.774 15.2439 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex -13.774 15.2439 6
+      vertex -13.756 15.1225 -1
+      vertex -13.756 15.1225 6
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex -13.75 15 -1
+      vertex -13.756 15.1225 6
+      vertex -13.756 15.1225 -1
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex -13.756 15.1225 6
+      vertex -13.75 15 -1
+      vertex -13.75 15 6
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 -0
+    outer loop
+      vertex -15.6945 13.9607 -1
+      vertex -15.793 14.0337 6
+      vertex -15.6945 13.9607 6
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 0
+    outer loop
+      vertex -15.793 14.0337 6
+      vertex -15.6945 13.9607 -1
+      vertex -15.793 14.0337 -1
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex -15.9663 15.793 6
+      vertex -15.8839 15.8839 -1
+      vertex -15.8839 15.8839 6
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex -15.8839 15.8839 -1
+      vertex -15.9663 15.793 6
+      vertex -15.9663 15.793 -1
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex -16.1962 15.3629 6
+      vertex -16.1549 15.4784 -1
+      vertex -16.1549 15.4784 6
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex -16.1549 15.4784 -1
+      vertex -16.1962 15.3629 6
+      vertex -16.1962 15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex -14.207 14.0337 -1
+      vertex -14.3055 13.9607 6
+      vertex -14.207 14.0337 6
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex -14.3055 13.9607 6
+      vertex -14.207 14.0337 -1
+      vertex -14.3055 13.9607 -1
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex -14.5216 13.8451 -1
+      vertex -14.6371 13.8038 6
+      vertex -14.5216 13.8451 6
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex -14.6371 13.8038 6
+      vertex -14.5216 13.8451 -1
+      vertex -14.6371 13.8038 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex -13.8976 14.4108 -1
+      vertex -13.8451 14.5216 6
+      vertex -13.8451 14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex -13.8451 14.5216 6
+      vertex -13.8976 14.4108 -1
+      vertex -13.8976 14.4108 6
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex -13.756 14.8775 -1
+      vertex -13.75 15 6
+      vertex -13.75 15 -1
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex -13.75 15 6
+      vertex -13.756 14.8775 -1
+      vertex -13.756 14.8775 6
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex -14.6371 13.8038 -1
+      vertex -14.7561 13.774 6
+      vertex -14.6371 13.8038 6
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex -14.7561 13.774 6
+      vertex -14.6371 13.8038 -1
+      vertex -14.7561 13.774 -1
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex -16.244 14.8775 6
+      vertex -16.25 15 -1
+      vertex -16.25 15 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex -16.25 15 -1
+      vertex -16.244 14.8775 6
+      vertex -16.244 14.8775 -1
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex -16.226 15.2439 6
+      vertex -16.1962 15.3629 -1
+      vertex -16.1962 15.3629 6
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex -16.1962 15.3629 -1
+      vertex -16.226 15.2439 6
+      vertex -16.226 15.2439 -1
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex -16.1549 15.4784 6
+      vertex -16.1024 15.5892 -1
+      vertex -16.1024 15.5892 6
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex -16.1024 15.5892 -1
+      vertex -16.1549 15.4784 6
+      vertex -16.1549 15.4784 -1
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 -0
+    outer loop
+      vertex -15.5892 13.8976 -1
+      vertex -15.6945 13.9607 6
+      vertex -15.5892 13.8976 6
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 0
+    outer loop
+      vertex -15.6945 13.9607 6
+      vertex -15.5892 13.8976 -1
+      vertex -15.6945 13.9607 -1
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 -0
+    outer loop
+      vertex -15.4784 13.8451 -1
+      vertex -15.5892 13.8976 6
+      vertex -15.4784 13.8451 6
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 0
+    outer loop
+      vertex -15.5892 13.8976 6
+      vertex -15.4784 13.8451 -1
+      vertex -15.5892 13.8976 -1
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 -0
+    outer loop
+      vertex -15.1225 13.756 -1
+      vertex -15.2439 13.774 6
+      vertex -15.1225 13.756 6
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 0
+    outer loop
+      vertex -15.2439 13.774 6
+      vertex -15.1225 13.756 -1
+      vertex -15.2439 13.774 -1
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex -15.2439 16.226 -1
+      vertex -15.1225 16.244 6
+      vertex -15.2439 16.226 6
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex -15.1225 16.244 6
+      vertex -15.2439 16.226 -1
+      vertex -15.1225 16.244 -1
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex -14.3055 13.9607 -1
+      vertex -14.4108 13.8976 6
+      vertex -14.3055 13.9607 6
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex -14.4108 13.8976 6
+      vertex -14.3055 13.9607 -1
+      vertex -14.4108 13.8976 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex -13.8038 14.6371 -1
+      vertex -13.774 14.7561 6
+      vertex -13.774 14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex -13.774 14.7561 6
+      vertex -13.8038 14.6371 -1
+      vertex -13.8038 14.6371 6
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex -15.6945 16.0393 -1
+      vertex -15.5892 16.1024 6
+      vertex -15.6945 16.0393 6
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex -15.5892 16.1024 6
+      vertex -15.6945 16.0393 -1
+      vertex -15.5892 16.1024 -1
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 0
+    outer loop
+      vertex -14.7561 16.226 -1
+      vertex -14.6371 16.1962 6
+      vertex -14.7561 16.226 6
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 -0
+    outer loop
+      vertex -14.6371 16.1962 6
+      vertex -14.7561 16.226 -1
+      vertex -14.6371 16.1962 -1
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex -16.0393 14.3055 6
+      vertex -16.1024 14.4108 -1
+      vertex -16.1024 14.4108 6
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex -16.1024 14.4108 -1
+      vertex -16.0393 14.3055 6
+      vertex -16.0393 14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex -13.774 14.7561 -1
+      vertex -13.756 14.8775 6
+      vertex -13.756 14.8775 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex -13.756 14.8775 6
+      vertex -13.774 14.7561 -1
+      vertex -13.774 14.7561 6
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex -16.226 14.7561 6
+      vertex -16.244 14.8775 -1
+      vertex -16.244 14.8775 6
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex -16.244 14.8775 -1
+      vertex -16.226 14.7561 6
+      vertex -16.226 14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 0
+    outer loop
+      vertex -14.6371 16.1962 -1
+      vertex -14.5216 16.1549 6
+      vertex -14.6371 16.1962 6
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 -0
+    outer loop
+      vertex -14.5216 16.1549 6
+      vertex -14.6371 16.1962 -1
+      vertex -14.5216 16.1549 -1
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex -13.8976 15.5892 -1
+      vertex -13.9607 15.6945 6
+      vertex -13.9607 15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex -13.9607 15.6945 6
+      vertex -13.8976 15.5892 -1
+      vertex -13.8976 15.5892 6
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex -16.1024 15.5892 6
+      vertex -16.0393 15.6945 -1
+      vertex -16.0393 15.6945 6
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex -16.0393 15.6945 -1
+      vertex -16.1024 15.5892 6
+      vertex -16.1024 15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex -13.8451 15.4784 -1
+      vertex -13.8976 15.5892 6
+      vertex -13.8976 15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex -13.8976 15.5892 6
+      vertex -13.8451 15.4784 -1
+      vertex -13.8451 15.4784 6
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex -15.3629 16.1962 -1
+      vertex -15.2439 16.226 6
+      vertex -15.3629 16.1962 6
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex -15.2439 16.226 6
+      vertex -15.3629 16.1962 -1
+      vertex -15.2439 16.226 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex -13.8038 15.3629 -1
+      vertex -13.8451 15.4784 6
+      vertex -13.8451 15.4784 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex -13.8451 15.4784 6
+      vertex -13.8038 15.3629 -1
+      vertex -13.8038 15.3629 6
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex -13.8451 14.5216 -1
+      vertex -13.8038 14.6371 6
+      vertex -13.8038 14.6371 -1
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex -13.8038 14.6371 6
+      vertex -13.8451 14.5216 -1
+      vertex -13.8451 14.5216 6
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex -15.5892 16.1024 -1
+      vertex -15.4784 16.1549 6
+      vertex -15.5892 16.1024 6
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex -15.4784 16.1549 6
+      vertex -15.5892 16.1024 -1
+      vertex -15.4784 16.1549 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex -14.1161 14.1161 -1
+      vertex -14.0337 14.207 6
+      vertex -14.0337 14.207 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex -14.0337 14.207 6
+      vertex -14.1161 14.1161 -1
+      vertex -14.1161 14.1161 6
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex -15.8839 15.8839 -1
+      vertex -15.793 15.9663 6
+      vertex -15.8839 15.8839 6
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex -15.793 15.9663 6
+      vertex -15.8839 15.8839 -1
+      vertex -15.793 15.9663 -1
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex -15.793 15.9663 -1
+      vertex -15.6945 16.0393 6
+      vertex -15.793 15.9663 6
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex -15.6945 16.0393 6
+      vertex -15.793 15.9663 -1
+      vertex -15.6945 16.0393 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex -13.774 15.2439 -1
+      vertex -13.8038 15.3629 6
+      vertex -13.8038 15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex -13.8038 15.3629 6
+      vertex -13.774 15.2439 -1
+      vertex -13.774 15.2439 6
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex 15.4784 -16.1549 -1
+      vertex 15.3629 -16.1962 6
+      vertex 15.4784 -16.1549 6
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex 15.3629 -16.1962 6
+      vertex 15.4784 -16.1549 -1
+      vertex 15.3629 -16.1962 -1
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex 13.9607 -15.6945 6
+      vertex 13.8976 -15.5892 -1
+      vertex 13.8976 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex 13.8976 -15.5892 -1
+      vertex 13.9607 -15.6945 6
+      vertex 13.9607 -15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex 16.1549 -14.5216 -1
+      vertex 16.1024 -14.4108 6
+      vertex 16.1024 -14.4108 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex 16.1024 -14.4108 6
+      vertex 16.1549 -14.5216 -1
+      vertex 16.1549 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 -0
+    outer loop
+      vertex 14.3055 -16.0393 -1
+      vertex 14.207 -15.9663 6
+      vertex 14.3055 -16.0393 6
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 0
+    outer loop
+      vertex 14.207 -15.9663 6
+      vertex 14.3055 -16.0393 -1
+      vertex 14.207 -15.9663 -1
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex 14.4108 -13.8976 -1
+      vertex 14.5216 -13.8451 6
+      vertex 14.4108 -13.8976 6
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex 14.5216 -13.8451 6
+      vertex 14.4108 -13.8976 -1
+      vertex 14.5216 -13.8451 -1
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 -0
+    outer loop
+      vertex 14.4108 -16.1024 -1
+      vertex 14.3055 -16.0393 6
+      vertex 14.4108 -16.1024 6
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 0
+    outer loop
+      vertex 14.3055 -16.0393 6
+      vertex 14.4108 -16.1024 -1
+      vertex 14.3055 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 -0
+    outer loop
+      vertex 14.7561 -16.226 -1
+      vertex 14.6371 -16.1962 6
+      vertex 14.7561 -16.226 6
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 0
+    outer loop
+      vertex 14.6371 -16.1962 6
+      vertex 14.7561 -16.226 -1
+      vertex 14.6371 -16.1962 -1
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 0
+    outer loop
+      vertex 15.793 -14.0337 -1
+      vertex 15.8839 -14.1161 6
+      vertex 15.793 -14.0337 6
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 -0
+    outer loop
+      vertex 15.8839 -14.1161 6
+      vertex 15.793 -14.0337 -1
+      vertex 15.8839 -14.1161 -1
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex 15.6945 -16.0393 -1
+      vertex 15.5892 -16.1024 6
+      vertex 15.6945 -16.0393 6
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex 15.5892 -16.1024 6
+      vertex 15.6945 -16.0393 -1
+      vertex 15.5892 -16.1024 -1
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex 15.8839 -15.8839 -1
+      vertex 15.793 -15.9663 6
+      vertex 15.8839 -15.8839 6
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex 15.793 -15.9663 6
+      vertex 15.8839 -15.8839 -1
+      vertex 15.793 -15.9663 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex 16.0393 -14.3055 -1
+      vertex 15.9663 -14.207 6
+      vertex 15.9663 -14.207 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex 15.9663 -14.207 6
+      vertex 16.0393 -14.3055 -1
+      vertex 16.0393 -14.3055 6
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex 16.226 -15.2439 -1
+      vertex 16.244 -15.1225 6
+      vertex 16.244 -15.1225 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex 16.244 -15.1225 6
+      vertex 16.226 -15.2439 -1
+      vertex 16.226 -15.2439 6
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex 16.244 -15.1225 -1
+      vertex 16.25 -15 6
+      vertex 16.25 -15 -1
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex 16.25 -15 6
+      vertex 16.244 -15.1225 -1
+      vertex 16.244 -15.1225 6
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex 15.9663 -14.207 -1
+      vertex 15.8839 -14.1161 6
+      vertex 15.8839 -14.1161 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex 15.8839 -14.1161 6
+      vertex 15.9663 -14.207 -1
+      vertex 15.9663 -14.207 6
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex 14.1161 -15.8839 6
+      vertex 14.0337 -15.793 -1
+      vertex 14.0337 -15.793 6
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex 14.0337 -15.793 -1
+      vertex 14.1161 -15.8839 6
+      vertex 14.1161 -15.8839 -1
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 0
+    outer loop
+      vertex 15.4784 -13.8451 -1
+      vertex 15.5892 -13.8976 6
+      vertex 15.4784 -13.8451 6
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 -0
+    outer loop
+      vertex 15.5892 -13.8976 6
+      vertex 15.4784 -13.8451 -1
+      vertex 15.5892 -13.8976 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex 16.1024 -15.5892 -1
+      vertex 16.1549 -15.4784 6
+      vertex 16.1549 -15.4784 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex 16.1549 -15.4784 6
+      vertex 16.1024 -15.5892 -1
+      vertex 16.1024 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex 14.7561 -13.774 -1
+      vertex 14.8775 -13.756 6
+      vertex 14.7561 -13.774 6
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex 14.8775 -13.756 6
+      vertex 14.7561 -13.774 -1
+      vertex 14.8775 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex 14.0337 -15.793 6
+      vertex 13.9607 -15.6945 -1
+      vertex 13.9607 -15.6945 6
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex 13.9607 -15.6945 -1
+      vertex 14.0337 -15.793 6
+      vertex 14.0337 -15.793 -1
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex 14.8775 -13.756 -1
+      vertex 15 -13.75 6
+      vertex 14.8775 -13.756 6
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex 15 -13.75 6
+      vertex 14.8775 -13.756 -1
+      vertex 15 -13.75 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex 16.1962 -14.6371 -1
+      vertex 16.1549 -14.5216 6
+      vertex 16.1549 -14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex 16.1549 -14.5216 6
+      vertex 16.1962 -14.6371 -1
+      vertex 16.1962 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex 14.1161 -14.1161 -1
+      vertex 14.207 -14.0337 6
+      vertex 14.1161 -14.1161 6
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex 14.207 -14.0337 6
+      vertex 14.1161 -14.1161 -1
+      vertex 14.207 -14.0337 -1
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex 14.5216 -13.8451 -1
+      vertex 14.6371 -13.8038 6
+      vertex 14.5216 -13.8451 6
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex 14.6371 -13.8038 6
+      vertex 14.5216 -13.8451 -1
+      vertex 14.6371 -13.8038 -1
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 -0
+    outer loop
+      vertex 14.8775 -16.244 -1
+      vertex 14.7561 -16.226 6
+      vertex 14.8775 -16.244 6
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 0
+    outer loop
+      vertex 14.7561 -16.226 6
+      vertex 14.8775 -16.244 -1
+      vertex 14.7561 -16.226 -1
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 0
+    outer loop
+      vertex 15.2439 -13.774 -1
+      vertex 15.3629 -13.8038 6
+      vertex 15.2439 -13.774 6
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 -0
+    outer loop
+      vertex 15.3629 -13.8038 6
+      vertex 15.2439 -13.774 -1
+      vertex 15.3629 -13.8038 -1
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 -0
+    outer loop
+      vertex 15 -16.25 -1
+      vertex 14.8775 -16.244 6
+      vertex 15 -16.25 6
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 0
+    outer loop
+      vertex 14.8775 -16.244 6
+      vertex 15 -16.25 -1
+      vertex 14.8775 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex 13.9607 -14.3055 6
+      vertex 14.0337 -14.207 -1
+      vertex 14.0337 -14.207 6
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex 14.0337 -14.207 -1
+      vertex 13.9607 -14.3055 6
+      vertex 13.9607 -14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex 15.3629 -16.1962 -1
+      vertex 15.2439 -16.226 6
+      vertex 15.3629 -16.1962 6
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex 15.2439 -16.226 6
+      vertex 15.3629 -16.1962 -1
+      vertex 15.2439 -16.226 -1
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex 13.774 -15.2439 6
+      vertex 13.756 -15.1225 -1
+      vertex 13.756 -15.1225 6
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex 13.756 -15.1225 -1
+      vertex 13.774 -15.2439 6
+      vertex 13.774 -15.2439 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex 16.226 -14.7561 -1
+      vertex 16.1962 -14.6371 6
+      vertex 16.1962 -14.6371 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex 16.1962 -14.6371 6
+      vertex 16.226 -14.7561 -1
+      vertex 16.226 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex 13.756 -15.1225 6
+      vertex 13.75 -15 -1
+      vertex 13.75 -15 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex 13.75 -15 -1
+      vertex 13.756 -15.1225 6
+      vertex 13.756 -15.1225 -1
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 0
+    outer loop
+      vertex 15.6945 -13.9607 -1
+      vertex 15.793 -14.0337 6
+      vertex 15.6945 -13.9607 6
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 -0
+    outer loop
+      vertex 15.793 -14.0337 6
+      vertex 15.6945 -13.9607 -1
+      vertex 15.793 -14.0337 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex 15.8839 -15.8839 -1
+      vertex 15.9663 -15.793 6
+      vertex 15.9663 -15.793 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex 15.9663 -15.793 6
+      vertex 15.8839 -15.8839 -1
+      vertex 15.8839 -15.8839 6
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex 16.1549 -15.4784 -1
+      vertex 16.1962 -15.3629 6
+      vertex 16.1962 -15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex 16.1962 -15.3629 6
+      vertex 16.1549 -15.4784 -1
+      vertex 16.1549 -15.4784 6
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex 15.1225 -16.244 -1
+      vertex 15 -16.25 6
+      vertex 15.1225 -16.244 6
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex 15 -16.25 6
+      vertex 15.1225 -16.244 -1
+      vertex 15 -16.25 -1
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex 13.8976 -15.5892 6
+      vertex 13.8451 -15.4784 -1
+      vertex 13.8451 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex 13.8451 -15.4784 -1
+      vertex 13.8976 -15.5892 6
+      vertex 13.8976 -15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex 16.25 -15 -1
+      vertex 16.244 -14.8775 6
+      vertex 16.244 -14.8775 -1
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex 16.244 -14.8775 6
+      vertex 16.25 -15 -1
+      vertex 16.25 -15 6
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 0
+    outer loop
+      vertex 15.5892 -13.8976 -1
+      vertex 15.6945 -13.9607 6
+      vertex 15.5892 -13.8976 6
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 -0
+    outer loop
+      vertex 15.6945 -13.9607 6
+      vertex 15.5892 -13.8976 -1
+      vertex 15.6945 -13.9607 -1
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 0
+    outer loop
+      vertex 15.1225 -13.756 -1
+      vertex 15.2439 -13.774 6
+      vertex 15.1225 -13.756 6
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 -0
+    outer loop
+      vertex 15.2439 -13.774 6
+      vertex 15.1225 -13.756 -1
+      vertex 15.2439 -13.774 -1
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex 15.2439 -16.226 -1
+      vertex 15.1225 -16.244 6
+      vertex 15.2439 -16.226 6
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex 15.1225 -16.244 6
+      vertex 15.2439 -16.226 -1
+      vertex 15.1225 -16.244 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex 16.1962 -15.3629 -1
+      vertex 16.226 -15.2439 6
+      vertex 16.226 -15.2439 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex 16.226 -15.2439 6
+      vertex 16.1962 -15.3629 -1
+      vertex 16.1962 -15.3629 6
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex 15.793 -15.9663 -1
+      vertex 15.6945 -16.0393 6
+      vertex 15.793 -15.9663 6
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex 15.6945 -16.0393 6
+      vertex 15.793 -15.9663 -1
+      vertex 15.6945 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex 14.207 -14.0337 -1
+      vertex 14.3055 -13.9607 6
+      vertex 14.207 -14.0337 6
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex 14.3055 -13.9607 6
+      vertex 14.207 -14.0337 -1
+      vertex 14.3055 -13.9607 -1
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex 16.1024 -14.4108 -1
+      vertex 16.0393 -14.3055 6
+      vertex 16.0393 -14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex 16.0393 -14.3055 6
+      vertex 16.1024 -14.4108 -1
+      vertex 16.1024 -14.4108 6
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex 13.774 -14.7561 6
+      vertex 13.8038 -14.6371 -1
+      vertex 13.8038 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex 13.8038 -14.6371 -1
+      vertex 13.774 -14.7561 6
+      vertex 13.774 -14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex 15.5892 -16.1024 -1
+      vertex 15.4784 -16.1549 6
+      vertex 15.5892 -16.1024 6
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex 15.4784 -16.1549 6
+      vertex 15.5892 -16.1024 -1
+      vertex 15.4784 -16.1549 -1
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 0
+    outer loop
+      vertex 15.3629 -13.8038 -1
+      vertex 15.4784 -13.8451 6
+      vertex 15.3629 -13.8038 6
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 -0
+    outer loop
+      vertex 15.4784 -13.8451 6
+      vertex 15.3629 -13.8038 -1
+      vertex 15.4784 -13.8451 -1
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex 14.3055 -13.9607 -1
+      vertex 14.4108 -13.8976 6
+      vertex 14.3055 -13.9607 6
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex 14.4108 -13.8976 6
+      vertex 14.3055 -13.9607 -1
+      vertex 14.4108 -13.8976 -1
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex 14.6371 -13.8038 -1
+      vertex 14.7561 -13.774 6
+      vertex 14.6371 -13.8038 6
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex 14.7561 -13.774 6
+      vertex 14.6371 -13.8038 -1
+      vertex 14.7561 -13.774 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex 16.244 -14.8775 -1
+      vertex 16.226 -14.7561 6
+      vertex 16.226 -14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex 16.226 -14.7561 6
+      vertex 16.244 -14.8775 -1
+      vertex 16.244 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex 13.75 -15 6
+      vertex 13.756 -14.8775 -1
+      vertex 13.756 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex 13.756 -14.8775 -1
+      vertex 13.75 -15 6
+      vertex 13.75 -15 -1
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 -0
+    outer loop
+      vertex 14.6371 -16.1962 -1
+      vertex 14.5216 -16.1549 6
+      vertex 14.6371 -16.1962 6
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 0
+    outer loop
+      vertex 14.5216 -16.1549 6
+      vertex 14.6371 -16.1962 -1
+      vertex 14.5216 -16.1549 -1
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex 14.0337 -14.207 6
+      vertex 14.1161 -14.1161 -1
+      vertex 14.1161 -14.1161 6
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex 14.1161 -14.1161 -1
+      vertex 14.0337 -14.207 6
+      vertex 14.0337 -14.207 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex 16.0393 -15.6945 -1
+      vertex 16.1024 -15.5892 6
+      vertex 16.1024 -15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex 16.1024 -15.5892 6
+      vertex 16.0393 -15.6945 -1
+      vertex 16.0393 -15.6945 6
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 0
+    outer loop
+      vertex 15 -13.75 -1
+      vertex 15.1225 -13.756 6
+      vertex 15 -13.75 6
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 -0
+    outer loop
+      vertex 15.1225 -13.756 6
+      vertex 15 -13.75 -1
+      vertex 15.1225 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex 13.8451 -15.4784 6
+      vertex 13.8038 -15.3629 -1
+      vertex 13.8038 -15.3629 6
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex 13.8038 -15.3629 -1
+      vertex 13.8451 -15.4784 6
+      vertex 13.8451 -15.4784 -1
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex 13.756 -14.8775 6
+      vertex 13.774 -14.7561 -1
+      vertex 13.774 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex 13.774 -14.7561 -1
+      vertex 13.756 -14.8775 6
+      vertex 13.756 -14.8775 -1
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 -0
+    outer loop
+      vertex 14.207 -15.9663 -1
+      vertex 14.1161 -15.8839 6
+      vertex 14.207 -15.9663 6
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 0
+    outer loop
+      vertex 14.1161 -15.8839 6
+      vertex 14.207 -15.9663 -1
+      vertex 14.1161 -15.8839 -1
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex 13.8038 -14.6371 6
+      vertex 13.8451 -14.5216 -1
+      vertex 13.8451 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex 13.8451 -14.5216 -1
+      vertex 13.8038 -14.6371 6
+      vertex 13.8038 -14.6371 -1
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex 13.8451 -14.5216 6
+      vertex 13.8976 -14.4108 -1
+      vertex 13.8976 -14.4108 6
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex 13.8976 -14.4108 -1
+      vertex 13.8451 -14.5216 6
+      vertex 13.8451 -14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex 15.9663 -15.793 -1
+      vertex 16.0393 -15.6945 6
+      vertex 16.0393 -15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex 16.0393 -15.6945 6
+      vertex 15.9663 -15.793 -1
+      vertex 15.9663 -15.793 6
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 -0
+    outer loop
+      vertex 14.5216 -16.1549 -1
+      vertex 14.4108 -16.1024 6
+      vertex 14.5216 -16.1549 6
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 0
+    outer loop
+      vertex 14.4108 -16.1024 6
+      vertex 14.5216 -16.1549 -1
+      vertex 14.4108 -16.1024 -1
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex 13.8976 -14.4108 6
+      vertex 13.9607 -14.3055 -1
+      vertex 13.9607 -14.3055 6
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex 13.9607 -14.3055 -1
+      vertex 13.8976 -14.4108 6
+      vertex 13.8976 -14.4108 -1
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex 13.8038 -15.3629 6
+      vertex 13.774 -15.2439 -1
+      vertex 13.774 -15.2439 6
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex 13.774 -15.2439 -1
+      vertex 13.8038 -15.3629 6
+      vertex 13.8038 -15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 0
+    outer loop
+      vertex -14.6371 -13.8038 -1
+      vertex -14.5216 -13.8451 6
+      vertex -14.6371 -13.8038 6
+    endloop
+  endfacet
+  facet normal -0.336698 -0.941613 -0
+    outer loop
+      vertex -14.5216 -13.8451 6
+      vertex -14.6371 -13.8038 -1
+      vertex -14.5216 -13.8451 -1
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex -16.1962 -15.3629 6
+      vertex -16.226 -15.2439 -1
+      vertex -16.226 -15.2439 6
+    endloop
+  endfacet
+  facet normal 0.970047 0.242919 0
+    outer loop
+      vertex -16.226 -15.2439 -1
+      vertex -16.1962 -15.3629 6
+      vertex -16.1962 -15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex -14.6371 -16.1962 -1
+      vertex -14.7561 -16.226 6
+      vertex -14.6371 -16.1962 6
+    endloop
+  endfacet
+  facet normal -0.242919 0.970047 0
+    outer loop
+      vertex -14.7561 -16.226 6
+      vertex -14.6371 -16.1962 -1
+      vertex -14.7561 -16.226 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex -13.774 -15.2439 -1
+      vertex -13.756 -15.1225 6
+      vertex -13.756 -15.1225 -1
+    endloop
+  endfacet
+  facet normal -0.989186 0.146667 0
+    outer loop
+      vertex -13.756 -15.1225 6
+      vertex -13.774 -15.2439 -1
+      vertex -13.774 -15.2439 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex -16.244 -15.1225 6
+      vertex -16.25 -15 -1
+      vertex -16.25 -15 6
+    endloop
+  endfacet
+  facet normal 0.998803 0.0489209 0
+    outer loop
+      vertex -16.25 -15 -1
+      vertex -16.244 -15.1225 6
+      vertex -16.244 -15.1225 -1
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex -14.3055 -16.0393 -1
+      vertex -14.4108 -16.1024 6
+      vertex -14.3055 -16.0393 6
+    endloop
+  endfacet
+  facet normal -0.514016 0.85778 0
+    outer loop
+      vertex -14.4108 -16.1024 6
+      vertex -14.3055 -16.0393 -1
+      vertex -14.4108 -16.1024 -1
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 0
+    outer loop
+      vertex -14.4108 -13.8976 -1
+      vertex -14.3055 -13.9607 6
+      vertex -14.4108 -13.8976 6
+    endloop
+  endfacet
+  facet normal -0.514016 -0.85778 -0
+    outer loop
+      vertex -14.3055 -13.9607 6
+      vertex -14.4108 -13.8976 -1
+      vertex -14.3055 -13.9607 -1
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex -15.3629 -13.8038 -1
+      vertex -15.2439 -13.774 6
+      vertex -15.3629 -13.8038 6
+    endloop
+  endfacet
+  facet normal 0.242919 -0.970047 0
+    outer loop
+      vertex -15.2439 -13.774 6
+      vertex -15.3629 -13.8038 -1
+      vertex -15.2439 -13.774 -1
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 0
+    outer loop
+      vertex -14.3055 -13.9607 -1
+      vertex -14.207 -14.0337 6
+      vertex -14.3055 -13.9607 6
+    endloop
+  endfacet
+  facet normal -0.595423 -0.803413 -0
+    outer loop
+      vertex -14.207 -14.0337 6
+      vertex -14.3055 -13.9607 -1
+      vertex -14.207 -14.0337 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex -13.9607 -15.6945 -1
+      vertex -13.8976 -15.5892 6
+      vertex -13.8976 -15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.85778 0.514016 0
+    outer loop
+      vertex -13.8976 -15.5892 6
+      vertex -13.9607 -15.6945 -1
+      vertex -13.9607 -15.6945 6
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex -15.6945 -13.9607 -1
+      vertex -15.5892 -13.8976 6
+      vertex -15.6945 -13.9607 6
+    endloop
+  endfacet
+  facet normal 0.514016 -0.85778 0
+    outer loop
+      vertex -15.5892 -13.8976 6
+      vertex -15.6945 -13.9607 -1
+      vertex -15.5892 -13.8976 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex -14.1161 -15.8839 -1
+      vertex -14.0337 -15.793 6
+      vertex -14.0337 -15.793 -1
+    endloop
+  endfacet
+  facet normal -0.740898 0.671617 0
+    outer loop
+      vertex -14.0337 -15.793 6
+      vertex -14.1161 -15.8839 -1
+      vertex -14.1161 -15.8839 6
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex -14.207 -15.9663 -1
+      vertex -14.3055 -16.0393 6
+      vertex -14.207 -15.9663 6
+    endloop
+  endfacet
+  facet normal -0.595423 0.803413 0
+    outer loop
+      vertex -14.3055 -16.0393 6
+      vertex -14.207 -15.9663 -1
+      vertex -14.3055 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex -15.5892 -13.8976 -1
+      vertex -15.4784 -13.8451 6
+      vertex -15.5892 -13.8976 6
+    endloop
+  endfacet
+  facet normal 0.428192 -0.903688 0
+    outer loop
+      vertex -15.4784 -13.8451 6
+      vertex -15.5892 -13.8976 -1
+      vertex -15.4784 -13.8451 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex -14.0337 -15.793 -1
+      vertex -13.9607 -15.6945 6
+      vertex -13.9607 -15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.803413 0.595423 0
+    outer loop
+      vertex -13.9607 -15.6945 6
+      vertex -14.0337 -15.793 -1
+      vertex -14.0337 -15.793 6
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex -13.8451 -15.4784 -1
+      vertex -13.8038 -15.3629 6
+      vertex -13.8038 -15.3629 -1
+    endloop
+  endfacet
+  facet normal -0.941613 0.336698 0
+    outer loop
+      vertex -13.8038 -15.3629 6
+      vertex -13.8451 -15.4784 -1
+      vertex -13.8451 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 -0
+    outer loop
+      vertex -15.4784 -16.1549 -1
+      vertex -15.5892 -16.1024 6
+      vertex -15.4784 -16.1549 6
+    endloop
+  endfacet
+  facet normal 0.428192 0.903688 0
+    outer loop
+      vertex -15.5892 -16.1024 6
+      vertex -15.4784 -16.1549 -1
+      vertex -15.5892 -16.1024 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex -13.8038 -15.3629 -1
+      vertex -13.774 -15.2439 6
+      vertex -13.774 -15.2439 -1
+    endloop
+  endfacet
+  facet normal -0.970047 0.242919 0
+    outer loop
+      vertex -13.774 -15.2439 6
+      vertex -13.8038 -15.3629 -1
+      vertex -13.8038 -15.3629 6
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex -13.8976 -14.4108 -1
+      vertex -13.9607 -14.3055 6
+      vertex -13.9607 -14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.85778 -0.514016 0
+    outer loop
+      vertex -13.9607 -14.3055 6
+      vertex -13.8976 -14.4108 -1
+      vertex -13.8976 -14.4108 6
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 0
+    outer loop
+      vertex -14.7561 -13.774 -1
+      vertex -14.6371 -13.8038 6
+      vertex -14.7561 -13.774 6
+    endloop
+  endfacet
+  facet normal -0.242919 -0.970047 -0
+    outer loop
+      vertex -14.6371 -13.8038 6
+      vertex -14.7561 -13.774 -1
+      vertex -14.6371 -13.8038 -1
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 0
+    outer loop
+      vertex -15 -13.75 -1
+      vertex -14.8775 -13.756 6
+      vertex -15 -13.75 6
+    endloop
+  endfacet
+  facet normal -0.0489209 -0.998803 -0
+    outer loop
+      vertex -14.8775 -13.756 6
+      vertex -15 -13.75 -1
+      vertex -14.8775 -13.756 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex -13.8038 -14.6371 -1
+      vertex -13.8451 -14.5216 6
+      vertex -13.8451 -14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.941613 -0.336698 0
+    outer loop
+      vertex -13.8451 -14.5216 6
+      vertex -13.8038 -14.6371 -1
+      vertex -13.8038 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex -16.226 -14.7561 6
+      vertex -16.1962 -14.6371 -1
+      vertex -16.1962 -14.6371 6
+    endloop
+  endfacet
+  facet normal 0.970047 -0.242919 0
+    outer loop
+      vertex -16.1962 -14.6371 -1
+      vertex -16.226 -14.7561 6
+      vertex -16.226 -14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex -14.8775 -16.244 -1
+      vertex -15 -16.25 6
+      vertex -14.8775 -16.244 6
+    endloop
+  endfacet
+  facet normal -0.0489209 0.998803 0
+    outer loop
+      vertex -15 -16.25 6
+      vertex -14.8775 -16.244 -1
+      vertex -15 -16.25 -1
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 -0
+    outer loop
+      vertex -15.5892 -16.1024 -1
+      vertex -15.6945 -16.0393 6
+      vertex -15.5892 -16.1024 6
+    endloop
+  endfacet
+  facet normal 0.514016 0.85778 0
+    outer loop
+      vertex -15.6945 -16.0393 6
+      vertex -15.5892 -16.1024 -1
+      vertex -15.6945 -16.0393 -1
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex -15.9663 -15.793 6
+      vertex -16.0393 -15.6945 -1
+      vertex -16.0393 -15.6945 6
+    endloop
+  endfacet
+  facet normal 0.803413 0.595423 0
+    outer loop
+      vertex -16.0393 -15.6945 -1
+      vertex -15.9663 -15.793 6
+      vertex -15.9663 -15.793 -1
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex -14.1161 -15.8839 -1
+      vertex -14.207 -15.9663 6
+      vertex -14.1161 -15.8839 6
+    endloop
+  endfacet
+  facet normal -0.671617 0.740898 0
+    outer loop
+      vertex -14.207 -15.9663 6
+      vertex -14.1161 -15.8839 -1
+      vertex -14.207 -15.9663 -1
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex -15.4784 -13.8451 -1
+      vertex -15.3629 -13.8038 6
+      vertex -15.4784 -13.8451 6
+    endloop
+  endfacet
+  facet normal 0.336698 -0.941613 0
+    outer loop
+      vertex -15.3629 -13.8038 6
+      vertex -15.4784 -13.8451 -1
+      vertex -15.3629 -13.8038 -1
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex -14.5216 -16.1549 -1
+      vertex -14.6371 -16.1962 6
+      vertex -14.5216 -16.1549 6
+    endloop
+  endfacet
+  facet normal -0.336698 0.941613 0
+    outer loop
+      vertex -14.6371 -16.1962 6
+      vertex -14.5216 -16.1549 -1
+      vertex -14.6371 -16.1962 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex -13.8451 -14.5216 -1
+      vertex -13.8976 -14.4108 6
+      vertex -13.8976 -14.4108 -1
+    endloop
+  endfacet
+  facet normal -0.903688 -0.428192 0
+    outer loop
+      vertex -13.8976 -14.4108 6
+      vertex -13.8451 -14.5216 -1
+      vertex -13.8451 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 -0
+    outer loop
+      vertex -15.3629 -16.1962 -1
+      vertex -15.4784 -16.1549 6
+      vertex -15.3629 -16.1962 6
+    endloop
+  endfacet
+  facet normal 0.336698 0.941613 0
+    outer loop
+      vertex -15.4784 -16.1549 6
+      vertex -15.3629 -16.1962 -1
+      vertex -15.4784 -16.1549 -1
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex -16.226 -15.2439 6
+      vertex -16.244 -15.1225 -1
+      vertex -16.244 -15.1225 6
+    endloop
+  endfacet
+  facet normal 0.989186 0.146667 0
+    outer loop
+      vertex -16.244 -15.1225 -1
+      vertex -16.226 -15.2439 6
+      vertex -16.226 -15.2439 -1
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 -0
+    outer loop
+      vertex -15.1225 -16.244 -1
+      vertex -15.2439 -16.226 6
+      vertex -15.1225 -16.244 6
+    endloop
+  endfacet
+  facet normal 0.146667 0.989186 0
+    outer loop
+      vertex -15.2439 -16.226 6
+      vertex -15.1225 -16.244 -1
+      vertex -15.2439 -16.226 -1
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex -16.25 -15 6
+      vertex -16.244 -14.8775 -1
+      vertex -16.244 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0.998803 -0.0489209 0
+    outer loop
+      vertex -16.244 -14.8775 -1
+      vertex -16.25 -15 6
+      vertex -16.25 -15 -1
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex -16.1549 -14.5216 6
+      vertex -16.1024 -14.4108 -1
+      vertex -16.1024 -14.4108 6
+    endloop
+  endfacet
+  facet normal 0.903688 -0.428192 0
+    outer loop
+      vertex -16.1024 -14.4108 -1
+      vertex -16.1549 -14.5216 6
+      vertex -16.1549 -14.5216 -1
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 0
+    outer loop
+      vertex -14.207 -14.0337 -1
+      vertex -14.1161 -14.1161 6
+      vertex -14.207 -14.0337 6
+    endloop
+  endfacet
+  facet normal -0.671617 -0.740898 -0
+    outer loop
+      vertex -14.1161 -14.1161 6
+      vertex -14.207 -14.0337 -1
+      vertex -14.1161 -14.1161 -1
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex -16.244 -14.8775 6
+      vertex -16.226 -14.7561 -1
+      vertex -16.226 -14.7561 6
+    endloop
+  endfacet
+  facet normal 0.989186 -0.146667 0
+    outer loop
+      vertex -16.226 -14.7561 -1
+      vertex -16.244 -14.8775 6
+      vertex -16.244 -14.8775 -1
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 -0
+    outer loop
+      vertex -15.6945 -16.0393 -1
+      vertex -15.793 -15.9663 6
+      vertex -15.6945 -16.0393 6
+    endloop
+  endfacet
+  facet normal 0.595423 0.803413 0
+    outer loop
+      vertex -15.793 -15.9663 6
+      vertex -15.6945 -16.0393 -1
+      vertex -15.793 -15.9663 -1
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex -15.2439 -13.774 -1
+      vertex -15.1225 -13.756 6
+      vertex -15.2439 -13.774 6
+    endloop
+  endfacet
+  facet normal 0.146667 -0.989186 0
+    outer loop
+      vertex -15.1225 -13.756 6
+      vertex -15.2439 -13.774 -1
+      vertex -15.1225 -13.756 -1
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex -16.1549 -15.4784 6
+      vertex -16.1962 -15.3629 -1
+      vertex -16.1962 -15.3629 6
+    endloop
+  endfacet
+  facet normal 0.941613 0.336698 0
+    outer loop
+      vertex -16.1962 -15.3629 -1
+      vertex -16.1549 -15.4784 6
+      vertex -16.1549 -15.4784 -1
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex -16.1024 -14.4108 6
+      vertex -16.0393 -14.3055 -1
+      vertex -16.0393 -14.3055 6
+    endloop
+  endfacet
+  facet normal 0.85778 -0.514016 0
+    outer loop
+      vertex -16.0393 -14.3055 -1
+      vertex -16.1024 -14.4108 6
+      vertex -16.1024 -14.4108 -1
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex -16.0393 -14.3055 6
+      vertex -15.9663 -14.207 -1
+      vertex -15.9663 -14.207 6
+    endloop
+  endfacet
+  facet normal 0.803413 -0.595423 0
+    outer loop
+      vertex -15.9663 -14.207 -1
+      vertex -16.0393 -14.3055 6
+      vertex -16.0393 -14.3055 -1
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex -13.75 -15 -1
+      vertex -13.756 -14.8775 6
+      vertex -13.756 -14.8775 -1
+    endloop
+  endfacet
+  facet normal -0.998803 -0.0489209 0
+    outer loop
+      vertex -13.756 -14.8775 6
+      vertex -13.75 -15 -1
+      vertex -13.75 -15 6
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex -14.7561 -16.226 -1
+      vertex -14.8775 -16.244 6
+      vertex -14.7561 -16.226 6
+    endloop
+  endfacet
+  facet normal -0.146667 0.989186 0
+    outer loop
+      vertex -14.8775 -16.244 6
+      vertex -14.7561 -16.226 -1
+      vertex -14.8775 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 -0
+    outer loop
+      vertex -15 -16.25 -1
+      vertex -15.1225 -16.244 6
+      vertex -15 -16.25 6
+    endloop
+  endfacet
+  facet normal 0.0489209 0.998803 0
+    outer loop
+      vertex -15.1225 -16.244 6
+      vertex -15 -16.25 -1
+      vertex -15.1225 -16.244 -1
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex -16.1024 -15.5892 6
+      vertex -16.1549 -15.4784 -1
+      vertex -16.1549 -15.4784 6
+    endloop
+  endfacet
+  facet normal 0.903688 0.428192 0
+    outer loop
+      vertex -16.1549 -15.4784 -1
+      vertex -16.1024 -15.5892 6
+      vertex -16.1024 -15.5892 -1
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 0
+    outer loop
+      vertex -14.8775 -13.756 -1
+      vertex -14.7561 -13.774 6
+      vertex -14.8775 -13.756 6
+    endloop
+  endfacet
+  facet normal -0.146667 -0.989186 -0
+    outer loop
+      vertex -14.7561 -13.774 6
+      vertex -14.8775 -13.756 -1
+      vertex -14.7561 -13.774 -1
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex -16.0393 -15.6945 6
+      vertex -16.1024 -15.5892 -1
+      vertex -16.1024 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0.85778 0.514016 0
+    outer loop
+      vertex -16.1024 -15.5892 -1
+      vertex -16.0393 -15.6945 6
+      vertex -16.0393 -15.6945 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex -13.8976 -15.5892 -1
+      vertex -13.8451 -15.4784 6
+      vertex -13.8451 -15.4784 -1
+    endloop
+  endfacet
+  facet normal -0.903688 0.428192 0
+    outer loop
+      vertex -13.8451 -15.4784 6
+      vertex -13.8976 -15.5892 -1
+      vertex -13.8976 -15.5892 6
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex -15.8839 -15.8839 6
+      vertex -15.9663 -15.793 -1
+      vertex -15.9663 -15.793 6
+    endloop
+  endfacet
+  facet normal 0.740898 0.671617 0
+    outer loop
+      vertex -15.9663 -15.793 -1
+      vertex -15.8839 -15.8839 6
+      vertex -15.8839 -15.8839 -1
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 -0
+    outer loop
+      vertex -15.793 -15.9663 -1
+      vertex -15.8839 -15.8839 6
+      vertex -15.793 -15.9663 6
+    endloop
+  endfacet
+  facet normal 0.671617 0.740898 0
+    outer loop
+      vertex -15.8839 -15.8839 6
+      vertex -15.793 -15.9663 -1
+      vertex -15.8839 -15.8839 -1
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex -14.4108 -16.1024 -1
+      vertex -14.5216 -16.1549 6
+      vertex -14.4108 -16.1024 6
+    endloop
+  endfacet
+  facet normal -0.428192 0.903688 0
+    outer loop
+      vertex -14.5216 -16.1549 6
+      vertex -14.4108 -16.1024 -1
+      vertex -14.5216 -16.1549 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex -13.774 -14.7561 -1
+      vertex -13.8038 -14.6371 6
+      vertex -13.8038 -14.6371 -1
+    endloop
+  endfacet
+  facet normal -0.970047 -0.242919 0
+    outer loop
+      vertex -13.8038 -14.6371 6
+      vertex -13.774 -14.7561 -1
+      vertex -13.774 -14.7561 6
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 0
+    outer loop
+      vertex -14.5216 -13.8451 -1
+      vertex -14.4108 -13.8976 6
+      vertex -14.5216 -13.8451 6
+    endloop
+  endfacet
+  facet normal -0.428192 -0.903688 -0
+    outer loop
+      vertex -14.4108 -13.8976 6
+      vertex -14.5216 -13.8451 -1
+      vertex -14.4108 -13.8976 -1
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex -15.8839 -14.1161 -1
+      vertex -15.793 -14.0337 6
+      vertex -15.8839 -14.1161 6
+    endloop
+  endfacet
+  facet normal 0.671617 -0.740898 0
+    outer loop
+      vertex -15.793 -14.0337 6
+      vertex -15.8839 -14.1161 -1
+      vertex -15.793 -14.0337 -1
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 -0
+    outer loop
+      vertex -15.2439 -16.226 -1
+      vertex -15.3629 -16.1962 6
+      vertex -15.2439 -16.226 6
+    endloop
+  endfacet
+  facet normal 0.242919 0.970047 0
+    outer loop
+      vertex -15.3629 -16.1962 6
+      vertex -15.2439 -16.226 -1
+      vertex -15.3629 -16.1962 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex -14.0337 -14.207 -1
+      vertex -14.1161 -14.1161 6
+      vertex -14.1161 -14.1161 -1
+    endloop
+  endfacet
+  facet normal -0.740898 -0.671617 0
+    outer loop
+      vertex -14.1161 -14.1161 6
+      vertex -14.0337 -14.207 -1
+      vertex -14.0337 -14.207 6
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex -15.1225 -13.756 -1
+      vertex -15 -13.75 6
+      vertex -15.1225 -13.756 6
+    endloop
+  endfacet
+  facet normal 0.0489209 -0.998803 0
+    outer loop
+      vertex -15 -13.75 6
+      vertex -15.1225 -13.756 -1
+      vertex -15 -13.75 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex -13.756 -14.8775 -1
+      vertex -13.774 -14.7561 6
+      vertex -13.774 -14.7561 -1
+    endloop
+  endfacet
+  facet normal -0.989186 -0.146667 0
+    outer loop
+      vertex -13.774 -14.7561 6
+      vertex -13.756 -14.8775 -1
+      vertex -13.756 -14.8775 6
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex -15.793 -14.0337 -1
+      vertex -15.6945 -13.9607 6
+      vertex -15.793 -14.0337 6
+    endloop
+  endfacet
+  facet normal 0.595423 -0.803413 0
+    outer loop
+      vertex -15.6945 -13.9607 6
+      vertex -15.793 -14.0337 -1
+      vertex -15.6945 -13.9607 -1
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex -16.1962 -14.6371 6
+      vertex -16.1549 -14.5216 -1
+      vertex -16.1549 -14.5216 6
+    endloop
+  endfacet
+  facet normal 0.941613 -0.336698 0
+    outer loop
+      vertex -16.1549 -14.5216 -1
+      vertex -16.1962 -14.6371 6
+      vertex -16.1962 -14.6371 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex -13.9607 -14.3055 -1
+      vertex -14.0337 -14.207 6
+      vertex -14.0337 -14.207 -1
+    endloop
+  endfacet
+  facet normal -0.803413 -0.595423 0
+    outer loop
+      vertex -14.0337 -14.207 6
+      vertex -13.9607 -14.3055 -1
+      vertex -13.9607 -14.3055 6
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex -13.756 -15.1225 -1
+      vertex -13.75 -15 6
+      vertex -13.75 -15 -1
+    endloop
+  endfacet
+  facet normal -0.998803 0.0489209 0
+    outer loop
+      vertex -13.75 -15 6
+      vertex -13.756 -15.1225 -1
+      vertex -13.756 -15.1225 6
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex -15.9663 -14.207 6
+      vertex -15.8839 -14.1161 -1
+      vertex -15.8839 -14.1161 6
+    endloop
+  endfacet
+  facet normal 0.740898 -0.671617 0
+    outer loop
+      vertex -15.8839 -14.1161 -1
+      vertex -15.9663 -14.207 6
+      vertex -15.9663 -14.207 -1
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
It looks like you're threading bolts right into the plastic. As a rule, I wouldn't do that! You can probably get away with it in the longer cylinders, but in the case where you're putting bolts into a 2mm plate, you're asking for trouble!

I've added a couple of seats for nuts in the plate of the camera mount. I don't know what size nut would go on the bolts you're using, so I just randomly set a 4mm diameter (to be adjusted) and a 1mm depth (which should mean that the nut won't be completely flush; it'll stick out a bit, which is probably helpful). 

This will result in a bit of support material to allow the upper part of the plate to be printed suspended in the air above the nut seat. However, it'll be minimal, and any mess from cleaning it up will be hidden by the nuts themselves. My trick to save time is: I do a bit of desultory cleaning with a knife, and then heat the nut with a lighter or torch (not red-hot, just enough that it softens the plastic). Then I jam it into the seat with a needlenose pliers. Any leftover support material ends up getting mushed out of the way.

If you do this, you can then widen your holes a bit, as they don't have to be self-threading anymore. 

You may want to consider doing something similar with the holes in the mounting cylinders, though this is less critical as the bolts will be self-threading into a lot more plastic.