### PR TITLE
Allow external access to child databases

### DIFF
--- a/provisioning/database_setup_child.sh
+++ b/provisioning/database_setup_child.sh
@@ -24,6 +24,11 @@ sudo -u postgres psql -d odm360 -f dbase_child.sql
 # make sure that the database folder is prepared
 sudo mkdir /home/pi/piimages
 
+# ensure external access to database
+sudo sed -i -e "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" /etc/postgresql/11/main/postgresql.conf
+echo "host    all             all              0.0.0.0/0                       md5" | sudo tee -a /etc/postgresql/11/main/pg_hba.conf
+echo "host    all             all              ::/0                            md5" | sudo tee -a /etc/postgresql/11/main/pg_hba.conf
+
 echo ##########################################################
 echo Now you should have a Postgresql database with a user and password properly configured to connect to using psycopg2 from Python.
 echo ##########################################################


### PR DESCRIPTION
This allows external access to the child pi databases and should fix this (sub) issue here: https://github.com/OpenDroneMap/odm360/issues/57#issuecomment-706514365

If we solve the WiFi issue here:
https://github.com/OpenDroneMap/odm360/issues/102

Then we can lock down the parent pi to a static address on it's own network, and set better security settings than we have here, but this is fine for the interim.