### PR TITLE
Add continuous integration pipeline using Github Actions.

### DIFF
--- a/.github/scripts/build-apt-repo.sh
+++ b/.github/scripts/build-apt-repo.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -e
+
+REPO_BRANCH=apt-repo
+KEYNAME=
+GIT_REMOTE=origin
+
+###
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <\*.deb>"
+  exit 1
+fi
+
+echo "=== Determine working branch"
+[ -z ${GITHUB_REF} ] && GITHUB_REF=$(git symbolic-ref -q HEAD)
+WORK_BRANCH=${GITHUB_REF##*/}
+
+echo "=== Set Git identity"
+NAME=$(git log -1 --pretty=format:'%an')
+EMAIL=$(git log -1 --pretty=format:'%ae')
+
+git config user.name "${NAME}"
+git config user.email "${EMAIL}"
+
+echo "${NAME} <${EMAIL}>"
+
+echo "=== Check out repository branch: ${REPO_BRANCH}"
+if ! git checkout -f ${REPO_BRANCH}; then
+  git checkout --orphan ${REPO_BRANCH}
+  git rm -rf .
+  echo "Debian package repository for ${GITHUB_REPOSITORY}" > README.md
+  git add README.md
+  git commit -m "Add empty README"
+fi
+git reset --hard HEAD
+
+echo "=== Replace files in ${WORK_BRANCH}"
+rm -rf ${WORK_BRANCH}
+mkdir ${WORK_BRANCH}
+cd ${WORK_BRANCH}
+cp -v $@ .
+
+# based roughly on:
+# https://medium.com/sqooba/create-your-own-custom-and-authenticated-apt-repository-1e4a4cf0b864
+
+echo "=== Build Packages"
+apt-ftparchive packages . > Packages
+gzip -k -f Packages
+
+echo "=== Build Release"
+apt-ftparchive release . > Release
+git add Release
+
+if [ -n "${KEYNAME}" ]; then
+  echo "=== Sign Release"
+  gpg --default-key ${KEYNAME} -abs -o Release.gpg Release
+
+  echo "=== Sign InRelease"
+  gpg --default-key ${KEYNAME} --clearsign -o InRelease Release
+else
+  echo "=== No key name set; skipping signatures"
+fi
+
+if git describe --tags --exact-match 2>/dev/null; then
+  echo "=== Previous Git commit was tagged; adding a new commit"
+else
+  echo "=== Overwrite previous automated Git commit"
+  AMEND=--amend
+fi
+git add .
+git commit ${AMEND} -m "${GITHUB_WORKFLOW:-workflow} ${GITHUB_RUN_NUMBER:-(unknown)} from ${GITHUB_REPOSITORY:-(unknown)}"
+
+if [ -n "${GIT_REMOTE}" ]; then
+  echo "=== Force push to remote"
+  git push -f ${GIT_REMOTE} ${REPO_BRANCH}
+fi

--- a/.github/scripts/set-snapshot-version.sh
+++ b/.github/scripts/set-snapshot-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# See https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables
+
+# Get the latest vX.Y.Z tag from the repo and throw away the v prefix
+PROJECT_VERSION=$(git describe --abbrev=0 | cut -c2-)
+
+# Use dch to update debian/changelog
+dch --newversion "${PROJECT_VERSION}-b${GITHUB_RUN_NUMBER}" \
+  "${GITHUB_WORKFLOW} #${GITHUB_RUN_NUMBER} from ${GITHUB_REPOSITORY}"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,1 @@
+https://github.community/t/testing-against-multiple-architectures/17111/8

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,30 @@
+name: build-packages
+on: push
+jobs:
+  build-amd64:
+    name: Build amd64 packages
+    runs-on: ubuntu-latest
+    container: debian:buster-slim
+    steps:
+      - name: Download build tools
+        run: apt-get update && apt-get install -y devscripts git
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install build dependencies
+        run: yes | mk-build-deps -ri
+      - name: Update snapshot version
+        run: .github/scripts/set-snapshot-version.sh
+      - name: Build packages
+        run: dpkg-buildpackage --build=all,any
+      - name: Save packages
+        run: cp ../*.deb debian/changelog /github/home
+      - name: Upload packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: odm360-amd64-debs
+          path: |
+            /github/home/*.deb
+            /github/home/changelog
+          if-no-files-found: error

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -14,17 +14,54 @@ jobs:
           fetch-depth: 0
       - name: Install build dependencies
         run: yes | mk-build-deps -ri
-      - name: Update snapshot version
+      - name: Update changelog with snapshot version
         run: .github/scripts/set-snapshot-version.sh
       - name: Build packages
         run: dpkg-buildpackage --build=all,any
       - name: Save packages
-        run: cp ../*.deb debian/changelog /github/home
+        run: cp ../*.deb /github/home
       - name: Upload packages
         uses: actions/upload-artifact@v2
         with:
           name: odm360-amd64-debs
-          path: |
-            /github/home/*.deb
-            /github/home/changelog
+          path: /github/home/*.deb
+          if-no-files-found: error
+      - name: Upload changelog
+        uses: actions/upload-artifact@v2
+        with:
+          name: changelog
+          path: debian/changelog
+          if-no-files-found: error
+
+  build-armhf:
+    name: Build armhf packages
+    needs: build-amd64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changelog from amd64 build
+        uses: actions/download-artifact@v2
+        with:
+          name: changelog
+      - name: Overwrite existing changelog
+        run: mv changelog debian
+      - name: Start QEMU for 32-bit ARM emulation
+        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - name: Install dependencies and build packages
+        uses: docker://arm32v7/debian:buster-slim
+        with:
+          args: >
+            bash -c "apt-get update && \
+                     apt-get install -y devscripts && \
+                     yes | mk-build-deps -ri && \
+                     dpkg-buildpackage --build=any && \
+                     eval 'cp -v ../*.deb .'"
+      - name: Upload packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: odm360-armhf-debs
+          path: ${{ github.workspace }}/*.deb
           if-no-files-found: error

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,5 +1,10 @@
 name: build-packages
-on: push
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "*"
+      - "!apt-repo"
 jobs:
   build-amd64:
     name: Build amd64 packages
@@ -65,3 +70,19 @@ jobs:
           name: odm360-armhf-debs
           path: ${{ github.workspace }}/*.deb
           if-no-files-found: error
+
+  apt-repo:
+    name: Build apt repository
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-armhf]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ~/artifacts
+      - name: Build package repository
+        run: .github/scripts/build-apt-repo.sh ~/artifacts/**/*.deb


### PR DESCRIPTION
This PR adds a `build-packages` pipeline to Github Actions. This pipeline builds Debian packages for odm360 for both amd64 and armhf architectures, and then compile those packages into a Debian package repository accessible[*] with the following `sources.list` entry:

```
deb [trusted=yes] https://opendronemap.github.io/odm360/main/ /
```

The Github Actions configuration will build packages for any branch pushed to Github. To access those packages from apt, substitute the branch name for `main` in the URL above.

Debian packages are versioned using the scheme `<X.Y.Z>-b<b>` where *X.Y.Z* is drawn from the most recent Github tag on the branch of the form `vX.Y.Z` and *b* is the Github Actions job number, which is a monotonically increasing number associated with the `build-package` pipeline.

[*] All packages are written to the `apt-repo` branch in the `odm360` repository in Github. I've already created this branch, but the repository owner should mark it as the target Github Pages branch in the repository configuration. Only the most recent version of each package is retained by the build pipeline.

This PR should be merged after #98 and #99 are added.